### PR TITLE
Improve order management sorting and highlighting

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -239,9 +239,22 @@
 
           <section class="card dashboard-panel" id="orderListPanel">
             <h3>Órdenes registradas</h3>
-            <p class="muted small">
-              Las fechas próximas de entrega se subrayan en rojo cuando la orden aún no está entregada.
-            </p>
+            <div class="order-panel-controls">
+              <p class="muted small">
+                Las órdenes pendientes se muestran primero, ordenadas por la fecha de entrega más
+                cercana. Las fechas vencidas se resaltan en rojo mientras la orden no haya sido
+                entregada.
+              </p>
+              <div class="order-search">
+                <label for="orderSearchInput">Buscar</label>
+                <input
+                  type="search"
+                  id="orderSearchInput"
+                  placeholder="Número de orden o cédula"
+                  autocomplete="off"
+                />
+              </div>
+            </div>
             <div class="table-wrapper">
               <table>
                 <thead>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -225,11 +225,17 @@ button.full-width {
 button.link-button {
   background: none;
   border: none;
-  color: white;
+  color: var(--primary-dark);
   font-weight: 600;
   padding: 0;
   margin-left: 0.5rem;
   text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+}
+
+button.link-button:hover {
+  color: var(--primary);
 }
 
 button[disabled] {
@@ -395,6 +401,19 @@ button[disabled] {
   .customer-panel-actions button {
     width: 100%;
   }
+
+  .order-panel-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .order-search {
+    width: 100%;
+  }
+
+  .order-search input {
+    width: 100%;
+  }
 }
 
 .customer-detail {
@@ -452,9 +471,43 @@ button[disabled] {
   gap: 0.75rem;
 }
 
+.order-panel-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.order-panel-controls p {
+  margin: 0;
+  max-width: 48ch;
+}
+
+.order-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-search label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.order-search input {
+  width: min(260px, 100%);
+}
+
 .user-info {
   color: var(--muted);
   font-size: 0.95rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .measurement-set-list,
@@ -538,6 +591,12 @@ th {
   text-decoration-color: var(--danger);
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
+  font-weight: 600;
+}
+
+.overdue {
+  color: var(--danger);
+  font-weight: 700;
 }
 
 .measurement-list {


### PR DESCRIPTION
## Summary
- ensure the dashboard logout control is visible by updating link button styling and layout
- add filtering and sorting helpers so pending orders appear first by delivery date, highlight overdue dates, and support search by order number or customer document
- refresh the orders panel copy and layout with a search input and responsive styling for the new controls

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cdcf43fe008332ba9c2c6e4861b52d