### PR TITLE
Set application timezone to GMT-5

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Optional
 
 from fastapi import Depends, HTTPException, status
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from .config import get_settings
 from .database import get_db
 from . import models, schemas
+from .timezone import now
 
 settings = get_settings()
 
@@ -34,7 +35,7 @@ def authenticate_user(db: Session, username: str, password: str) -> Optional[mod
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (
+    expire = now() + (
         expires_delta if expires_delta else timedelta(minutes=settings.access_token_expire_minutes)
     )
     to_encode.update({"exp": expire})

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,10 +1,10 @@
 import enum
-from datetime import datetime
 
 from sqlalchemy import Column, Date, DateTime, Enum, ForeignKey, Integer, JSON, String, Text
 from sqlalchemy.orm import relationship
 
 from .database import Base
+from .timezone import now
 
 
 class UserRole(str, enum.Enum):
@@ -61,11 +61,11 @@ class Order(Base):
     notes = Column(Text, nullable=True)
     assigned_tailor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     delivery_date = Column(Date, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=now, nullable=False)
     updated_at = Column(
-        DateTime,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        DateTime(timezone=True),
+        default=now,
+        onupdate=now,
         nullable=False,
     )
 
@@ -82,11 +82,11 @@ class Customer(Base):
     full_name = Column(String(100), nullable=False)
     document_id = Column(String(50), unique=True, nullable=False, index=True)
     phone = Column(String(50), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=now, nullable=False)
     updated_at = Column(
-        DateTime,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        DateTime(timezone=True),
+        default=now,
+        onupdate=now,
         nullable=False,
     )
 
@@ -107,11 +107,11 @@ class CustomerMeasurement(Base):
     customer_id = Column(Integer, ForeignKey("customers.id", ondelete="CASCADE"), nullable=False)
     title = Column(String(100), nullable=False)
     measurements = Column(JSON, nullable=False, default=list)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=now, nullable=False)
     updated_at = Column(
-        DateTime,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        DateTime(timezone=True),
+        default=now,
+        onupdate=now,
         nullable=False,
     )
 
@@ -124,7 +124,7 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id = Column(Integer, primary_key=True, index=True)
-    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False)
+    timestamp = Column(DateTime(timezone=True), default=now, nullable=False)
     actor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     action = Column(String(50), nullable=False)
     entity_type = Column(String(50), nullable=False)

--- a/backend/app/timezone.py
+++ b/backend/app/timezone.py
@@ -1,0 +1,19 @@
+"""Utility helpers for working with the application timezone."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+# The tailoring business operates on the GMT-5 timezone (e.g., Ecuador/Colombia).
+# Using a fixed offset keeps the behaviour consistent regardless of the server's
+# locale configuration.
+APP_TIMEZONE = timezone(timedelta(hours=-5))
+
+
+def now() -> datetime:
+    """Return the current time in the application timezone."""
+
+    return datetime.now(tz=APP_TIMEZONE)
+
+
+__all__ = ["APP_TIMEZONE", "now"]

--- a/backend/seed_database.py
+++ b/backend/seed_database.py
@@ -8,13 +8,14 @@ import re
 import secrets
 import string
 from collections import Counter
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Iterable, List, Sequence, Tuple
 
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from app import crud, models, schemas
+from app.timezone import now
 from app.database import Base, SessionLocal, engine
 
 FIRST_NAMES: Sequence[str] = (
@@ -211,7 +212,7 @@ def random_password(length: int = 10) -> str:
 
 
 def random_delivery_date(status: models.OrderStatus) -> date | None:
-    today = date.today()
+    today = now().date()
     if status == models.OrderStatus.ENTREGADO:
         return today - timedelta(days=random.randint(1, 30))
     if status in {
@@ -280,7 +281,7 @@ def seed_orders(
     if count <= 0 or not customers:
         return []
     existing_order_numbers = set(db.execute(select(models.Order.order_number)).scalars())
-    year = datetime.utcnow().year
+    year = now().year
     orders: List[models.Order] = []
     for _ in range(count):
         customer = random.choice(customers)


### PR DESCRIPTION
## Summary
- add a shared timezone helper that returns datetimes in the GMT-5 offset used by the business
- update ORM models to persist timestamps with timezone-aware values in that offset
- apply the new helper in authentication token expiry logic and the seed script

## Testing
- cd backend && python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cdc9516fb8833284e22430faf4e401