### PR TITLE
Add pagination controls and adjust delivered order ordering

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,4 +1,6 @@
 const API_BASE_URL = window.API_BASE_URL || 'http://localhost:8000';
+const DEFAULT_PAGE_SIZE = 10;
+const PAGE_SIZE_OPTIONS = [10, 15, 20, 25, 30, 35, 40, 45, 50];
 
 const state = {
   statuses: [],
@@ -9,6 +11,10 @@ const state = {
   customers: [],
   customerSearchTerm: '',
   orderSearchTerm: '',
+  customerPage: 1,
+  customerPageSize: DEFAULT_PAGE_SIZE,
+  orderPage: 1,
+  orderPageSize: DEFAULT_PAGE_SIZE,
   isCreateCustomerVisible: false,
   auditLogs: [],
   selectedCustomerId: null,
@@ -37,6 +43,10 @@ const showCreateCustomerButton = document.getElementById('showCreateCustomerButt
 const createCustomerSection = document.getElementById('createCustomerSection');
 const closeCreateCustomerButton = document.getElementById('closeCreateCustomerButton');
 const customersTableBody = document.getElementById('customersTableBody');
+const customerPageSizeSelect = document.getElementById('customerPageSize');
+const customerPrevPageButton = document.getElementById('customerPrevPage');
+const customerNextPageButton = document.getElementById('customerNextPage');
+const customerPaginationInfo = document.getElementById('customerPaginationInfo');
 const customerDetail = document.getElementById('customerDetail');
 const customerMeasurementsContainer = document.getElementById('customerMeasurementsContainer');
 const updateCustomerMeasurementsContainer = document.getElementById('updateCustomerMeasurementsContainer');
@@ -46,6 +56,10 @@ const deleteCustomerButton = document.getElementById('deleteCustomerButton');
 const orderCustomerSelect = document.getElementById('orderCustomerSelect');
 const customerMeasurementOptions = document.getElementById('customerMeasurementOptions');
 const ordersTableBody = document.getElementById('ordersTableBody');
+const orderPageSizeSelect = document.getElementById('orderPageSize');
+const orderPrevPageButton = document.getElementById('orderPrevPage');
+const orderNextPageButton = document.getElementById('orderNextPage');
+const orderPaginationInfo = document.getElementById('orderPaginationInfo');
 const orderSearchInput = document.getElementById('orderSearchInput');
 const measurementsList = document.getElementById('measurementsList');
 const addMeasurementButton = document.getElementById('addMeasurementButton');
@@ -831,6 +845,10 @@ function handleLogout(auto = false) {
   state.customers = [];
   state.customerSearchTerm = '';
   state.orderSearchTerm = '';
+  state.customerPage = 1;
+  state.customerPageSize = DEFAULT_PAGE_SIZE;
+  state.orderPage = 1;
+  state.orderPageSize = DEFAULT_PAGE_SIZE;
   state.isCreateCustomerVisible = false;
   state.auditLogs = [];
   state.selectedCustomerId = null;
@@ -852,6 +870,12 @@ function handleLogout(auto = false) {
   if (orderSearchInput) {
     orderSearchInput.value = '';
   }
+  if (customerPageSizeSelect) {
+    customerPageSizeSelect.value = String(DEFAULT_PAGE_SIZE);
+  }
+  if (orderPageSizeSelect) {
+    orderPageSizeSelect.value = String(DEFAULT_PAGE_SIZE);
+  }
   setCreateCustomerVisible(false);
   if (ordersTableBody) {
     ordersTableBody.innerHTML = '';
@@ -870,6 +894,26 @@ function handleLogout(auto = false) {
   ensureMeasurementRow();
   renderCustomerMeasurementOptions(null);
   clearOrderResult();
+  updatePaginationControls({
+    infoElement: customerPaginationInfo,
+    prevButton: customerPrevPageButton,
+    nextButton: customerNextPageButton,
+    pageSizeSelect: customerPageSizeSelect,
+    currentPage: 1,
+    totalItems: 0,
+    pageSize: state.customerPageSize,
+    emptyLabel: 'clientes',
+  });
+  updatePaginationControls({
+    infoElement: orderPaginationInfo,
+    prevButton: orderPrevPageButton,
+    nextButton: orderNextPageButton,
+    pageSizeSelect: orderPageSizeSelect,
+    currentPage: 1,
+    totalItems: 0,
+    pageSize: state.orderPageSize,
+    emptyLabel: 'órdenes',
+  });
   updateNavigationForAuth();
   setActiveView('staff-view');
   if (auto) {
@@ -889,11 +933,26 @@ if (logoutButton) {
 }
 function renderCustomers() {
   if (!customersTableBody) return;
+  const pageSize = getValidPageSize(state.customerPageSize);
+  if (state.customerPageSize !== pageSize) {
+    state.customerPageSize = pageSize;
+  }
   customersTableBody.innerHTML = '';
   if (customerSearchInput && customerSearchInput.value !== state.customerSearchTerm) {
     customerSearchInput.value = state.customerSearchTerm;
   }
   if (!state.customers.length) {
+    state.customerPage = 1;
+    updatePaginationControls({
+      infoElement: customerPaginationInfo,
+      prevButton: customerPrevPageButton,
+      nextButton: customerNextPageButton,
+      pageSizeSelect: customerPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'clientes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = 5;
@@ -922,6 +981,17 @@ function renderCustomers() {
   }
 
   if (!filteredCustomers.length) {
+    state.customerPage = 1;
+    updatePaginationControls({
+      infoElement: customerPaginationInfo,
+      prevButton: customerPrevPageButton,
+      nextButton: customerNextPageButton,
+      pageSizeSelect: customerPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'clientes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = 5;
@@ -932,7 +1002,34 @@ function renderCustomers() {
     return;
   }
 
-  filteredCustomers.forEach((customer) => {
+  const totalItems = filteredCustomers.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  let currentPage = Number(state.customerPage) || 1;
+  currentPage = Math.min(Math.max(currentPage, 1), totalPages);
+  currentPage =
+    updatePaginationControls({
+      infoElement: customerPaginationInfo,
+      prevButton: customerPrevPageButton,
+      nextButton: customerNextPageButton,
+      pageSizeSelect: customerPageSizeSelect,
+      currentPage,
+      totalItems,
+      pageSize,
+      emptyLabel: 'clientes',
+    }) || currentPage;
+
+  if (!Number.isFinite(currentPage) || currentPage < 1) {
+    currentPage = 1;
+  }
+
+  if (state.customerPage !== currentPage) {
+    state.customerPage = currentPage;
+  }
+
+  const startIndex = (currentPage - 1) * pageSize;
+  const paginatedCustomers = filteredCustomers.slice(startIndex, startIndex + pageSize);
+
+  paginatedCustomers.forEach((customer) => {
     const row = document.createElement('tr');
 
     const nameCell = document.createElement('td');
@@ -1138,6 +1235,7 @@ if (addUpdateCustomerMeasurementSetButton) {
 if (customerSearchInput) {
   customerSearchInput.addEventListener('input', (event) => {
     state.customerSearchTerm = event.target.value;
+    state.customerPage = 1;
     renderCustomers();
   });
 }
@@ -1145,6 +1243,57 @@ if (customerSearchInput) {
 if (orderSearchInput) {
   orderSearchInput.addEventListener('input', (event) => {
     state.orderSearchTerm = event.target.value;
+    state.orderPage = 1;
+    renderOrders();
+  });
+}
+
+if (customerPageSizeSelect) {
+  customerPageSizeSelect.addEventListener('change', (event) => {
+    const newSize = getValidPageSize(event.target.value);
+    state.customerPageSize = newSize;
+    state.customerPage = 1;
+    renderCustomers();
+  });
+}
+
+if (customerPrevPageButton) {
+  customerPrevPageButton.addEventListener('click', () => {
+    if (state.customerPage > 1) {
+      state.customerPage -= 1;
+      renderCustomers();
+    }
+  });
+}
+
+if (customerNextPageButton) {
+  customerNextPageButton.addEventListener('click', () => {
+    state.customerPage += 1;
+    renderCustomers();
+  });
+}
+
+if (orderPageSizeSelect) {
+  orderPageSizeSelect.addEventListener('change', (event) => {
+    const newSize = getValidPageSize(event.target.value);
+    state.orderPageSize = newSize;
+    state.orderPage = 1;
+    renderOrders();
+  });
+}
+
+if (orderPrevPageButton) {
+  orderPrevPageButton.addEventListener('click', () => {
+    if (state.orderPage > 1) {
+      state.orderPage -= 1;
+      renderOrders();
+    }
+  });
+}
+
+if (orderNextPageButton) {
+  orderNextPageButton.addEventListener('click', () => {
+    state.orderPage += 1;
     renderOrders();
   });
 }
@@ -1348,19 +1497,6 @@ function toTimestamp(value) {
   return parsed ? parsed.getTime() : null;
 }
 
-function compareNullableNumbers(a, b) {
-  if (a !== null && b !== null && a !== b) {
-    return a - b;
-  }
-  if (a !== null && b === null) {
-    return -1;
-  }
-  if (a === null && b !== null) {
-    return 1;
-  }
-  return 0;
-}
-
 function compareOrdersForDisplay(a, b) {
   const aDelivered = isOrderDelivered(a.status);
   const bDelivered = isOrderDelivered(b.status);
@@ -1368,29 +1504,36 @@ function compareOrdersForDisplay(a, b) {
     return aDelivered ? 1 : -1;
   }
 
-  const deliveryComparison = compareNullableNumbers(
-    toTimestamp(a.delivery_date),
-    toTimestamp(b.delivery_date),
-  );
-  if (deliveryComparison !== 0) {
-    return deliveryComparison;
+  const aDelivery = toTimestamp(a.delivery_date);
+  const bDelivery = toTimestamp(b.delivery_date);
+
+  if (aDelivered && bDelivered) {
+    if (aDelivery !== bDelivery) {
+      if (aDelivery === null) return 1;
+      if (bDelivery === null) return -1;
+      return bDelivery - aDelivery;
+    }
+  } else if (aDelivery !== bDelivery) {
+    if (aDelivery === null) return 1;
+    if (bDelivery === null) return -1;
+    return aDelivery - bDelivery;
   }
 
   if (!aDelivered) {
-    const createdComparison = compareNullableNumbers(
-      toTimestamp(a.created_at),
-      toTimestamp(b.created_at),
-    );
-    if (createdComparison !== 0) {
-      return createdComparison;
+    const aCreated = toTimestamp(a.created_at);
+    const bCreated = toTimestamp(b.created_at);
+    if (aCreated !== bCreated) {
+      if (aCreated === null) return 1;
+      if (bCreated === null) return -1;
+      return aCreated - bCreated;
     }
   } else {
-    const updatedComparison = compareNullableNumbers(
-      toTimestamp(a.updated_at),
-      toTimestamp(b.updated_at),
-    );
-    if (updatedComparison !== 0) {
-      return updatedComparison;
+    const aUpdated = toTimestamp(a.updated_at);
+    const bUpdated = toTimestamp(b.updated_at);
+    if (aUpdated !== bUpdated) {
+      if (aUpdated === null) return 1;
+      if (bUpdated === null) return -1;
+      return bUpdated - aUpdated;
     }
   }
 
@@ -1454,8 +1597,63 @@ function createStatusBadge(status) {
 }
 
 
+function getValidPageSize(value) {
+  const numericValue = Number(value);
+  if (PAGE_SIZE_OPTIONS.includes(numericValue)) {
+    return numericValue;
+  }
+  return DEFAULT_PAGE_SIZE;
+}
+
+function updatePaginationControls({
+  infoElement,
+  prevButton,
+  nextButton,
+  pageSizeSelect,
+  currentPage,
+  totalItems,
+  pageSize,
+  emptyLabel,
+}) {
+  const totalPages = totalItems > 0 ? Math.ceil(totalItems / pageSize) : 1;
+  const normalizedPage = totalItems > 0 ? Math.min(Math.max(currentPage, 1), totalPages) : 1;
+  const startItem = totalItems === 0 ? 0 : (normalizedPage - 1) * pageSize + 1;
+  const endItem = totalItems === 0 ? 0 : Math.min(normalizedPage * pageSize, totalItems);
+
+  if (infoElement) {
+    infoElement.textContent =
+      totalItems === 0
+        ? `Sin ${emptyLabel}`
+        : `Mostrando ${startItem}-${endItem} de ${totalItems}`;
+  }
+
+  if (prevButton) {
+    const isDisabled = totalItems === 0 || normalizedPage <= 1;
+    prevButton.disabled = isDisabled;
+    prevButton.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+  }
+
+  if (nextButton) {
+    const isDisabled = totalItems === 0 || normalizedPage >= totalPages;
+    nextButton.disabled = isDisabled;
+    nextButton.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+  }
+
+  if (pageSizeSelect && pageSizeSelect.value !== String(pageSize)) {
+    pageSizeSelect.value = String(pageSize);
+  }
+
+  return normalizedPage;
+}
+
+
 function renderOrders() {
   if (!ordersTableBody) return;
+
+  const pageSize = getValidPageSize(state.orderPageSize);
+  if (state.orderPageSize !== pageSize) {
+    state.orderPageSize = pageSize;
+  }
 
   removeOrderDetailRow();
   if (orderDetail) {
@@ -1468,6 +1666,17 @@ function renderOrders() {
   }
 
   if (!state.orders.length) {
+    state.orderPage = 1;
+    updatePaginationControls({
+      infoElement: orderPaginationInfo,
+      prevButton: orderPrevPageButton,
+      nextButton: orderNextPageButton,
+      pageSizeSelect: orderPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'órdenes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = ORDER_TABLE_COLUMN_COUNT;
@@ -1489,27 +1698,17 @@ function renderOrders() {
     : [...state.orders];
 
   if (!filteredOrders.length) {
-    const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 5;
-    cell.textContent = 'No se encontraron órdenes que coincidan con la búsqueda.';
-    cell.className = 'muted';
-    row.appendChild(cell);
-    ordersTableBody.appendChild(row);
-    clearOrderDetail();
-    return;
-  }
-
-  const sortedOrders = [...filteredOrders].sort(compareOrdersForDisplay);
-
-  if (
-    state.selectedOrderId !== null &&
-    sortedOrders.every((order) => order.id !== state.selectedOrderId)
-  ) {
-    clearOrderDetail();
-  }
-
-  sortedOrders.forEach((order) => {
+    state.orderPage = 1;
+    updatePaginationControls({
+      infoElement: orderPaginationInfo,
+      prevButton: orderPrevPageButton,
+      nextButton: orderNextPageButton,
+      pageSizeSelect: orderPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'órdenes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = ORDER_TABLE_COLUMN_COUNT;
@@ -1530,9 +1729,47 @@ function renderOrders() {
     clearOrderDetail({ skipRender: true });
   }
 
+  const totalItems = sortedOrders.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  let currentPage = Number(state.orderPage) || 1;
+
+  if (state.selectedOrderId !== null) {
+    const selectedIndex = sortedOrders.findIndex((order) => order.id === state.selectedOrderId);
+    if (selectedIndex >= 0) {
+      const selectedPage = Math.floor(selectedIndex / pageSize) + 1;
+      if (selectedPage !== currentPage) {
+        currentPage = selectedPage;
+      }
+    }
+  }
+
+  currentPage = Math.min(Math.max(currentPage, 1), totalPages);
+  currentPage =
+    updatePaginationControls({
+      infoElement: orderPaginationInfo,
+      prevButton: orderPrevPageButton,
+      nextButton: orderNextPageButton,
+      pageSizeSelect: orderPageSizeSelect,
+      currentPage,
+      totalItems,
+      pageSize,
+      emptyLabel: 'órdenes',
+    }) || currentPage;
+
+  if (!Number.isFinite(currentPage) || currentPage < 1) {
+    currentPage = 1;
+  }
+
+  if (state.orderPage !== currentPage) {
+    state.orderPage = currentPage;
+  }
+
+  const startIndex = (currentPage - 1) * pageSize;
+  const paginatedOrders = sortedOrders.slice(startIndex, startIndex + pageSize);
+
   let hasActiveDetail = false;
 
-  sortedOrders.forEach((order) => {
+  paginatedOrders.forEach((order) => {
     const row = document.createElement('tr');
     row.classList.add('order-row');
     const isSelected = state.selectedOrderId === order.id;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,13 +92,54 @@
                 <h3>Gestión de clientes</h3>
                 <p class="muted">Consulta, busca y administra la información de tus clientes.</p>
               </div>
-              <div class="customer-panel-actions">
-                <div class="customer-search">
-                  <label for="customerSearchInput">Buscar</label>
-                  <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
-                </div>
-                <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
+            <div class="customer-panel-actions">
+              <div class="customer-search">
+                <label for="customerSearchInput">Buscar</label>
+                <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
               </div>
+              <div class="table-pagination">
+                <label for="customerPageSize">Filas por página</label>
+                <div class="pagination-controls">
+                  <select id="customerPageSize">
+                    <option value="10" selected>10</option>
+                    <option value="15">15</option>
+                    <option value="20">20</option>
+                    <option value="25">25</option>
+                    <option value="30">30</option>
+                    <option value="35">35</option>
+                    <option value="40">40</option>
+                    <option value="45">45</option>
+                    <option value="50">50</option>
+                  </select>
+                  <div class="pagination-buttons">
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="customerPrevPage"
+                      aria-label="Página anterior de clientes"
+                    >
+                      Anterior
+                    </button>
+                    <span
+                      id="customerPaginationInfo"
+                      class="pagination-info"
+                      aria-live="polite"
+                    >
+                      Mostrando 0-0 de 0
+                    </span>
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="customerNextPage"
+                      aria-label="Página siguiente de clientes"
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
+            </div>
             </div>
             <div id="createCustomerSection" class="customer-create hidden">
               <div class="customer-create-header">
@@ -253,6 +294,47 @@
                   placeholder="Número de orden o cédula"
                   autocomplete="off"
                 />
+              </div>
+              <div class="table-pagination">
+                <label for="orderPageSize">Filas por página</label>
+                <div class="pagination-controls">
+                  <select id="orderPageSize">
+                    <option value="10" selected>10</option>
+                    <option value="15">15</option>
+                    <option value="20">20</option>
+                    <option value="25">25</option>
+                    <option value="30">30</option>
+                    <option value="35">35</option>
+                    <option value="40">40</option>
+                    <option value="45">45</option>
+                    <option value="50">50</option>
+                  </select>
+                  <div class="pagination-buttons">
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="orderPrevPage"
+                      aria-label="Página anterior de órdenes"
+                    >
+                      Anterior
+                    </button>
+                    <span
+                      id="orderPaginationInfo"
+                      class="pagination-info"
+                      aria-live="polite"
+                    >
+                      Mostrando 0-0 de 0
+                    </span>
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="orderNextPage"
+                      aria-label="Página siguiente de órdenes"
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
             <div class="table-wrapper">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -398,7 +398,7 @@ button[disabled] {
     align-items: stretch;
   }
 
-  .customer-panel-actions button {
+  .customer-panel-actions > button {
     width: 100%;
   }
 
@@ -413,6 +413,33 @@ button[disabled] {
 
   .order-search input {
     width: 100%;
+  }
+
+  .table-pagination {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .pagination-controls {
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .pagination-buttons {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .pagination-button {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+
+  .pagination-info {
+    width: 100%;
+    text-align: center;
   }
 }
 
@@ -499,6 +526,64 @@ button[disabled] {
 
 .order-search input {
   width: min(260px, 100%);
+}
+
+.table-pagination {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-end;
+  min-width: 200px;
+}
+
+.table-pagination label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.pagination-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.pagination-controls select {
+  min-width: 90px;
+}
+
+.pagination-buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pagination-button {
+  border: 1px solid var(--border);
+  background: white;
+  color: var(--primary-dark);
+  padding: 0.35rem 0.85rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.pagination-button:hover:not(:disabled) {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+}
+
+.pagination-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .user-info {


### PR DESCRIPTION
## Summary
- add pagination selectors and navigation controls to the customer and order tables in the dashboard
- implement client-side pagination logic tied to search filters and dropdowns
- sort delivered orders from most recent to oldest while keeping pagination state consistent on logout

## Testing
- `cd frontend && node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68cde10b55a08332b48f16f709a69d85