### PR TITLE
Actualizar navegación para mostrar Panel solo al iniciar sesión

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -16,6 +16,8 @@ const state = {
 
 const views = document.querySelectorAll('.view');
 const navButtons = document.querySelectorAll('.nav-button');
+const panelNavButton = document.getElementById('panelNavButton');
+const loginNavButton = document.getElementById('loginNavButton');
 const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
 const orderLookupForm = document.getElementById('orderLookupForm');
@@ -91,11 +93,25 @@ function setActiveView(viewId) {
   navButtons.forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.view === viewId);
   });
+  if (loginNavButton) {
+    const shouldHighlightLogin = viewId === 'staff-view' && !state.token;
+    loginNavButton.classList.toggle('active', shouldHighlightLogin);
+  }
 }
 
 navButtons.forEach((btn) => {
   btn.addEventListener('click', () => setActiveView(btn.dataset.view));
 });
+
+if (loginNavButton) {
+  loginNavButton.addEventListener('click', () => {
+    setActiveView('staff-view');
+    const usernameInput = document.getElementById('username');
+    if (usernameInput) {
+      usernameInput.focus();
+    }
+  });
+}
 
 function setActiveDashboardTab(tabId = 'orderListPanel') {
   if (!dashboardPanels.length) return;
@@ -646,6 +662,19 @@ function hideDashboard() {
   }
 }
 
+function updateNavigationForAuth() {
+  const isAuthenticated = Boolean(state.token);
+  if (panelNavButton) {
+    panelNavButton.classList.toggle('hidden', !isAuthenticated);
+  }
+  if (loginNavButton) {
+    loginNavButton.classList.toggle('hidden', isAuthenticated);
+    if (isAuthenticated) {
+      loginNavButton.classList.remove('active');
+    }
+  }
+}
+
 async function handleLogin(event) {
   event.preventDefault();
   const username = document.getElementById('username').value.trim();
@@ -669,6 +698,8 @@ async function handleLogin(event) {
       await loadAuditLogs();
     }
     showDashboard();
+    updateNavigationForAuth();
+    setActiveView('staff-view');
     state.customerSearchTerm = '';
     if (customerSearchInput) {
       customerSearchInput.value = '';
@@ -810,6 +841,8 @@ function handleLogout(auto = false) {
   ensureMeasurementRow();
   renderCustomerMeasurementOptions(null);
   clearOrderResult();
+  updateNavigationForAuth();
+  setActiveView('staff-view');
   if (auto) {
     showToast('La sesión ha expirado, vuelve a iniciar sesión.', 'error');
   }
@@ -1366,3 +1399,4 @@ function initialise() {
 }
 
 initialise();
+updateNavigationForAuth();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,8 +11,19 @@
       <div class="container">
         <h1>Portal de Sastrería</h1>
         <nav class="main-nav">
-          <button class="nav-button active" data-view="client-view">Clientes</button>
-          <button class="nav-button" data-view="staff-view">Personal</button>
+          <div class="main-nav-buttons">
+            <button class="nav-button active" data-view="client-view">Clientes</button>
+            <button
+              class="nav-button hidden"
+              data-view="staff-view"
+              id="panelNavButton"
+            >
+              Panel
+            </button>
+          </div>
+          <button type="button" class="login-button" id="loginNavButton">
+            Iniciar sesión
+          </button>
         </nav>
       </div>
     </header>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -41,8 +41,16 @@ body {
 
 .main-nav {
   display: flex;
+  align-items: center;
   gap: 0.75rem;
   margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.main-nav-buttons {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .nav-button {
@@ -58,6 +66,25 @@ body {
 
 .nav-button:hover,
 .nav-button.active {
+  background: white;
+  color: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+.login-button {
+  margin-left: auto;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: transparent;
+  color: white;
+  padding: 0.5rem 1.35rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.login-button:hover,
+.login-button.active {
   background: white;
   color: var(--primary-dark);
   transform: translateY(-1px);


### PR DESCRIPTION
## Summary
- rename the Personal tab to Panel and wrap the header nav to include an Iniciar sesión button
- adjust styles so the new login button sits to the right and matches hover/active states
- update front-end logic to toggle the Panel tab visibility based on authentication, manage the login button state, and focus the username field when opening the login view

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cdc4fc51388332be27db56b781100e