### PR TITLE
Add delivery date support and order detail view

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -53,6 +53,7 @@ def serialize_order(order: Optional[models.Order]) -> Optional[Dict[str, Any]]:
         "measurements": order.measurements,
         "notes": order.notes,
         "assigned_tailor_id": order.assigned_tailor_id,
+        "delivery_date": order.delivery_date.isoformat() if order.delivery_date else None,
         "created_at": order.created_at.isoformat() if order.created_at else None,
         "updated_at": order.updated_at.isoformat() if order.updated_at else None,
     }
@@ -241,6 +242,7 @@ def create_order(db: Session, order_in: schemas.OrderCreate) -> models.Order:
         measurements=_measurements_to_dicts(order_in.measurements),
         notes=order_in.notes,
         assigned_tailor_id=order_in.assigned_tailor_id,
+        delivery_date=order_in.delivery_date,
     )
     db.add(db_order)
     db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 import enum
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy import Column, Date, DateTime, Enum, ForeignKey, Integer, JSON, String, Text
 from sqlalchemy.orm import relationship
 
 from .database import Base
@@ -60,6 +60,7 @@ class Order(Base):
     measurements = Column(JSON, nullable=False, default=list)
     notes = Column(Text, nullable=True)
     assigned_tailor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    delivery_date = Column(Date, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(
         DateTime,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
@@ -102,6 +102,7 @@ class OrderBase(BaseModel):
     measurements: List[MeasurementItem] = Field(default_factory=list)
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    delivery_date: Optional[date] = None
 
 
 class OrderCreate(OrderBase):
@@ -117,6 +118,7 @@ class OrderUpdate(BaseModel):
     measurements: Optional[List[MeasurementItem]] = None
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    delivery_date: Optional[date] = None
 
 
 class OrderPublic(BaseModel):
@@ -126,6 +128,7 @@ class OrderPublic(BaseModel):
     status: OrderStatus
     notes: Optional[str]
     updated_at: datetime
+    delivery_date: Optional[date] = None
     measurements: List[MeasurementItem] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,6 +9,7 @@ const state = {
   customers: [],
   auditLogs: [],
   selectedCustomerId: null,
+  selectedOrderId: null,
 };
 
 const views = document.querySelectorAll('.view');
@@ -38,6 +39,21 @@ const measurementsList = document.getElementById('measurementsList');
 const addMeasurementButton = document.getElementById('addMeasurementButton');
 const statusSelect = document.getElementById('newOrderStatus');
 const assignTailorSelect = document.getElementById('assignTailor');
+const newOrderDeliveryDateInput = document.getElementById('newOrderDeliveryDate');
+const orderDetail = document.getElementById('orderDetail');
+const updateOrderForm = document.getElementById('updateOrderForm');
+const orderDetailNumberElement = document.getElementById('orderDetailNumber');
+const orderDetailCreatedAtElement = document.getElementById('orderDetailCreatedAt');
+const orderDetailUpdatedAtElement = document.getElementById('orderDetailUpdatedAt');
+const orderDetailCustomerInput = document.getElementById('orderDetailCustomer');
+const orderDetailDocumentInput = document.getElementById('orderDetailDocument');
+const orderDetailContactInput = document.getElementById('orderDetailContact');
+const orderDetailStatusSelect = document.getElementById('orderDetailStatus');
+const orderDetailTailorSelect = document.getElementById('orderDetailTailor');
+const orderDetailDeliveryDateInput = document.getElementById('orderDetailDeliveryDate');
+const orderDetailNotesTextarea = document.getElementById('orderDetailNotes');
+const orderDetailMeasurementsContainer = document.getElementById('orderDetailMeasurements');
+const closeOrderDetailButton = document.getElementById('closeOrderDetailButton');
 const toastElement = document.getElementById('toast');
 const currentYearElement = document.getElementById('currentYear');
 const currentUserNameElement = document.getElementById('currentUserName');
@@ -50,6 +66,8 @@ const ROLE_LABELS = {
   vendedor: 'Vendedor',
   sastre: 'Sastre',
 };
+
+const DELIVERY_WARNING_DAYS = 2;
 
 function setActiveView(viewId) {
   views.forEach((view) => {
@@ -90,6 +108,47 @@ function formatDate(dateString) {
   } catch (error) {
     return dateString;
   }
+}
+
+function formatDateOnly(dateString) {
+  try {
+    return new Date(dateString).toLocaleDateString('es-EC', {
+      dateStyle: 'medium',
+    });
+  } catch (error) {
+    return dateString;
+  }
+}
+
+function toInputDateValue(dateString) {
+  if (!dateString) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+    return dateString;
+  }
+  const parsedDate = new Date(dateString);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return '';
+  }
+  const year = parsedDate.getFullYear();
+  const month = String(parsedDate.getMonth() + 1).padStart(2, '0');
+  const day = String(parsedDate.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function isDeliveryDateClose(deliveryDateString, status) {
+  if (!deliveryDateString) return false;
+  if (typeof status === 'string' && status.toLowerCase() === 'entregado') {
+    return false;
+  }
+  const deliveryDate = new Date(deliveryDateString);
+  if (Number.isNaN(deliveryDate.getTime())) {
+    return false;
+  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  deliveryDate.setHours(0, 0, 0, 0);
+  const diffInDays = (deliveryDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24);
+  return diffInDays <= DELIVERY_WARNING_DAYS;
 }
 
 async function apiFetch(path, { method = 'GET', body, headers = {}, auth = true } = {}) {
@@ -558,6 +617,13 @@ async function loadStatuses() {
   const statuses = await apiFetch('/statuses', { auth: false });
   state.statuses = statuses;
   populateStatusSelect(statusSelect);
+  if (orderDetailStatusSelect) {
+    const selectedStatus =
+      state.selectedOrderId !== null
+        ? state.orders.find((order) => order.id === state.selectedOrderId)?.status
+        : orderDetailStatusSelect.value;
+    populateStatusSelect(orderDetailStatusSelect, selectedStatus);
+  }
 }
 
 async function loadTailors() {
@@ -568,6 +634,14 @@ async function loadTailors() {
     showToast(error.message, 'error');
   }
   populateTailorSelect(assignTailorSelect);
+  if (orderDetailTailorSelect) {
+    const selectedValue =
+      orderDetailTailorSelect.value ||
+      (state.selectedOrderId !== null
+        ? state.orders.find((order) => order.id === state.selectedOrderId)?.assigned_tailor?.id ?? ''
+        : '');
+    populateTailorSelect(orderDetailTailorSelect, selectedValue);
+  }
 }
 
 async function loadOrders() {
@@ -575,6 +649,14 @@ async function loadOrders() {
   try {
     state.orders = await apiFetch('/orders');
     renderOrders();
+    if (state.selectedOrderId !== null) {
+      const selected = state.orders.find((order) => order.id === state.selectedOrderId);
+      if (selected) {
+        populateOrderDetail(selected);
+      } else {
+        clearOrderDetail();
+      }
+    }
   } catch (error) {
     showToast(error.message, 'error');
   }
@@ -623,6 +705,7 @@ function handleLogout(auto = false) {
   state.customers = [];
   state.auditLogs = [];
   state.selectedCustomerId = null;
+  state.selectedOrderId = null;
   if (assignTailorSelect) {
     populateTailorSelect(assignTailorSelect);
   }
@@ -640,6 +723,7 @@ function handleLogout(auto = false) {
     auditLogTableBody.innerHTML = '';
   }
   clearCustomerDetail();
+  clearOrderDetail();
   resetCreateCustomerForm();
   measurementsList.innerHTML = '';
   ensureMeasurementRow();
@@ -738,6 +822,113 @@ function clearCustomerDetail() {
   }
 }
 
+function populateOrderDetail(order) {
+  if (!orderDetail || !order) return;
+  state.selectedOrderId = order.id;
+  orderDetail.classList.remove('hidden');
+  if (orderDetailNumberElement) {
+    orderDetailNumberElement.textContent = order.order_number;
+  }
+  if (orderDetailCreatedAtElement) {
+    orderDetailCreatedAtElement.textContent = formatDate(order.created_at);
+  }
+  if (orderDetailUpdatedAtElement) {
+    orderDetailUpdatedAtElement.textContent = formatDate(order.updated_at);
+  }
+  if (orderDetailCustomerInput) {
+    orderDetailCustomerInput.value = order.customer_name || '';
+  }
+  if (orderDetailDocumentInput) {
+    orderDetailDocumentInput.value = order.customer_document || '';
+  }
+  if (orderDetailContactInput) {
+    orderDetailContactInput.value = order.customer_contact || '';
+  }
+  if (orderDetailStatusSelect) {
+    populateStatusSelect(orderDetailStatusSelect, order.status);
+  }
+  if (orderDetailTailorSelect) {
+    populateTailorSelect(orderDetailTailorSelect, order.assigned_tailor?.id ?? '');
+  }
+  if (orderDetailDeliveryDateInput) {
+    orderDetailDeliveryDateInput.value = toInputDateValue(order.delivery_date);
+  }
+  if (orderDetailNotesTextarea) {
+    orderDetailNotesTextarea.value = order.notes || '';
+  }
+  if (orderDetailMeasurementsContainer) {
+    orderDetailMeasurementsContainer.innerHTML = '';
+    if (order.measurements?.length) {
+      orderDetailMeasurementsContainer.classList.remove('muted');
+      order.measurements.forEach((item) => {
+        const tag = document.createElement('span');
+        tag.className = 'tag';
+        tag.textContent = `${item.nombre}: ${item.valor}`;
+        orderDetailMeasurementsContainer.appendChild(tag);
+      });
+    } else {
+      orderDetailMeasurementsContainer.classList.add('muted');
+      orderDetailMeasurementsContainer.textContent = 'Sin medidas registradas.';
+    }
+  }
+}
+
+function clearOrderDetail() {
+  if (!orderDetail) return;
+  state.selectedOrderId = null;
+  orderDetail.classList.add('hidden');
+  updateOrderForm?.reset();
+  if (orderDetailNumberElement) orderDetailNumberElement.textContent = '';
+  if (orderDetailCreatedAtElement) orderDetailCreatedAtElement.textContent = '';
+  if (orderDetailUpdatedAtElement) orderDetailUpdatedAtElement.textContent = '';
+  if (orderDetailCustomerInput) orderDetailCustomerInput.value = '';
+  if (orderDetailDocumentInput) orderDetailDocumentInput.value = '';
+  if (orderDetailContactInput) orderDetailContactInput.value = '';
+  if (orderDetailStatusSelect) populateStatusSelect(orderDetailStatusSelect);
+  if (orderDetailTailorSelect) populateTailorSelect(orderDetailTailorSelect);
+  if (orderDetailDeliveryDateInput) orderDetailDeliveryDateInput.value = '';
+  if (orderDetailNotesTextarea) orderDetailNotesTextarea.value = '';
+  if (orderDetailMeasurementsContainer) {
+    orderDetailMeasurementsContainer.innerHTML = '';
+    orderDetailMeasurementsContainer.classList.add('muted');
+  }
+}
+
+async function handleOrderUpdate(event) {
+  event.preventDefault();
+  if (state.selectedOrderId === null) {
+    showToast('Selecciona una orden para actualizar.', 'error');
+    return;
+  }
+  const submitButton = updateOrderForm?.querySelector('button[type="submit"]');
+  if (submitButton) {
+    submitButton.disabled = true;
+  }
+  const deliveryDateValue = orderDetailDeliveryDateInput?.value || '';
+  try {
+    await apiFetch(`/orders/${state.selectedOrderId}`, {
+      method: 'PATCH',
+      body: {
+        status: orderDetailStatusSelect?.value,
+        assigned_tailor_id: orderDetailTailorSelect?.value
+          ? Number(orderDetailTailorSelect.value)
+          : null,
+        customer_contact: orderDetailContactInput?.value.trim() || null,
+        notes: orderDetailNotesTextarea?.value.trim() || null,
+        delivery_date: deliveryDateValue ? deliveryDateValue : null,
+      },
+    });
+    showToast('Orden actualizada.', 'success');
+    await loadOrders();
+  } catch (error) {
+    showToast(error.message, 'error');
+  } finally {
+    if (submitButton) {
+      submitButton.disabled = false;
+    }
+  }
+}
+
 if (addCustomerMeasurementSetButton) {
   addCustomerMeasurementSetButton.addEventListener('click', () => {
     createMeasurementSetBlock(customerMeasurementsContainer);
@@ -747,6 +938,16 @@ if (addCustomerMeasurementSetButton) {
 if (addUpdateCustomerMeasurementSetButton) {
   addUpdateCustomerMeasurementSetButton.addEventListener('click', () => {
     createMeasurementSetBlock(updateCustomerMeasurementsContainer);
+  });
+}
+
+if (updateOrderForm) {
+  updateOrderForm.addEventListener('submit', handleOrderUpdate);
+}
+
+if (closeOrderDetailButton) {
+  closeOrderDetailButton.addEventListener('click', () => {
+    clearOrderDetail();
   });
 }
 
@@ -845,6 +1046,7 @@ async function createOrder(event) {
   const newCustomerDocument = document.getElementById('newCustomerDocument').value.trim();
   const newCustomerContact = document.getElementById('newCustomerContact').value.trim();
   const newOrderStatus = document.getElementById('newOrderStatus').value;
+  const newOrderDeliveryDate = newOrderDeliveryDateInput?.value || '';
   const newOrderNotes = document.getElementById('newOrderNotes').value.trim();
   const assignedTailorId = assignTailorSelect.value ? Number(assignTailorSelect.value) : null;
   const measurements = collectMeasurements();
@@ -869,6 +1071,7 @@ async function createOrder(event) {
         notes: newOrderNotes || null,
         measurements,
         assigned_tailor_id: assignedTailorId,
+        delivery_date: newOrderDeliveryDate ? newOrderDeliveryDate : null,
       },
     });
     await loadOrders();
@@ -908,29 +1111,18 @@ if (orderCustomerSelect) {
   orderCustomerSelect.addEventListener('change', handleOrderCustomerChange);
 }
 
-function createStatusSelect(currentStatus) {
-  const select = document.createElement('select');
-  populateStatusSelect(select, currentStatus);
-  return select;
-}
-
-function createTailorSelector(selectedId) {
-  const select = document.createElement('select');
-  populateTailorSelect(select, selectedId ?? '');
-  return select;
-}
-
 function renderOrders() {
   if (!ordersTableBody) return;
   ordersTableBody.innerHTML = '';
   if (!state.orders.length) {
     const row = document.createElement('tr');
     const cell = document.createElement('td');
-    cell.colSpan = 9;
+    cell.colSpan = 5;
     cell.textContent = 'No hay órdenes registradas todavía.';
     cell.className = 'muted';
     row.appendChild(cell);
     ordersTableBody.appendChild(row);
+    clearOrderDetail();
     return;
   }
 
@@ -938,80 +1130,38 @@ function renderOrders() {
     const row = document.createElement('tr');
 
     const orderCell = document.createElement('td');
-    orderCell.innerHTML = `<strong>${order.order_number}</strong><br /><small>${formatDate(order.created_at)}</small>`;
+    orderCell.innerHTML = `<strong>${order.order_number}</strong>`;
 
     const customerCell = document.createElement('td');
-    customerCell.textContent = order.customer_name;
+    customerCell.textContent = order.customer_name || '—';
 
-    const documentCell = document.createElement('td');
-    documentCell.textContent = order.customer_document || '—';
+    const createdCell = document.createElement('td');
+    createdCell.textContent = formatDate(order.created_at);
 
-    const contactCell = document.createElement('td');
-    const contactInput = document.createElement('input');
-    contactInput.type = 'text';
-    contactInput.value = order.customer_contact || '';
-    contactCell.appendChild(contactInput);
-
-    const statusCell = document.createElement('td');
-    const statusSelector = createStatusSelect(order.status);
-    statusCell.appendChild(statusSelector);
-
-    const tailorCell = document.createElement('td');
-    const tailorSelector = createTailorSelector(order.assigned_tailor?.id);
-    tailorCell.appendChild(tailorSelector);
-
-    const measurementsCell = document.createElement('td');
-    if (order.measurements?.length) {
-      order.measurements.forEach((item) => {
-        const tag = document.createElement('span');
-        tag.className = 'tag';
-        tag.textContent = `${item.nombre}: ${item.valor}`;
-        measurementsCell.appendChild(tag);
-      });
+    const deliveryCell = document.createElement('td');
+    if (order.delivery_date) {
+      deliveryCell.textContent = formatDateOnly(order.delivery_date);
+      if (isDeliveryDateClose(order.delivery_date, order.status)) {
+        deliveryCell.classList.add('due-soon');
+      }
     } else {
-      measurementsCell.innerHTML = '<span class="muted">Sin medidas</span>';
+      deliveryCell.innerHTML = '<span class="muted">Sin definir</span>';
     }
 
-    const notesCell = document.createElement('td');
-    const notesTextarea = document.createElement('textarea');
-    notesTextarea.rows = 2;
-    notesTextarea.value = order.notes || '';
-    notesCell.appendChild(notesTextarea);
-
     const actionsCell = document.createElement('td');
-    const saveButton = document.createElement('button');
-    saveButton.className = 'primary';
-    saveButton.textContent = 'Guardar';
-    saveButton.addEventListener('click', async () => {
-      saveButton.disabled = true;
-      try {
-        await apiFetch(`/orders/${order.id}`, {
-          method: 'PATCH',
-          body: {
-            status: statusSelector.value,
-            assigned_tailor_id: tailorSelector.value ? Number(tailorSelector.value) : null,
-            customer_contact: contactInput.value.trim() || null,
-            notes: notesTextarea.value.trim() || null,
-          },
-        });
-        showToast('Orden actualizada.', 'success');
-        await loadOrders();
-      } catch (error) {
-        showToast(error.message, 'error');
-      } finally {
-        saveButton.disabled = false;
-      }
+    const detailButton = document.createElement('button');
+    detailButton.type = 'button';
+    detailButton.className = 'secondary';
+    detailButton.textContent = 'Ver detalle';
+    detailButton.addEventListener('click', () => {
+      populateOrderDetail(order);
     });
-    actionsCell.appendChild(saveButton);
+    actionsCell.appendChild(detailButton);
 
     row.appendChild(orderCell);
     row.appendChild(customerCell);
-    row.appendChild(documentCell);
-    row.appendChild(contactCell);
-    row.appendChild(statusCell);
-    row.appendChild(tailorCell);
-    row.appendChild(measurementsCell);
-    row.appendChild(notesCell);
+    row.appendChild(createdCell);
+    row.appendChild(deliveryCell);
     row.appendChild(actionsCell);
 
     ordersTableBody.appendChild(row);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -164,6 +164,10 @@
                 <select id="newOrderStatus"></select>
               </div>
               <div class="form-row">
+                <label for="newOrderDeliveryDate">Fecha de entrega</label>
+                <input type="date" id="newOrderDeliveryDate" />
+              </div>
+              <div class="form-row">
                 <label>Medidas guardadas del cliente</label>
                 <div id="customerMeasurementOptions" class="measurement-option-list muted">
                   Selecciona un cliente para ver sus medidas guardadas.
@@ -196,17 +200,63 @@
                   <tr>
                     <th>Orden</th>
                     <th>Cliente</th>
-                    <th>Documento</th>
-                    <th>Contacto</th>
-                    <th>Estado</th>
-                    <th>Sastre</th>
-                    <th>Medidas</th>
-                    <th>Notas</th>
+                    <th>Fecha de ingreso</th>
+                    <th>Fecha de entrega</th>
                     <th>Acciones</th>
                   </tr>
                 </thead>
                 <tbody id="ordersTableBody"></tbody>
               </table>
+            </div>
+            <div id="orderDetail" class="order-detail hidden">
+              <div class="order-detail-header">
+                <div>
+                  <h4>Detalle de la orden</h4>
+                  <p class="muted small">Orden <span id="orderDetailNumber"></span></p>
+                </div>
+                <button type="button" id="closeOrderDetailButton" class="link-button">Cerrar</button>
+              </div>
+              <div class="order-detail-meta">
+                <p><strong>Registrada:</strong> <span id="orderDetailCreatedAt"></span></p>
+                <p><strong>Última actualización:</strong> <span id="orderDetailUpdatedAt"></span></p>
+              </div>
+              <form id="updateOrderForm" class="form-grid">
+                <div class="form-row">
+                  <label for="orderDetailCustomer">Cliente</label>
+                  <input type="text" id="orderDetailCustomer" readonly />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailDocument">Documento</label>
+                  <input type="text" id="orderDetailDocument" readonly />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailContact">Contacto</label>
+                  <input type="text" id="orderDetailContact" />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailStatus">Estado</label>
+                  <select id="orderDetailStatus"></select>
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailTailor">Sastre asignado</label>
+                  <select id="orderDetailTailor"></select>
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailDeliveryDate">Fecha de entrega</label>
+                  <input type="date" id="orderDetailDeliveryDate" />
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailNotes">Notas</label>
+                  <textarea id="orderDetailNotes" rows="3"></textarea>
+                </div>
+                <div class="form-row">
+                  <label>Medidas</label>
+                  <div id="orderDetailMeasurements" class="measurement-tags muted"></div>
+                </div>
+                <div class="button-row">
+                  <button type="submit" class="primary">Guardar cambios</button>
+                </div>
+              </form>
             </div>
           </section>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -266,6 +266,48 @@ button[disabled] {
   background: #f9fbfc;
 }
 
+.order-detail {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #f9fbfc;
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.order-detail-header h4 {
+  margin: 0;
+}
+
+.order-detail-header p {
+  margin: 0.2rem 0 0;
+}
+
+.order-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.order-detail-meta p {
+  margin: 0;
+}
+
+.order-detail .measurement-tags {
+  margin-top: 0;
+}
+
 .button-row {
   display: flex;
   flex-wrap: wrap;
@@ -350,6 +392,14 @@ th {
 .table-wrapper textarea,
 .table-wrapper select {
   width: 100%;
+}
+
+.due-soon {
+  color: var(--danger);
+  text-decoration: underline;
+  text-decoration-color: var(--danger);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
 }
 
 .measurement-list {


### PR DESCRIPTION
## Summary
- add a delivery_date column to orders and surface it through the API models and serializers
- simplify the staff orders table to show key fields and highlight upcoming delivery deadlines
- introduce an order detail panel with editing for delivery date, status, assignments, contact data, and notes

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd97bf623c8332af0d141b39628670