### PR TITLE
Show status in order list and inline detail

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -239,15 +239,29 @@
 
           <section class="card dashboard-panel" id="orderListPanel">
             <h3>Órdenes registradas</h3>
-            <p class="muted small">
-              Las fechas próximas de entrega se subrayan en rojo cuando la orden aún no está entregada.
-            </p>
+            <div class="order-panel-controls">
+              <p class="muted small">
+                Las órdenes pendientes se muestran primero, ordenadas por la fecha de entrega más
+                cercana. Las fechas vencidas se resaltan en rojo mientras la orden no haya sido
+                entregada.
+              </p>
+              <div class="order-search">
+                <label for="orderSearchInput">Buscar</label>
+                <input
+                  type="search"
+                  id="orderSearchInput"
+                  placeholder="Número de orden o cédula"
+                  autocomplete="off"
+                />
+              </div>
+            </div>
             <div class="table-wrapper">
               <table>
                 <thead>
                   <tr>
                     <th>Orden</th>
                     <th>Cliente</th>
+                    <th>Estado</th>
                     <th>Fecha de ingreso</th>
                     <th>Fecha de entrega</th>
                     <th>Acciones</th>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -225,11 +225,17 @@ button.full-width {
 button.link-button {
   background: none;
   border: none;
-  color: white;
+  color: var(--primary-dark);
   font-weight: 600;
   padding: 0;
   margin-left: 0.5rem;
   text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+}
+
+button.link-button:hover {
+  color: var(--primary);
 }
 
 button[disabled] {
@@ -395,6 +401,19 @@ button[disabled] {
   .customer-panel-actions button {
     width: 100%;
   }
+
+  .order-panel-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .order-search {
+    width: 100%;
+  }
+
+  .order-search input {
+    width: 100%;
+  }
 }
 
 .customer-detail {
@@ -406,10 +425,10 @@ button[disabled] {
 
 .order-detail {
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 0 0 12px 12px;
   padding: 1.5rem;
   background: #f9fbfc;
-  margin-top: 1.5rem;
+  margin: 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -452,9 +471,43 @@ button[disabled] {
   gap: 0.75rem;
 }
 
+.order-panel-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.order-panel-controls p {
+  margin: 0;
+  max-width: 48ch;
+}
+
+.order-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-search label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.order-search input {
+  width: min(260px, 100%);
+}
+
 .user-info {
   color: var(--muted);
   font-size: 0.95rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .measurement-set-list,
@@ -526,6 +579,28 @@ th {
   background: rgba(31, 122, 140, 0.08);
 }
 
+.order-row {
+  transition: background 0.2s ease;
+}
+
+.order-row.is-selected {
+  background: rgba(31, 122, 140, 0.08);
+}
+
+.order-row.is-selected td {
+  border-bottom-color: transparent;
+}
+
+.order-detail-row td {
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.order-detail-cell {
+  padding: 0;
+}
+
 .table-wrapper input,
 .table-wrapper textarea,
 .table-wrapper select {
@@ -538,6 +613,12 @@ th {
   text-decoration-color: var(--danger);
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
+  font-weight: 600;
+}
+
+.overdue {
+  color: var(--danger);
+  font-weight: 700;
 }
 
 .measurement-list {
@@ -569,6 +650,44 @@ th {
   color: var(--primary-dark);
   margin: 0.15rem;
   font-size: 0.85rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  background: rgba(31, 122, 140, 0.12);
+  color: var(--primary-dark);
+  white-space: nowrap;
+}
+
+.status-badge.status-neutral {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+}
+
+.status-badge.status-info {
+  background: rgba(31, 122, 140, 0.12);
+  color: var(--primary-dark);
+}
+
+.status-badge.status-success {
+  background: rgba(47, 133, 90, 0.15);
+  color: var(--success);
+}
+
+.status-badge.status-warning {
+  background: rgba(255, 127, 80, 0.18);
+  color: var(--accent);
+}
+
+.status-badge.status-danger {
+  background: rgba(197, 48, 48, 0.15);
+  color: var(--danger);
 }
 
 .table-wrapper pre {


### PR DESCRIPTION
## Summary
- show each order's current status directly in the registered orders table using colored badges
- render the order detail form inline beneath the selected row so "Ver detalle" expands in-place and can be collapsed again
- tweak table helpers and styling for the new column and inline detail layout

## Testing
- not run (frontend changes only)

------
https://chatgpt.com/codex/tasks/task_e_68cdcf43fe008332ba9c2c6e4861b52d