### PR TITLE
Refine order list with detail view and due date alerts

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query, status
@@ -135,11 +136,12 @@ def search_public_orders(
 
 @app.get("/customers", response_model=List[schemas.CustomerRead])
 def list_customers(
+    search: Optional[str] = Query(default=None, min_length=1),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(staff_required()),
 ):
     _ = current_user
-    return crud.get_customers(db)
+    return crud.get_customers(db, search=search)
 
 
 @app.post("/customers", response_model=schemas.CustomerRead, status_code=status.HTTP_201_CREATED)
@@ -255,6 +257,8 @@ def create_order_endpoint(
         order_data["customer_document"] = customer.document_id
     if order_data.get("customer_contact") in (None, ""):
         order_data["customer_contact"] = customer.phone
+    if not order_data.get("entry_date"):
+        order_data["entry_date"] = date.today()
     order = crud.create_order(db, schemas.OrderCreate(**order_data))
     crud.create_audit_log(
         db,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 import enum
-from datetime import datetime
+from datetime import date, datetime
 
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy import Column, Date, DateTime, Enum, ForeignKey, Integer, JSON, String, Text
 from sqlalchemy.orm import relationship
 
 from .database import Base
@@ -60,6 +60,8 @@ class Order(Base):
     measurements = Column(JSON, nullable=False, default=list)
     notes = Column(Text, nullable=True)
     assigned_tailor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    entry_date = Column(Date, nullable=False, default=date.today)
+    delivery_date = Column(Date, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(
         DateTime,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
@@ -102,6 +102,8 @@ class OrderBase(BaseModel):
     measurements: List[MeasurementItem] = Field(default_factory=list)
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    entry_date: date = Field(default_factory=date.today)
+    delivery_date: Optional[date] = None
 
 
 class OrderCreate(OrderBase):
@@ -117,6 +119,8 @@ class OrderUpdate(BaseModel):
     measurements: Optional[List[MeasurementItem]] = None
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    entry_date: Optional[date] = None
+    delivery_date: Optional[date] = None
 
 
 class OrderPublic(BaseModel):
@@ -127,6 +131,8 @@ class OrderPublic(BaseModel):
     notes: Optional[str]
     updated_at: datetime
     measurements: List[MeasurementItem] = Field(default_factory=list)
+    entry_date: date
+    delivery_date: Optional[date]
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -61,80 +61,104 @@
             </div>
           </div>
 
-          <section class="card" id="customersCard">
-            <h3>Gestión de clientes</h3>
-            <div class="customer-layout">
-              <div class="customer-column">
-                <h4>Registrar cliente</h4>
-                <form id="createCustomerForm" class="form-grid">
-                  <div class="form-row">
-                    <label for="customerFullName">Nombre completo</label>
-                    <input type="text" id="customerFullName" required />
-                  </div>
-                  <div class="form-row">
-                    <label for="customerDocumentInput">Cédula o identificación</label>
-                    <input type="text" id="customerDocumentInput" required />
-                  </div>
-                  <div class="form-row">
-                    <label for="customerPhone">Teléfono</label>
-                    <input type="text" id="customerPhone" placeholder="Número de contacto" />
-                  </div>
-                  <div class="form-row">
-                    <label>Conjuntos de medidas</label>
-                    <div id="customerMeasurementsContainer" class="measurement-set-list"></div>
-                    <button type="button" id="addCustomerMeasurementSet" class="secondary">Agregar conjunto</button>
-                  </div>
-                  <button type="submit" class="primary">Guardar cliente</button>
-                </form>
-              </div>
+          <nav class="dashboard-subnav">
+            <button class="dashboard-tab active" data-tab="customersListPanel">Clientes</button>
+            <button class="dashboard-tab" data-tab="customerRegisterPanel">Registrar cliente</button>
+            <button class="dashboard-tab" data-tab="orderCreatePanel">Crear orden</button>
+            <button class="dashboard-tab" data-tab="orderListPanel">Órdenes registradas</button>
+            <button
+              class="dashboard-tab admin-only hidden"
+              data-tab="auditLogPanel"
+              id="auditLogTabButton"
+            >
+              Bitácora de auditoría
+            </button>
+          </nav>
 
-              <div class="customer-column">
-                <h4>Clientes registrados</h4>
-                <div class="table-wrapper">
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Nombre</th>
-                        <th>Documento</th>
-                        <th>Teléfono</th>
-                        <th>Medidas</th>
-                        <th>Acciones</th>
-                      </tr>
-                    </thead>
-                    <tbody id="customersTableBody"></tbody>
-                  </table>
-                </div>
-                <div id="customerDetail" class="customer-detail hidden">
-                  <h4>Detalle del cliente</h4>
-                  <form id="updateCustomerForm" class="form-grid">
-                    <div class="form-row">
-                      <label for="updateCustomerName">Nombre completo</label>
-                      <input type="text" id="updateCustomerName" required />
-                    </div>
-                    <div class="form-row">
-                      <label for="updateCustomerDocument">Cédula o identificación</label>
-                      <input type="text" id="updateCustomerDocument" required />
-                    </div>
-                    <div class="form-row">
-                      <label for="updateCustomerPhone">Teléfono</label>
-                      <input type="text" id="updateCustomerPhone" />
-                    </div>
-                    <div class="form-row">
-                      <label>Conjuntos de medidas</label>
-                      <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
-                      <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">Agregar conjunto</button>
-                    </div>
-                    <div class="button-row">
-                      <button type="submit" class="primary">Guardar cambios</button>
-                      <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
-                    </div>
-                  </form>
-                </div>
+          <section class="card dashboard-panel" id="customersListPanel">
+            <header class="panel-header">
+              <div>
+                <h3>Clientes registrados</h3>
+                <p class="muted small">Consulta, busca y administra los clientes existentes.</p>
               </div>
+              <form id="customerSearchForm" class="search-form">
+                <input
+                  type="search"
+                  id="customerSearchInput"
+                  placeholder="Buscar por nombre o identificación"
+                />
+                <button type="submit" class="secondary small">Buscar</button>
+                <button type="button" id="customerSearchClear" class="ghost-button small">Limpiar</button>
+              </form>
+            </header>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Nombre</th>
+                    <th>Documento</th>
+                    <th>Teléfono</th>
+                    <th>Medidas</th>
+                    <th>Acciones</th>
+                  </tr>
+                </thead>
+                <tbody id="customersTableBody"></tbody>
+              </table>
+            </div>
+            <div id="customerDetail" class="customer-detail hidden">
+              <h4>Detalle del cliente</h4>
+              <form id="updateCustomerForm" class="form-grid">
+                <div class="form-row">
+                  <label for="updateCustomerName">Nombre completo</label>
+                  <input type="text" id="updateCustomerName" required />
+                </div>
+                <div class="form-row">
+                  <label for="updateCustomerDocument">Cédula o identificación</label>
+                  <input type="text" id="updateCustomerDocument" required />
+                </div>
+                <div class="form-row">
+                  <label for="updateCustomerPhone">Teléfono</label>
+                  <input type="text" id="updateCustomerPhone" />
+                </div>
+                <div class="form-row">
+                  <label>Conjuntos de medidas</label>
+                  <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
+                  <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">Agregar conjunto</button>
+                </div>
+                <div class="button-row">
+                  <button type="submit" class="primary">Guardar cambios</button>
+                  <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
+                </div>
+              </form>
             </div>
           </section>
 
-          <section class="card">
+          <section class="card dashboard-panel hidden" id="customerRegisterPanel">
+            <h3>Registrar nuevo cliente</h3>
+            <p class="muted small">Completa la información y agrega conjuntos de medidas reutilizables.</p>
+            <form id="createCustomerForm" class="form-grid">
+              <div class="form-row">
+                <label for="customerFullName">Nombre completo</label>
+                <input type="text" id="customerFullName" required />
+              </div>
+              <div class="form-row">
+                <label for="customerDocumentInput">Cédula o identificación</label>
+                <input type="text" id="customerDocumentInput" required />
+              </div>
+              <div class="form-row">
+                <label for="customerPhone">Teléfono</label>
+                <input type="text" id="customerPhone" placeholder="Número de contacto" />
+              </div>
+              <div class="form-row">
+                <label>Conjuntos de medidas</label>
+                <div id="customerMeasurementsContainer" class="measurement-set-list"></div>
+                <button type="button" id="addCustomerMeasurementSet" class="secondary">Agregar conjunto</button>
+              </div>
+              <button type="submit" class="primary">Guardar cliente</button>
+            </form>
+          </section>
+
+          <section class="card dashboard-panel hidden" id="orderCreatePanel">
             <h3>Crear nueva orden</h3>
             <form id="createOrderForm" class="form-grid">
               <div class="form-row">
@@ -142,11 +166,22 @@
                 <input type="text" id="newOrderNumber" required />
               </div>
               <div class="form-row">
-                <label for="orderCustomerSelect">Cliente</label>
-                <select id="orderCustomerSelect" required>
-                  <option value="">Selecciona un cliente</option>
-                </select>
+                <label for="orderCustomerSearch">Buscar cliente</label>
+                <div class="search-field">
+                  <div class="search-input-wrapper">
+                    <input
+                      type="search"
+                      id="orderCustomerSearch"
+                      placeholder="Escribe nombre o identificación"
+                      autocomplete="off"
+                    />
+                    <div id="orderCustomerResults" class="search-results hidden"></div>
+                  </div>
+                  <button type="button" id="orderCustomerClear" class="ghost-button small hidden">Limpiar selección</button>
+                </div>
+                <p class="muted small">Selecciona un cliente para precargar sus datos y medidas guardadas.</p>
               </div>
+              <input type="hidden" id="orderCustomerId" />
               <div class="form-row">
                 <label for="newCustomerDocument">Documento</label>
                 <input type="text" id="newCustomerDocument" readonly />
@@ -158,6 +193,14 @@
               <div class="form-row">
                 <label for="newCustomerContact">Contacto del cliente</label>
                 <input type="text" id="newCustomerContact" placeholder="Teléfono o correo" />
+              </div>
+              <div class="form-row">
+                <label for="newOrderEntryDate">Fecha de ingreso</label>
+                <input type="date" id="newOrderEntryDate" required />
+              </div>
+              <div class="form-row">
+                <label for="newOrderDeliveryDate">Fecha de entrega</label>
+                <input type="date" id="newOrderDeliveryDate" />
               </div>
               <div class="form-row">
                 <label for="newOrderStatus">Estado inicial</label>
@@ -188,29 +231,86 @@
             </form>
           </section>
 
-          <section class="card">
+          <section class="card dashboard-panel hidden" id="orderListPanel">
             <h3>Órdenes registradas</h3>
+            <p class="muted small">
+              Las órdenes pendientes se muestran primero y se ordenan por la fecha de entrega más próxima.
+              Selecciona una orden para consultar y actualizar toda la información.
+            </p>
             <div class="table-wrapper">
               <table>
                 <thead>
                   <tr>
                     <th>Orden</th>
                     <th>Cliente</th>
-                    <th>Documento</th>
-                    <th>Contacto</th>
-                    <th>Estado</th>
-                    <th>Sastre</th>
-                    <th>Medidas</th>
-                    <th>Notas</th>
-                    <th>Acciones</th>
+                    <th>Ingreso</th>
+                    <th>Entrega</th>
+                    <th></th>
                   </tr>
                 </thead>
                 <tbody id="ordersTableBody"></tbody>
               </table>
             </div>
+            <p id="orderDetailEmpty" class="muted small">Selecciona una orden para ver toda la información.</p>
+            <div id="orderDetail" class="order-detail hidden">
+              <div class="order-detail-header">
+                <div>
+                  <h4 id="orderDetailTitle">Detalle de la orden</h4>
+                  <p id="orderDetailInfo" class="muted small"></p>
+                </div>
+                <button type="button" id="closeOrderDetail" class="ghost-button small">Cerrar</button>
+              </div>
+              <form id="orderDetailForm" class="form-grid order-detail-grid">
+                <div class="form-row">
+                  <label for="orderDetailNumber">Número de orden</label>
+                  <input type="text" id="orderDetailNumber" readonly />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailStatus">Estado</label>
+                  <select id="orderDetailStatus"></select>
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailCustomer">Cliente</label>
+                  <input type="text" id="orderDetailCustomer" readonly />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailTailor">Sastre asignado</label>
+                  <select id="orderDetailTailor"></select>
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailDocument">Documento</label>
+                  <input type="text" id="orderDetailDocument" readonly />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailContact">Contacto</label>
+                  <input type="text" id="orderDetailContact" placeholder="Teléfono o correo" />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailEntryDate">Fecha de ingreso</label>
+                  <input type="date" id="orderDetailEntryDate" required />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailDeliveryDate">Fecha de entrega</label>
+                  <input type="date" id="orderDetailDeliveryDate" />
+                </div>
+                <div class="form-row full-width">
+                  <label for="orderDetailNotes">Notas</label>
+                  <textarea id="orderDetailNotes" rows="3" placeholder="Detalles adicionales"></textarea>
+                </div>
+                <div class="form-row full-width">
+                  <label>Medidas registradas</label>
+                  <div id="orderDetailMeasurements" class="order-detail-measurements muted">
+                    Sin medidas registradas.
+                  </div>
+                </div>
+                <div class="button-row full-width">
+                  <button type="submit" class="primary">Guardar cambios</button>
+                </div>
+              </form>
+            </div>
           </section>
 
-          <section class="card hidden" id="auditLogSection">
+          <section class="card dashboard-panel hidden" id="auditLogPanel">
             <h3>Bitácora de auditoría</h3>
             <p class="muted small">Registros inmutables de las acciones realizadas por los usuarios.</p>
             <div class="table-wrapper">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -246,6 +246,137 @@ button[disabled] {
   margin-bottom: 1.5rem;
 }
 
+.dashboard-subnav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-tab {
+  border: 1px solid var(--border);
+  background: white;
+  color: var(--primary-dark);
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-tab:hover {
+  background: rgba(31, 122, 140, 0.12);
+}
+
+.dashboard-tab.active {
+  background: var(--primary);
+  color: white;
+  box-shadow: 0 15px 30px rgba(15, 76, 92, 0.15);
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.search-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.search-form input[type='search'] {
+  min-width: 220px;
+}
+
+button.ghost-button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--primary-dark);
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+button.ghost-button:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: rgba(31, 122, 140, 0.08);
+}
+
+button.small {
+  font-size: 0.85rem;
+  padding: 0.4rem 0.75rem;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.search-field button {
+  flex-shrink: 0;
+}
+
+.search-input-wrapper {
+  position: relative;
+  flex: 1;
+}
+
+.search-results {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(15, 76, 92, 0.12);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden auto;
+  max-height: 260px;
+  z-index: 50;
+}
+
+.search-result-item {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 0.65rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.search-result-item:hover {
+  background: rgba(31, 122, 140, 0.08);
+}
+
+.search-result-title {
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+
+.search-result-meta {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.search-empty {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
 .customer-layout {
   display: flex;
   gap: 2rem;
@@ -346,6 +477,26 @@ th {
   background: rgba(31, 122, 140, 0.08);
 }
 
+.order-row {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.order-row:hover {
+  background: rgba(31, 122, 140, 0.06);
+}
+
+.order-row-selected {
+  background: rgba(31, 122, 140, 0.12);
+}
+
+.deadline-warning {
+  text-decoration: underline;
+  text-decoration-color: var(--danger);
+  text-decoration-thickness: 2px;
+  text-decoration-skip-ink: auto;
+}
+
 .table-wrapper input,
 .table-wrapper textarea,
 .table-wrapper select {
@@ -420,6 +571,50 @@ th {
   margin: 0.3rem 0;
 }
 
+.order-detail {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #f9fbfc;
+  margin-top: 1.5rem;
+  box-shadow: 0 15px 35px rgba(15, 76, 92, 0.06);
+}
+
+.order-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.order-detail-header h4 {
+  margin: 0;
+}
+
+.order-detail-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.order-detail-grid .full-width {
+  grid-column: 1 / -1;
+}
+
+.order-detail-measurements {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.5rem 0;
+}
+
+.order-detail-measurements .tag {
+  margin: 0;
+}
+
+.order-detail .button-row {
+  justify-content: flex-end;
+}
+
 .muted {
   color: var(--muted);
 }
@@ -469,6 +664,20 @@ th {
 @media (max-width: 768px) {
   .input-group {
     flex-direction: column;
+  }
+
+  .panel-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-form {
+    width: 100%;
+  }
+
+  .search-form input[type='search'] {
+    flex: 1;
+    min-width: 0;
   }
 
   .measurement-row {


### PR DESCRIPTION
## Summary
- trim the registered orders table to core columns and add a placeholder message for selecting an order
- add an expandable order detail card with editable fields for status, contact info, dates, notes, and measurements
- underline approaching delivery dates for undelivered orders to surface upcoming deadlines

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68cc8bfc92148332beb6d2b1e3b03c0c