### PR TITLE
Fix login navigation by resolving renderOrders syntax errors

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1496,27 +1496,6 @@ function renderOrders() {
     cell.className = 'muted';
     row.appendChild(cell);
     ordersTableBody.appendChild(row);
-    clearOrderDetail();
-    return;
-  }
-
-  const sortedOrders = [...filteredOrders].sort(compareOrdersForDisplay);
-
-  if (
-    state.selectedOrderId !== null &&
-    sortedOrders.every((order) => order.id !== state.selectedOrderId)
-  ) {
-    clearOrderDetail();
-  }
-
-  sortedOrders.forEach((order) => {
-    const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = ORDER_TABLE_COLUMN_COUNT;
-    cell.textContent = 'No se encontraron órdenes que coincidan con la búsqueda.';
-    cell.className = 'muted';
-    row.appendChild(cell);
-    ordersTableBody.appendChild(row);
     clearOrderDetail({ skipRender: true });
     return;
   }


### PR DESCRIPTION
## Summary
- remove the duplicated placeholder rendering block in `renderOrders` that introduced a syntax error preventing the staff login view from activating
- ensure empty search results clear the detail panel without re-triggering `renderOrders`, keeping the dashboard toggle functional

## Testing
- `cd frontend && node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68cde10b55a08332b48f16f709a69d85