### PR TITLE
Implement customer catalog, public search, and audit logging

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Portal de Sastrería
 
-Aplicación completa para gestionar y consultar órdenes de un taller de sastrería. El proyecto incluye un backend basado en FastAPI con autenticación y un frontend ligero en HTML/JavaScript para clientes y personal interno.
+Aplicación completa para gestionar y consultar órdenes de un taller de sastrería. El proyecto incluye un backend basado en FastAPI con autenticación JWT y un frontend ligero en HTML/JavaScript para clientes y personal interno.
 
 ## Requisitos
 
@@ -48,15 +48,17 @@ Luego visita `http://localhost:5173` en tu navegador. Asegúrate de que el backe
 
 ## Roles disponibles
 
-- **Administrador**: crear usuarios, gestionar órdenes y eliminar registros.
-- **Vendedor**: crear y actualizar órdenes.
-- **Sastre**: consultar y actualizar el estado de las órdenes asignadas.
+- **Administrador**: crear usuarios, gestionar clientes y órdenes, consultar la bitácora y eliminar registros.
+- **Vendedor**: crear clientes, registrar nuevas órdenes y actualizar sus datos.
+- **Sastre**: consultar clientes y órdenes, actualizar los arreglos y estados (sin crear órdenes).
 
 ## Funcionalidades principales
 
-- Consulta pública del estado de una orden por número.
-- Gestión interna de órdenes: creación, actualización de estado, notas y asignación de sastre.
-- Registro de medidas del cliente por orden.
+- Consulta pública del estado de una orden por número de orden **o** cédula del cliente.
+- Catálogo reutilizable de clientes con teléfono y conjuntos de medidas guardadas.
+- Gestión interna de órdenes: creación (según rol), actualización de estado, notas y asignación de sastre.
+- Aplicación rápida de las medidas guardadas del cliente al generar una orden.
+- Bitácora de auditoría inmutable accesible para administradores.
 - Gestión de usuarios con control de permisos (Administrador, Vendedor, Sastre).
 
 ## Estructura del proyecto

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -54,12 +54,20 @@ def list_statuses() -> List[str]:
 def create_user(
     user_in: schemas.UserCreate,
     db: Session = Depends(get_db),
-    _: models.User = Depends(admin_required()),
+    current_user: models.User = Depends(admin_required()),
 ):
     existing = crud.get_user_by_username(db, user_in.username)
     if existing:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="El usuario ya existe")
     user = crud.create_user(db, user_in)
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="create",
+        entity_type="user",
+        entity_id=user.id,
+        after=crud.serialize_user(user),
+    )
     return user
 
 
@@ -72,16 +80,18 @@ def read_current_user(current_user: models.User = Depends(auth.get_current_user)
 def read_users(
     role: Optional[models.UserRole] = Query(default=None),
     db: Session = Depends(get_db),
-    _: models.User = Depends(admin_required()),
+    current_user: models.User = Depends(admin_required()),
 ):
+    _ = current_user
     return crud.get_users(db, role=role)
 
 
 @app.get("/users/tailors", response_model=List[schemas.UserOut])
 def read_tailors(
     db: Session = Depends(get_db),
-    _: models.User = Depends(staff_required()),
+    current_user: models.User = Depends(staff_required()),
 ):
+    _ = current_user
     return crud.get_users(db, role=models.UserRole.SASTRE)
 
 
@@ -90,27 +100,140 @@ def update_user(
     user_id: int,
     user_update: schemas.UserUpdate,
     db: Session = Depends(get_db),
-    _: models.User = Depends(admin_required()),
+    current_user: models.User = Depends(admin_required()),
 ):
     db_user = crud.get_user(db, user_id)
     if not db_user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuario no encontrado")
-    return crud.update_user(db, db_user, user_update)
+    before = crud.serialize_user(db_user)
+    updated_user = crud.update_user(db, db_user, user_update)
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="update",
+        entity_type="user",
+        entity_id=updated_user.id,
+        before=before,
+        after=crud.serialize_user(updated_user),
+    )
+    return updated_user
 
 
-@app.get("/public/orders/{order_number}", response_model=schemas.OrderPublic)
-def get_order_public(order_number: str, db: Session = Depends(get_db)):
-    order = crud.get_order_by_number(db, order_number)
-    if not order:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Orden no encontrada")
-    return order
+@app.get("/public/orders", response_model=List[schemas.OrderPublic])
+def search_public_orders(
+    order_number: Optional[str] = Query(default=None),
+    customer_document: Optional[str] = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    if not order_number and not customer_document:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Debe proporcionar el número de orden o la cédula del cliente",
+        )
+    return crud.search_orders(db, order_number=order_number, customer_document=customer_document)
+
+
+@app.get("/customers", response_model=List[schemas.CustomerRead])
+def list_customers(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(staff_required()),
+):
+    _ = current_user
+    return crud.get_customers(db)
+
+
+@app.post("/customers", response_model=schemas.CustomerRead, status_code=status.HTTP_201_CREATED)
+def create_customer_endpoint(
+    customer_in: schemas.CustomerCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(staff_required()),
+):
+    if crud.get_customer_by_document(db, customer_in.document_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ya existe un cliente con esa identificación")
+    customer = crud.create_customer(db, customer_in)
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="create",
+        entity_type="customer",
+        entity_id=customer.id,
+        after=crud.serialize_customer(customer),
+    )
+    return customer
+
+
+@app.get("/customers/{customer_id}", response_model=schemas.CustomerRead)
+def get_customer_endpoint(
+    customer_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(staff_required()),
+):
+    _ = current_user
+    customer = crud.get_customer(db, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
+    return customer
+
+
+@app.patch("/customers/{customer_id}", response_model=schemas.CustomerRead)
+def update_customer_endpoint(
+    customer_id: int,
+    customer_update: schemas.CustomerUpdate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(staff_required()),
+):
+    customer = crud.get_customer(db, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
+    if (
+        customer_update.document_id
+        and customer_update.document_id != customer.document_id
+        and (existing := crud.get_customer_by_document(db, customer_update.document_id))
+        and existing.id != customer.id
+    ):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ya existe un cliente con esa identificación")
+    before = crud.serialize_customer(customer)
+    updated_customer = crud.update_customer(db, customer, customer_update)
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="update",
+        entity_type="customer",
+        entity_id=updated_customer.id,
+        before=before,
+        after=crud.serialize_customer(updated_customer),
+    )
+    return updated_customer
+
+
+@app.delete("/customers/{customer_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_customer_endpoint(
+    customer_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(admin_required()),
+):
+    customer = crud.get_customer(db, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
+    before = crud.serialize_customer(customer)
+    crud.delete_customer(db, customer)
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="delete",
+        entity_type="customer",
+        entity_id=customer_id,
+        before=before,
+    )
+    return None
 
 
 @app.get("/orders", response_model=List[schemas.OrderRead])
 def list_orders(
     db: Session = Depends(get_db),
-    _: models.User = Depends(staff_required()),
+    current_user: models.User = Depends(staff_required()),
 ):
+    _ = current_user
     return crud.get_orders(db)
 
 
@@ -118,19 +241,39 @@ def list_orders(
 def create_order_endpoint(
     order_in: schemas.OrderCreate,
     db: Session = Depends(get_db),
-    _: models.User = Depends(vendor_or_admin_required()),
+    current_user: models.User = Depends(vendor_or_admin_required()),
 ):
     if crud.get_order_by_number(db, order_in.order_number):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ya existe una orden con ese número")
-    return crud.create_order(db, order_in)
+    customer = crud.get_customer(db, order_in.customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
+    order_data = order_in.dict()
+    if not order_data.get("customer_name"):
+        order_data["customer_name"] = customer.full_name
+    if not order_data.get("customer_document"):
+        order_data["customer_document"] = customer.document_id
+    if order_data.get("customer_contact") in (None, ""):
+        order_data["customer_contact"] = customer.phone
+    order = crud.create_order(db, schemas.OrderCreate(**order_data))
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="create",
+        entity_type="order",
+        entity_id=order.id,
+        after=crud.serialize_order(order),
+    )
+    return order
 
 
 @app.get("/orders/{order_id}", response_model=schemas.OrderRead)
 def get_order_endpoint(
     order_id: int,
     db: Session = Depends(get_db),
-    _: models.User = Depends(staff_required()),
+    current_user: models.User = Depends(staff_required()),
 ):
+    _ = current_user
     order = crud.get_order(db, order_id)
     if not order:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Orden no encontrada")
@@ -142,22 +285,63 @@ def update_order_endpoint(
     order_id: int,
     order_update: schemas.OrderUpdate,
     db: Session = Depends(get_db),
-    _: models.User = Depends(staff_required()),
+    current_user: models.User = Depends(staff_required()),
 ):
     order = crud.get_order(db, order_id)
     if not order:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Orden no encontrada")
-    return crud.update_order(db, order, order_update)
+    update_data = order_update.dict(exclude_unset=True)
+    if "customer_id" in update_data and update_data["customer_id"] != order.customer_id:
+        new_customer = crud.get_customer(db, update_data["customer_id"])
+        if not new_customer:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
+        if not update_data.get("customer_name"):
+            update_data["customer_name"] = new_customer.full_name
+        if not update_data.get("customer_document"):
+            update_data["customer_document"] = new_customer.document_id
+        if update_data.get("customer_contact") in (None, ""):
+            update_data["customer_contact"] = new_customer.phone
+    before = crud.serialize_order(order)
+    updated_order = crud.update_order(db, order, schemas.OrderUpdate(**update_data))
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="update",
+        entity_type="order",
+        entity_id=updated_order.id,
+        before=before,
+        after=crud.serialize_order(updated_order),
+    )
+    return updated_order
 
 
 @app.delete("/orders/{order_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_order_endpoint(
     order_id: int,
     db: Session = Depends(get_db),
-    _: models.User = Depends(admin_required()),
+    current_user: models.User = Depends(admin_required()),
 ):
     order = crud.get_order(db, order_id)
     if not order:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Orden no encontrada")
+    before = crud.serialize_order(order)
     crud.delete_order(db, order)
+    crud.create_audit_log(
+        db,
+        actor=current_user,
+        action="delete",
+        entity_type="order",
+        entity_id=order_id,
+        before=before,
+    )
     return None
+
+
+@app.get("/audit-logs", response_model=List[schemas.AuditLogRead])
+def list_audit_logs_endpoint(
+    limit: int = Query(default=200, ge=1, le=500),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(admin_required()),
+):
+    _ = current_user
+    return crud.list_audit_logs(db, limit=limit)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -18,6 +18,56 @@ class TokenData(BaseModel):
 class MeasurementItem(BaseModel):
     nombre: str = Field(..., description="Nombre de la medida, por ejemplo 'Pecho'")
     valor: str = Field(..., description="Valor de la medida")
+
+
+class CustomerMeasurementBase(BaseModel):
+    name: str = Field(..., description="Nombre del conjunto de medidas")
+    measurements: List[MeasurementItem] = Field(default_factory=list)
+
+
+class CustomerMeasurementCreate(CustomerMeasurementBase):
+    pass
+
+
+class CustomerMeasurementUpdate(CustomerMeasurementBase):
+    pass
+
+
+class CustomerMeasurementRead(CustomerMeasurementBase):
+    id: int
+    name: str = Field(..., alias="title")
+
+    class Config:
+        orm_mode = True
+        allow_population_by_field_name = True
+
+
+class CustomerBase(BaseModel):
+    full_name: str
+    document_id: str
+    phone: Optional[str] = None
+
+
+class CustomerCreate(CustomerBase):
+    measurements: List[CustomerMeasurementCreate] = Field(default_factory=list)
+
+
+class CustomerUpdate(BaseModel):
+    full_name: Optional[str] = None
+    document_id: Optional[str] = None
+    phone: Optional[str] = None
+    measurements: Optional[List[CustomerMeasurementCreate]] = None
+
+
+class CustomerSummary(CustomerBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class CustomerRead(CustomerSummary):
+    measurements: List[CustomerMeasurementRead] = Field(default_factory=list)
 
 
 class UserBase(BaseModel):
@@ -48,7 +98,9 @@ class UserOut(UserBase):
 
 class OrderBase(BaseModel):
     order_number: str
-    customer_name: str
+    customer_id: int
+    customer_name: Optional[str] = None
+    customer_document: Optional[str] = None
     customer_contact: Optional[str] = None
     status: OrderStatus = OrderStatus.EN_TIENDA_BATAN
     measurements: List[MeasurementItem] = Field(default_factory=list)
@@ -61,7 +113,9 @@ class OrderCreate(OrderBase):
 
 
 class OrderUpdate(BaseModel):
+    customer_id: Optional[int] = None
     customer_name: Optional[str] = None
+    customer_document: Optional[str] = None
     customer_contact: Optional[str] = None
     status: Optional[OrderStatus] = None
     measurements: Optional[List[MeasurementItem]] = None
@@ -72,9 +126,11 @@ class OrderUpdate(BaseModel):
 class OrderPublic(BaseModel):
     order_number: str
     customer_name: str
+    customer_document: Optional[str]
     status: OrderStatus
     notes: Optional[str]
     updated_at: datetime
+    measurements: List[MeasurementItem] = Field(default_factory=list)
 
     class Config:
         orm_mode = True
@@ -82,8 +138,9 @@ class OrderPublic(BaseModel):
 
 class OrderRead(OrderPublic):
     id: int
+    customer_id: int
     customer_contact: Optional[str]
-    measurements: List[MeasurementItem]
+    customer: Optional[CustomerSummary]
     assigned_tailor: Optional[UserOut]
     created_at: datetime
 
@@ -91,3 +148,17 @@ class OrderRead(OrderPublic):
 class LoginRequest(BaseModel):
     username: str
     password: str
+
+
+class AuditLogRead(BaseModel):
+    id: int
+    timestamp: datetime
+    action: str
+    entity_type: str
+    entity_id: Optional[int]
+    before: Optional[Dict[str, Any]] = None
+    after: Optional[Dict[str, Any]] = None
+    actor: Optional[UserOut]
+
+    class Config:
+        orm_mode = True

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,13 +21,18 @@
       <section id="client-view" class="view active">
         <div class="card">
           <h2>Consulta el estado de tu orden</h2>
-          <p>Ingresa el número de la orden proporcionado por la sastrería.</p>
+          <p>Ingresa el número de orden o la cédula con la que registraste tu pedido.</p>
           <form id="orderLookupForm" class="form-grid">
-            <label for="orderNumber">Número de orden</label>
-            <div class="input-group">
-              <input type="text" id="orderNumber" required placeholder="Ej. BAT-00123" />
-              <button type="submit">Buscar</button>
+            <div class="form-row">
+              <label for="orderNumber">Número de orden</label>
+              <input type="text" id="orderNumber" placeholder="Ej. BAT-00123" />
             </div>
+            <div class="form-row">
+              <label for="customerDocument">Cédula o identificación</label>
+              <input type="text" id="customerDocument" placeholder="Ej. 0912345678" />
+            </div>
+            <p class="muted small">Ingresa al menos uno de los campos para realizar la búsqueda.</p>
+            <button type="submit" class="primary">Buscar</button>
           </form>
           <div id="orderStatusResult" class="order-result hidden"></div>
         </div>
@@ -36,7 +41,7 @@
       <section id="staff-view" class="view">
         <div id="staffLogin" class="card">
           <h2>Acceso de personal</h2>
-          <p>Autentícate para gestionar las órdenes y clientes.</p>
+          <p>Autentícate para gestionar las órdenes, clientes y registros.</p>
           <form id="staffLoginForm" class="form-grid">
             <label for="username">Usuario</label>
             <input type="text" id="username" required />
@@ -48,7 +53,7 @@
 
         <div id="staffDashboard" class="hidden">
           <div class="dashboard-header">
-            <h2>Panel de órdenes</h2>
+            <h2>Panel administrativo</h2>
             <div class="user-info">
               Sesión iniciada como <span id="currentUserName"></span>
               (<span id="currentUserRole"></span>)
@@ -56,12 +61,95 @@
             </div>
           </div>
 
+          <section class="card" id="customersCard">
+            <h3>Gestión de clientes</h3>
+            <div class="customer-layout">
+              <div class="customer-column">
+                <h4>Registrar cliente</h4>
+                <form id="createCustomerForm" class="form-grid">
+                  <div class="form-row">
+                    <label for="customerFullName">Nombre completo</label>
+                    <input type="text" id="customerFullName" required />
+                  </div>
+                  <div class="form-row">
+                    <label for="customerDocumentInput">Cédula o identificación</label>
+                    <input type="text" id="customerDocumentInput" required />
+                  </div>
+                  <div class="form-row">
+                    <label for="customerPhone">Teléfono</label>
+                    <input type="text" id="customerPhone" placeholder="Número de contacto" />
+                  </div>
+                  <div class="form-row">
+                    <label>Conjuntos de medidas</label>
+                    <div id="customerMeasurementsContainer" class="measurement-set-list"></div>
+                    <button type="button" id="addCustomerMeasurementSet" class="secondary">Agregar conjunto</button>
+                  </div>
+                  <button type="submit" class="primary">Guardar cliente</button>
+                </form>
+              </div>
+
+              <div class="customer-column">
+                <h4>Clientes registrados</h4>
+                <div class="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Nombre</th>
+                        <th>Documento</th>
+                        <th>Teléfono</th>
+                        <th>Medidas</th>
+                        <th>Acciones</th>
+                      </tr>
+                    </thead>
+                    <tbody id="customersTableBody"></tbody>
+                  </table>
+                </div>
+                <div id="customerDetail" class="customer-detail hidden">
+                  <h4>Detalle del cliente</h4>
+                  <form id="updateCustomerForm" class="form-grid">
+                    <div class="form-row">
+                      <label for="updateCustomerName">Nombre completo</label>
+                      <input type="text" id="updateCustomerName" required />
+                    </div>
+                    <div class="form-row">
+                      <label for="updateCustomerDocument">Cédula o identificación</label>
+                      <input type="text" id="updateCustomerDocument" required />
+                    </div>
+                    <div class="form-row">
+                      <label for="updateCustomerPhone">Teléfono</label>
+                      <input type="text" id="updateCustomerPhone" />
+                    </div>
+                    <div class="form-row">
+                      <label>Conjuntos de medidas</label>
+                      <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
+                      <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">Agregar conjunto</button>
+                    </div>
+                    <div class="button-row">
+                      <button type="submit" class="primary">Guardar cambios</button>
+                      <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </section>
+
           <section class="card">
             <h3>Crear nueva orden</h3>
             <form id="createOrderForm" class="form-grid">
               <div class="form-row">
                 <label for="newOrderNumber">Número de orden</label>
                 <input type="text" id="newOrderNumber" required />
+              </div>
+              <div class="form-row">
+                <label for="orderCustomerSelect">Cliente</label>
+                <select id="orderCustomerSelect" required>
+                  <option value="">Selecciona un cliente</option>
+                </select>
+              </div>
+              <div class="form-row">
+                <label for="newCustomerDocument">Documento</label>
+                <input type="text" id="newCustomerDocument" readonly />
               </div>
               <div class="form-row">
                 <label for="newCustomerName">Nombre del cliente</label>
@@ -76,13 +164,19 @@
                 <select id="newOrderStatus"></select>
               </div>
               <div class="form-row">
-                <label for="newOrderNotes">Notas</label>
-                <textarea id="newOrderNotes" rows="2" placeholder="Detalles adicionales"></textarea>
+                <label>Medidas guardadas del cliente</label>
+                <div id="customerMeasurementOptions" class="measurement-option-list muted">
+                  Selecciona un cliente para ver sus medidas guardadas.
+                </div>
               </div>
               <div class="form-row">
-                <label>Medidas del cliente</label>
+                <label>Medidas de la orden</label>
                 <div id="measurementsList" class="measurement-list"></div>
                 <button type="button" id="addMeasurementButton" class="secondary">Agregar medida</button>
+              </div>
+              <div class="form-row">
+                <label for="newOrderNotes">Notas</label>
+                <textarea id="newOrderNotes" rows="2" placeholder="Detalles adicionales"></textarea>
               </div>
               <div class="form-row">
                 <label for="assignTailor">Asignar a sastre</label>
@@ -102,6 +196,7 @@
                   <tr>
                     <th>Orden</th>
                     <th>Cliente</th>
+                    <th>Documento</th>
                     <th>Contacto</th>
                     <th>Estado</th>
                     <th>Sastre</th>
@@ -111,6 +206,26 @@
                   </tr>
                 </thead>
                 <tbody id="ordersTableBody"></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="card hidden" id="auditLogSection">
+            <h3>Bitácora de auditoría</h3>
+            <p class="muted small">Registros inmutables de las acciones realizadas por los usuarios.</p>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Fecha</th>
+                    <th>Usuario</th>
+                    <th>Acción</th>
+                    <th>Entidad</th>
+                    <th>Antes</th>
+                    <th>Después</th>
+                  </tr>
+                </thead>
+                <tbody id="auditLogTableBody"></tbody>
               </table>
             </div>
           </section>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -165,6 +165,27 @@ button.secondary:hover {
   border-style: solid;
 }
 
+button.danger {
+  background: var(--danger);
+  color: white;
+  border: none;
+  padding: 0.55rem 1rem;
+  border-radius: 8px;
+}
+
+button.danger:hover {
+  filter: brightness(0.9);
+}
+
+button.danger.ghost {
+  background: rgba(197, 48, 48, 0.1);
+  color: var(--danger);
+}
+
+button.danger.ghost:hover {
+  background: rgba(197, 48, 48, 0.2);
+}
+
 button.full-width {
   width: 100%;
   background: var(--primary);
@@ -225,9 +246,82 @@ button[disabled] {
   margin-bottom: 1.5rem;
 }
 
+.customer-layout {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.customer-column {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.customer-detail {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem;
+  background: #f9fbfc;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 .user-info {
   color: var(--muted);
   font-size: 0.95rem;
+}
+
+.measurement-set-list,
+.measurement-option-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.measurement-set {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  background: white;
+  box-shadow: 0 10px 25px rgba(15, 76, 92, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.measurement-set-header,
+.measurement-option-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.measurement-option {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.measurement-option .measurement-tags {
+  margin-top: 0;
+}
+
+.measurement-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
 }
 
 .table-wrapper {
@@ -252,6 +346,12 @@ th {
   background: rgba(31, 122, 140, 0.08);
 }
 
+.table-wrapper input,
+.table-wrapper textarea,
+.table-wrapper select {
+  width: 100%;
+}
+
 .measurement-list {
   display: flex;
   flex-direction: column;
@@ -270,14 +370,6 @@ th {
 
 .measurement-row button {
   border: none;
-  background: rgba(197, 48, 48, 0.1);
-  color: var(--danger);
-  padding: 0.4rem 0.6rem;
-  border-radius: 6px;
-}
-
-.measurement-row button:hover {
-  background: rgba(197, 48, 48, 0.2);
 }
 
 .tag {
@@ -291,8 +383,49 @@ th {
   font-size: 0.85rem;
 }
 
+.table-wrapper pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.8rem;
+  background: #f1f5f9;
+  border-radius: 8px;
+  padding: 0.5rem;
+}
+
+.public-order-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.public-order-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: white;
+  box-shadow: 0 10px 30px rgba(15, 76, 92, 0.08);
+}
+
+.public-order-card header {
+  margin-bottom: 0.75rem;
+}
+
+.public-order-card h3 {
+  margin: 0 0 0.4rem 0;
+}
+
+.public-order-card p {
+  margin: 0.3rem 0;
+}
+
 .muted {
   color: var(--muted);
+}
+
+.small {
+  font-size: 0.85rem;
 }
 
 .toast {


### PR DESCRIPTION
## Summary
- add customer, customer measurement and audit log models and expose enhanced schemas
- implement customer CRUD, public order search, and audit trail endpoints with role-based guards
- rebuild the client/staff UI with reusable customer data, measurement helpers, order management, audit log view, and refreshed styling
- refresh the README with updated roles, features, and setup instructions

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cc523a9684833296106a219b4b8969