### PR TITLE
Improve customer detail view and show delivery times

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,4 +1,6 @@
 const API_BASE_URL = window.API_BASE_URL || 'http://localhost:8000';
+const DEFAULT_PAGE_SIZE = 10;
+const PAGE_SIZE_OPTIONS = [10, 15, 20, 25, 30, 35, 40, 45, 50];
 
 const state = {
   statuses: [],
@@ -9,6 +11,10 @@ const state = {
   customers: [],
   customerSearchTerm: '',
   orderSearchTerm: '',
+  customerPage: 1,
+  customerPageSize: DEFAULT_PAGE_SIZE,
+  orderPage: 1,
+  orderPageSize: DEFAULT_PAGE_SIZE,
   isCreateCustomerVisible: false,
   auditLogs: [],
   selectedCustomerId: null,
@@ -37,7 +43,14 @@ const showCreateCustomerButton = document.getElementById('showCreateCustomerButt
 const createCustomerSection = document.getElementById('createCustomerSection');
 const closeCreateCustomerButton = document.getElementById('closeCreateCustomerButton');
 const customersTableBody = document.getElementById('customersTableBody');
+const customerPageSizeSelect = document.getElementById('customerPageSize');
+const customerPrevPageButton = document.getElementById('customerPrevPage');
+const customerNextPageButton = document.getElementById('customerNextPage');
+const customerPaginationInfo = document.getElementById('customerPaginationInfo');
 const customerDetail = document.getElementById('customerDetail');
+const customerDetailTitle = document.getElementById('customerDetailTitle');
+const customerDetailSummaryElement = document.getElementById('customerDetailSummary');
+const customerOrderHistoryContainer = document.getElementById('customerOrderHistory');
 const customerMeasurementsContainer = document.getElementById('customerMeasurementsContainer');
 const updateCustomerMeasurementsContainer = document.getElementById('updateCustomerMeasurementsContainer');
 const addCustomerMeasurementSetButton = document.getElementById('addCustomerMeasurementSet');
@@ -46,6 +59,10 @@ const deleteCustomerButton = document.getElementById('deleteCustomerButton');
 const orderCustomerSelect = document.getElementById('orderCustomerSelect');
 const customerMeasurementOptions = document.getElementById('customerMeasurementOptions');
 const ordersTableBody = document.getElementById('ordersTableBody');
+const orderPageSizeSelect = document.getElementById('orderPageSize');
+const orderPrevPageButton = document.getElementById('orderPrevPage');
+const orderNextPageButton = document.getElementById('orderNextPage');
+const orderPaginationInfo = document.getElementById('orderPaginationInfo');
 const orderSearchInput = document.getElementById('orderSearchInput');
 const measurementsList = document.getElementById('measurementsList');
 const addMeasurementButton = document.getElementById('addMeasurementButton');
@@ -72,6 +89,7 @@ const currentUserNameElement = document.getElementById('currentUserName');
 const currentUserRoleElement = document.getElementById('currentUserRole');
 const auditLogTabButton = document.getElementById('auditLogTabButton');
 const auditLogTableBody = document.getElementById('auditLogTableBody');
+const closeCustomerDetailButton = document.getElementById('closeCustomerDetailButton');
 
 const ROLE_LABELS = {
   administrador: 'Administrador',
@@ -80,6 +98,10 @@ const ROLE_LABELS = {
 };
 
 const DELIVERY_WARNING_DAYS = 2;
+const CUSTOMER_DETAIL_DEFAULT_TITLE = 'Detalle del cliente';
+const CUSTOMER_DETAIL_DEFAULT_SUMMARY = 'Selecciona un cliente para ver su información.';
+const CUSTOMER_ORDER_HISTORY_PROMPT = 'Selecciona un cliente para ver sus órdenes anteriores.';
+const CUSTOMER_ORDER_HISTORY_EMPTY_MESSAGE = 'No tiene órdenes registradas.';
 
 let activeDashboardTab = 'orderListPanel';
 const ORDER_TABLE_COLUMN_COUNT = 6;
@@ -232,6 +254,41 @@ function isDeliveryDateClose(deliveryDateString, status) {
   deliveryDate.setHours(0, 0, 0, 0);
   const diffInDays = (deliveryDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24);
   return diffInDays >= 0 && diffInDays <= DELIVERY_WARNING_DAYS;
+}
+
+function hasExplicitTimeComponent(value) {
+  if (!value) {
+    return false;
+  }
+  if (value instanceof Date) {
+    return true;
+  }
+  if (typeof value === 'string') {
+    return /T\d{2}:\d{2}| \d{2}:\d{2}/.test(value);
+  }
+  return false;
+}
+
+function formatDeliveryDateDisplay(order) {
+  if (!order?.delivery_date) {
+    return '';
+  }
+  const deliveryValue = order.delivery_date;
+  if (hasExplicitTimeComponent(deliveryValue)) {
+    return formatDate(deliveryValue);
+  }
+  const dateLabel = formatDateOnly(deliveryValue);
+  if (isOrderDelivered(order.status) && order.updated_at) {
+    const updated = new Date(order.updated_at);
+    if (!Number.isNaN(updated.getTime())) {
+      const timeLabel = updated.toLocaleTimeString('es-EC', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return `${dateLabel} · ${timeLabel}`;
+    }
+  }
+  return dateLabel;
 }
 
 async function apiFetch(path, { method = 'GET', body, headers = {}, auth = true } = {}) {
@@ -783,6 +840,15 @@ async function loadOrders() {
       }
     }
     renderOrders();
+    renderCustomers();
+    if (state.selectedCustomerId) {
+      const activeCustomer = state.customers.find(
+        (customer) => customer.id === state.selectedCustomerId,
+      );
+      if (activeCustomer) {
+        renderCustomerOrderHistory(activeCustomer);
+      }
+    }
   } catch (error) {
     showToast(error.message, 'error');
   }
@@ -831,6 +897,10 @@ function handleLogout(auto = false) {
   state.customers = [];
   state.customerSearchTerm = '';
   state.orderSearchTerm = '';
+  state.customerPage = 1;
+  state.customerPageSize = DEFAULT_PAGE_SIZE;
+  state.orderPage = 1;
+  state.orderPageSize = DEFAULT_PAGE_SIZE;
   state.isCreateCustomerVisible = false;
   state.auditLogs = [];
   state.selectedCustomerId = null;
@@ -852,6 +922,12 @@ function handleLogout(auto = false) {
   if (orderSearchInput) {
     orderSearchInput.value = '';
   }
+  if (customerPageSizeSelect) {
+    customerPageSizeSelect.value = String(DEFAULT_PAGE_SIZE);
+  }
+  if (orderPageSizeSelect) {
+    orderPageSizeSelect.value = String(DEFAULT_PAGE_SIZE);
+  }
   setCreateCustomerVisible(false);
   if (ordersTableBody) {
     ordersTableBody.innerHTML = '';
@@ -870,6 +946,26 @@ function handleLogout(auto = false) {
   ensureMeasurementRow();
   renderCustomerMeasurementOptions(null);
   clearOrderResult();
+  updatePaginationControls({
+    infoElement: customerPaginationInfo,
+    prevButton: customerPrevPageButton,
+    nextButton: customerNextPageButton,
+    pageSizeSelect: customerPageSizeSelect,
+    currentPage: 1,
+    totalItems: 0,
+    pageSize: state.customerPageSize,
+    emptyLabel: 'clientes',
+  });
+  updatePaginationControls({
+    infoElement: orderPaginationInfo,
+    prevButton: orderPrevPageButton,
+    nextButton: orderNextPageButton,
+    pageSizeSelect: orderPageSizeSelect,
+    currentPage: 1,
+    totalItems: 0,
+    pageSize: state.orderPageSize,
+    emptyLabel: 'órdenes',
+  });
   updateNavigationForAuth();
   setActiveView('staff-view');
   if (auto) {
@@ -887,13 +983,109 @@ if (logoutButton) {
     showToast('Sesión cerrada correctamente.', 'success');
   });
 }
+
+function getOrdersForCustomer(customerId) {
+  if (customerId === null || customerId === undefined) {
+    return [];
+  }
+  const numericId = Number(customerId);
+  if (!Number.isFinite(numericId)) {
+    return [];
+  }
+  return state.orders.filter((order) => Number(order.customer_id) === numericId);
+}
+
+function sortOrdersByRecency(orders) {
+  return [...orders].sort((a, b) => {
+    const aTimestamp = toTimestamp(a?.updated_at) ?? toTimestamp(a?.created_at) ?? 0;
+    const bTimestamp = toTimestamp(b?.updated_at) ?? toTimestamp(b?.created_at) ?? 0;
+    if (aTimestamp !== bTimestamp) {
+      return bTimestamp - aTimestamp;
+    }
+    const aId = typeof a?.id === 'number' ? a.id : Number(a?.id) || 0;
+    const bId = typeof b?.id === 'number' ? b.id : Number(b?.id) || 0;
+    return bId - aId;
+  });
+}
+
+function renderCustomerOrderHistory(customer) {
+  if (!customerOrderHistoryContainer) return;
+  if (!customer) {
+    customerOrderHistoryContainer.classList.add('muted');
+    customerOrderHistoryContainer.textContent = CUSTOMER_ORDER_HISTORY_PROMPT;
+    return;
+  }
+
+  const ordersForCustomer = sortOrdersByRecency(getOrdersForCustomer(customer.id));
+  if (!ordersForCustomer.length) {
+    customerOrderHistoryContainer.classList.add('muted');
+    customerOrderHistoryContainer.textContent = CUSTOMER_ORDER_HISTORY_EMPTY_MESSAGE;
+    return;
+  }
+
+  customerOrderHistoryContainer.classList.remove('muted');
+  customerOrderHistoryContainer.innerHTML = '';
+
+  const list = document.createElement('ul');
+  list.className = 'customer-order-history-items';
+
+  ordersForCustomer.forEach((order) => {
+    const item = document.createElement('li');
+    item.className = 'customer-order-history-item';
+
+    const header = document.createElement('div');
+    header.className = 'customer-order-history-item-header';
+
+    const orderNumber = document.createElement('strong');
+    orderNumber.textContent = order.order_number;
+
+    const statusWrapper = document.createElement('div');
+    statusWrapper.appendChild(createStatusBadge(order.status));
+
+    header.appendChild(orderNumber);
+    header.appendChild(statusWrapper);
+
+    const meta = document.createElement('p');
+    meta.className = 'customer-order-history-item-meta';
+    const parts = [];
+    const deliveryLabel = formatDeliveryDateDisplay(order);
+    if (deliveryLabel) {
+      parts.push(`Entrega: ${deliveryLabel}`);
+    }
+    if (order.updated_at) {
+      parts.push(`Actualizado: ${formatDate(order.updated_at)}`);
+    }
+    meta.textContent = parts.length ? parts.join(' • ') : 'Sin información adicional disponible.';
+
+    item.appendChild(header);
+    item.appendChild(meta);
+    list.appendChild(item);
+  });
+
+  customerOrderHistoryContainer.appendChild(list);
+}
 function renderCustomers() {
   if (!customersTableBody) return;
+  const pageSize = getValidPageSize(state.customerPageSize);
+  if (state.customerPageSize !== pageSize) {
+    state.customerPageSize = pageSize;
+  }
   customersTableBody.innerHTML = '';
   if (customerSearchInput && customerSearchInput.value !== state.customerSearchTerm) {
     customerSearchInput.value = state.customerSearchTerm;
   }
   if (!state.customers.length) {
+    state.customerPage = 1;
+    updatePaginationControls({
+      infoElement: customerPaginationInfo,
+      prevButton: customerPrevPageButton,
+      nextButton: customerNextPageButton,
+      pageSizeSelect: customerPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'clientes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = 5;
@@ -922,6 +1114,17 @@ function renderCustomers() {
   }
 
   if (!filteredCustomers.length) {
+    state.customerPage = 1;
+    updatePaginationControls({
+      infoElement: customerPaginationInfo,
+      prevButton: customerPrevPageButton,
+      nextButton: customerNextPageButton,
+      pageSizeSelect: customerPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'clientes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = 5;
@@ -932,8 +1135,42 @@ function renderCustomers() {
     return;
   }
 
-  filteredCustomers.forEach((customer) => {
+  const totalItems = filteredCustomers.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  let currentPage = Number(state.customerPage) || 1;
+  currentPage = Math.min(Math.max(currentPage, 1), totalPages);
+  currentPage =
+    updatePaginationControls({
+      infoElement: customerPaginationInfo,
+      prevButton: customerPrevPageButton,
+      nextButton: customerNextPageButton,
+      pageSizeSelect: customerPageSizeSelect,
+      currentPage,
+      totalItems,
+      pageSize,
+      emptyLabel: 'clientes',
+    }) || currentPage;
+
+  if (!Number.isFinite(currentPage) || currentPage < 1) {
+    currentPage = 1;
+  }
+
+  if (state.customerPage !== currentPage) {
+    state.customerPage = currentPage;
+  }
+
+  const startIndex = (currentPage - 1) * pageSize;
+  const paginatedCustomers = filteredCustomers.slice(startIndex, startIndex + pageSize);
+
+  paginatedCustomers.forEach((customer) => {
     const row = document.createElement('tr');
+    row.classList.add('customer-row');
+    row.dataset.customerId = String(customer.id);
+
+    const isSelected = state.selectedCustomerId === customer.id;
+    if (isSelected) {
+      row.classList.add('is-selected');
+    }
 
     const nameCell = document.createElement('td');
     nameCell.textContent = customer.full_name;
@@ -944,23 +1181,51 @@ function renderCustomers() {
     const phoneCell = document.createElement('td');
     phoneCell.textContent = customer.phone || '—';
 
-    const measurementsCell = document.createElement('td');
-    measurementsCell.textContent = `${customer.measurements?.length || 0}`;
+    const ordersCell = document.createElement('td');
+    const customerOrders = sortOrdersByRecency(getOrdersForCustomer(customer.id));
+    if (customerOrders.length) {
+      const tags = document.createElement('div');
+      tags.className = 'customer-order-tags';
+      const maxTags = 3;
+      customerOrders.slice(0, maxTags).forEach((orderItem) => {
+        const tag = document.createElement('span');
+        tag.className = 'tag';
+        tag.textContent = orderItem.order_number;
+        tags.appendChild(tag);
+      });
+      if (customerOrders.length > maxTags) {
+        const remaining = document.createElement('span');
+        remaining.className = 'tag muted-tag';
+        remaining.textContent = `+${customerOrders.length - maxTags}`;
+        tags.appendChild(remaining);
+      }
+      ordersCell.appendChild(tags);
+    } else {
+      ordersCell.innerHTML = '<span class="muted">Sin órdenes</span>';
+    }
 
     const actionsCell = document.createElement('td');
     const viewButton = document.createElement('button');
     viewButton.type = 'button';
     viewButton.className = 'secondary';
-    viewButton.textContent = 'Ver detalle';
+    viewButton.dataset.action = 'toggle-customer-detail';
+    viewButton.dataset.customerId = String(customer.id);
+    viewButton.setAttribute('aria-controls', 'customerDetail');
+    viewButton.textContent = isSelected ? 'Ocultar detalle' : 'Ver detalle';
+    viewButton.setAttribute('aria-expanded', isSelected ? 'true' : 'false');
     viewButton.addEventListener('click', () => {
-      populateCustomerDetail(customer);
+      if (state.selectedCustomerId === customer.id) {
+        clearCustomerDetail({ reRender: true });
+      } else {
+        populateCustomerDetail(customer);
+      }
     });
     actionsCell.appendChild(viewButton);
 
     row.appendChild(nameCell);
     row.appendChild(documentCell);
     row.appendChild(phoneCell);
-    row.appendChild(measurementsCell);
+    row.appendChild(ordersCell);
     row.appendChild(actionsCell);
 
     customersTableBody.appendChild(row);
@@ -971,9 +1236,30 @@ function populateCustomerDetail(customer) {
   if (!customerDetail) return;
   state.selectedCustomerId = customer.id;
   customerDetail.classList.remove('hidden');
-  document.getElementById('updateCustomerName').value = customer.full_name;
-  document.getElementById('updateCustomerDocument').value = customer.document_id;
-  document.getElementById('updateCustomerPhone').value = customer.phone || '';
+
+  if (customerDetailTitle) {
+    customerDetailTitle.textContent = customer.full_name || CUSTOMER_DETAIL_DEFAULT_TITLE;
+  }
+
+  if (customerDetailSummaryElement) {
+    const summaryParts = [];
+    if (customer.document_id) {
+      summaryParts.push(`Documento: ${customer.document_id}`);
+    }
+    if (customer.phone) {
+      summaryParts.push(`Teléfono: ${customer.phone}`);
+    }
+    customerDetailSummaryElement.textContent =
+      summaryParts.length ? summaryParts.join(' • ') : 'Sin datos de contacto registrados.';
+  }
+
+  const nameInput = document.getElementById('updateCustomerName');
+  const documentInput = document.getElementById('updateCustomerDocument');
+  const phoneInput = document.getElementById('updateCustomerPhone');
+  if (nameInput) nameInput.value = customer.full_name;
+  if (documentInput) documentInput.value = customer.document_id;
+  if (phoneInput) phoneInput.value = customer.phone || '';
+
   if (updateCustomerMeasurementsContainer) {
     updateCustomerMeasurementsContainer.innerHTML = '';
     if (customer.measurements?.length) {
@@ -984,16 +1270,61 @@ function populateCustomerDetail(customer) {
       createMeasurementSetBlock(updateCustomerMeasurementsContainer);
     }
   }
+
+  renderCustomerOrderHistory(customer);
+
+  if (customersTableBody) {
+    customersTableBody.querySelectorAll('.customer-row').forEach((row) => {
+      const matches = Number(row.dataset.customerId) === Number(customer.id);
+      row.classList.toggle('is-selected', matches);
+      const toggleButton = row.querySelector('button[data-action="toggle-customer-detail"]');
+      if (toggleButton) {
+        toggleButton.textContent = matches ? 'Ocultar detalle' : 'Ver detalle';
+        toggleButton.setAttribute('aria-expanded', matches ? 'true' : 'false');
+      }
+    });
+  }
 }
 
-function clearCustomerDetail() {
+function clearCustomerDetail(options = {}) {
   if (!customerDetail) return;
+  const { reRender = false } = options;
   customerDetail.classList.add('hidden');
   state.selectedCustomerId = null;
+
+  if (customerDetailTitle) {
+    customerDetailTitle.textContent = CUSTOMER_DETAIL_DEFAULT_TITLE;
+  }
+  if (customerDetailSummaryElement) {
+    customerDetailSummaryElement.textContent = CUSTOMER_DETAIL_DEFAULT_SUMMARY;
+  }
+  renderCustomerOrderHistory(null);
+
   updateCustomerForm?.reset();
   if (updateCustomerMeasurementsContainer) {
     updateCustomerMeasurementsContainer.innerHTML = '';
   }
+
+  if (!reRender && customersTableBody) {
+    customersTableBody.querySelectorAll('.customer-row').forEach((row) => {
+      row.classList.remove('is-selected');
+      const toggleButton = row.querySelector('button[data-action="toggle-customer-detail"]');
+      if (toggleButton) {
+        toggleButton.textContent = 'Ver detalle';
+        toggleButton.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  if (reRender) {
+    renderCustomers();
+  }
+}
+
+if (closeCustomerDetailButton) {
+  closeCustomerDetailButton.addEventListener('click', () => {
+    clearCustomerDetail({ reRender: true });
+  });
 }
 
 function populateOrderDetail(order, options = {}) {
@@ -1138,6 +1469,7 @@ if (addUpdateCustomerMeasurementSetButton) {
 if (customerSearchInput) {
   customerSearchInput.addEventListener('input', (event) => {
     state.customerSearchTerm = event.target.value;
+    state.customerPage = 1;
     renderCustomers();
   });
 }
@@ -1145,6 +1477,57 @@ if (customerSearchInput) {
 if (orderSearchInput) {
   orderSearchInput.addEventListener('input', (event) => {
     state.orderSearchTerm = event.target.value;
+    state.orderPage = 1;
+    renderOrders();
+  });
+}
+
+if (customerPageSizeSelect) {
+  customerPageSizeSelect.addEventListener('change', (event) => {
+    const newSize = getValidPageSize(event.target.value);
+    state.customerPageSize = newSize;
+    state.customerPage = 1;
+    renderCustomers();
+  });
+}
+
+if (customerPrevPageButton) {
+  customerPrevPageButton.addEventListener('click', () => {
+    if (state.customerPage > 1) {
+      state.customerPage -= 1;
+      renderCustomers();
+    }
+  });
+}
+
+if (customerNextPageButton) {
+  customerNextPageButton.addEventListener('click', () => {
+    state.customerPage += 1;
+    renderCustomers();
+  });
+}
+
+if (orderPageSizeSelect) {
+  orderPageSizeSelect.addEventListener('change', (event) => {
+    const newSize = getValidPageSize(event.target.value);
+    state.orderPageSize = newSize;
+    state.orderPage = 1;
+    renderOrders();
+  });
+}
+
+if (orderPrevPageButton) {
+  orderPrevPageButton.addEventListener('click', () => {
+    if (state.orderPage > 1) {
+      state.orderPage -= 1;
+      renderOrders();
+    }
+  });
+}
+
+if (orderNextPageButton) {
+  orderNextPageButton.addEventListener('click', () => {
+    state.orderPage += 1;
     renderOrders();
   });
 }
@@ -1348,19 +1731,6 @@ function toTimestamp(value) {
   return parsed ? parsed.getTime() : null;
 }
 
-function compareNullableNumbers(a, b) {
-  if (a !== null && b !== null && a !== b) {
-    return a - b;
-  }
-  if (a !== null && b === null) {
-    return -1;
-  }
-  if (a === null && b !== null) {
-    return 1;
-  }
-  return 0;
-}
-
 function compareOrdersForDisplay(a, b) {
   const aDelivered = isOrderDelivered(a.status);
   const bDelivered = isOrderDelivered(b.status);
@@ -1368,29 +1738,36 @@ function compareOrdersForDisplay(a, b) {
     return aDelivered ? 1 : -1;
   }
 
-  const deliveryComparison = compareNullableNumbers(
-    toTimestamp(a.delivery_date),
-    toTimestamp(b.delivery_date),
-  );
-  if (deliveryComparison !== 0) {
-    return deliveryComparison;
+  const aDelivery = toTimestamp(a.delivery_date);
+  const bDelivery = toTimestamp(b.delivery_date);
+
+  if (aDelivered && bDelivered) {
+    if (aDelivery !== bDelivery) {
+      if (aDelivery === null) return 1;
+      if (bDelivery === null) return -1;
+      return bDelivery - aDelivery;
+    }
+  } else if (aDelivery !== bDelivery) {
+    if (aDelivery === null) return 1;
+    if (bDelivery === null) return -1;
+    return aDelivery - bDelivery;
   }
 
   if (!aDelivered) {
-    const createdComparison = compareNullableNumbers(
-      toTimestamp(a.created_at),
-      toTimestamp(b.created_at),
-    );
-    if (createdComparison !== 0) {
-      return createdComparison;
+    const aCreated = toTimestamp(a.created_at);
+    const bCreated = toTimestamp(b.created_at);
+    if (aCreated !== bCreated) {
+      if (aCreated === null) return 1;
+      if (bCreated === null) return -1;
+      return aCreated - bCreated;
     }
   } else {
-    const updatedComparison = compareNullableNumbers(
-      toTimestamp(a.updated_at),
-      toTimestamp(b.updated_at),
-    );
-    if (updatedComparison !== 0) {
-      return updatedComparison;
+    const aUpdated = toTimestamp(a.updated_at);
+    const bUpdated = toTimestamp(b.updated_at);
+    if (aUpdated !== bUpdated) {
+      if (aUpdated === null) return 1;
+      if (bUpdated === null) return -1;
+      return bUpdated - aUpdated;
     }
   }
 
@@ -1454,8 +1831,63 @@ function createStatusBadge(status) {
 }
 
 
+function getValidPageSize(value) {
+  const numericValue = Number(value);
+  if (PAGE_SIZE_OPTIONS.includes(numericValue)) {
+    return numericValue;
+  }
+  return DEFAULT_PAGE_SIZE;
+}
+
+function updatePaginationControls({
+  infoElement,
+  prevButton,
+  nextButton,
+  pageSizeSelect,
+  currentPage,
+  totalItems,
+  pageSize,
+  emptyLabel,
+}) {
+  const totalPages = totalItems > 0 ? Math.ceil(totalItems / pageSize) : 1;
+  const normalizedPage = totalItems > 0 ? Math.min(Math.max(currentPage, 1), totalPages) : 1;
+  const startItem = totalItems === 0 ? 0 : (normalizedPage - 1) * pageSize + 1;
+  const endItem = totalItems === 0 ? 0 : Math.min(normalizedPage * pageSize, totalItems);
+
+  if (infoElement) {
+    infoElement.textContent =
+      totalItems === 0
+        ? `Sin ${emptyLabel}`
+        : `Mostrando ${startItem}-${endItem} de ${totalItems}`;
+  }
+
+  if (prevButton) {
+    const isDisabled = totalItems === 0 || normalizedPage <= 1;
+    prevButton.disabled = isDisabled;
+    prevButton.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+  }
+
+  if (nextButton) {
+    const isDisabled = totalItems === 0 || normalizedPage >= totalPages;
+    nextButton.disabled = isDisabled;
+    nextButton.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+  }
+
+  if (pageSizeSelect && pageSizeSelect.value !== String(pageSize)) {
+    pageSizeSelect.value = String(pageSize);
+  }
+
+  return normalizedPage;
+}
+
+
 function renderOrders() {
   if (!ordersTableBody) return;
+
+  const pageSize = getValidPageSize(state.orderPageSize);
+  if (state.orderPageSize !== pageSize) {
+    state.orderPageSize = pageSize;
+  }
 
   removeOrderDetailRow();
   if (orderDetail) {
@@ -1468,6 +1900,17 @@ function renderOrders() {
   }
 
   if (!state.orders.length) {
+    state.orderPage = 1;
+    updatePaginationControls({
+      infoElement: orderPaginationInfo,
+      prevButton: orderPrevPageButton,
+      nextButton: orderNextPageButton,
+      pageSizeSelect: orderPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'órdenes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = ORDER_TABLE_COLUMN_COUNT;
@@ -1489,27 +1932,17 @@ function renderOrders() {
     : [...state.orders];
 
   if (!filteredOrders.length) {
-    const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 5;
-    cell.textContent = 'No se encontraron órdenes que coincidan con la búsqueda.';
-    cell.className = 'muted';
-    row.appendChild(cell);
-    ordersTableBody.appendChild(row);
-    clearOrderDetail();
-    return;
-  }
-
-  const sortedOrders = [...filteredOrders].sort(compareOrdersForDisplay);
-
-  if (
-    state.selectedOrderId !== null &&
-    sortedOrders.every((order) => order.id !== state.selectedOrderId)
-  ) {
-    clearOrderDetail();
-  }
-
-  sortedOrders.forEach((order) => {
+    state.orderPage = 1;
+    updatePaginationControls({
+      infoElement: orderPaginationInfo,
+      prevButton: orderPrevPageButton,
+      nextButton: orderNextPageButton,
+      pageSizeSelect: orderPageSizeSelect,
+      currentPage: 1,
+      totalItems: 0,
+      pageSize,
+      emptyLabel: 'órdenes',
+    });
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = ORDER_TABLE_COLUMN_COUNT;
@@ -1530,9 +1963,47 @@ function renderOrders() {
     clearOrderDetail({ skipRender: true });
   }
 
+  const totalItems = sortedOrders.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  let currentPage = Number(state.orderPage) || 1;
+
+  if (state.selectedOrderId !== null) {
+    const selectedIndex = sortedOrders.findIndex((order) => order.id === state.selectedOrderId);
+    if (selectedIndex >= 0) {
+      const selectedPage = Math.floor(selectedIndex / pageSize) + 1;
+      if (selectedPage !== currentPage) {
+        currentPage = selectedPage;
+      }
+    }
+  }
+
+  currentPage = Math.min(Math.max(currentPage, 1), totalPages);
+  currentPage =
+    updatePaginationControls({
+      infoElement: orderPaginationInfo,
+      prevButton: orderPrevPageButton,
+      nextButton: orderNextPageButton,
+      pageSizeSelect: orderPageSizeSelect,
+      currentPage,
+      totalItems,
+      pageSize,
+      emptyLabel: 'órdenes',
+    }) || currentPage;
+
+  if (!Number.isFinite(currentPage) || currentPage < 1) {
+    currentPage = 1;
+  }
+
+  if (state.orderPage !== currentPage) {
+    state.orderPage = currentPage;
+  }
+
+  const startIndex = (currentPage - 1) * pageSize;
+  const paginatedOrders = sortedOrders.slice(startIndex, startIndex + pageSize);
+
   let hasActiveDetail = false;
 
-  sortedOrders.forEach((order) => {
+  paginatedOrders.forEach((order) => {
     const row = document.createElement('tr');
     row.classList.add('order-row');
     const isSelected = state.selectedOrderId === order.id;
@@ -1554,7 +2025,8 @@ function renderOrders() {
 
     const deliveryCell = document.createElement('td');
     if (order.delivery_date) {
-      deliveryCell.textContent = formatDateOnly(order.delivery_date);
+      const deliveryLabel = formatDeliveryDateDisplay(order) || formatDateOnly(order.delivery_date);
+      deliveryCell.textContent = deliveryLabel;
       if (isDeliveryDateOverdue(order.delivery_date, order.status)) {
         deliveryCell.classList.add('overdue');
       } else if (isDeliveryDateClose(order.delivery_date, order.status)) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,13 +92,54 @@
                 <h3>Gestión de clientes</h3>
                 <p class="muted">Consulta, busca y administra la información de tus clientes.</p>
               </div>
-              <div class="customer-panel-actions">
-                <div class="customer-search">
-                  <label for="customerSearchInput">Buscar</label>
-                  <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
-                </div>
-                <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
+            <div class="customer-panel-actions">
+              <div class="customer-search">
+                <label for="customerSearchInput">Buscar</label>
+                <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
               </div>
+              <div class="table-pagination">
+                <label for="customerPageSize">Filas por página</label>
+                <div class="pagination-controls">
+                  <select id="customerPageSize">
+                    <option value="10" selected>10</option>
+                    <option value="15">15</option>
+                    <option value="20">20</option>
+                    <option value="25">25</option>
+                    <option value="30">30</option>
+                    <option value="35">35</option>
+                    <option value="40">40</option>
+                    <option value="45">45</option>
+                    <option value="50">50</option>
+                  </select>
+                  <div class="pagination-buttons">
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="customerPrevPage"
+                      aria-label="Página anterior de clientes"
+                    >
+                      Anterior
+                    </button>
+                    <span
+                      id="customerPaginationInfo"
+                      class="pagination-info"
+                      aria-live="polite"
+                    >
+                      Mostrando 0-0 de 0
+                    </span>
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="customerNextPage"
+                      aria-label="Página siguiente de clientes"
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
+            </div>
             </div>
             <div id="createCustomerSection" class="customer-create hidden">
               <div class="customer-create-header">
@@ -128,54 +169,66 @@
                 </div>
               </form>
             </div>
-            <div class="customer-layout">
-              <div class="customer-column">
-                <h4>Clientes registrados</h4>
-                <div class="table-wrapper">
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Nombre</th>
-                        <th>Documento</th>
-                        <th>Teléfono</th>
-                        <th>Medidas</th>
-                        <th>Acciones</th>
-                      </tr>
-                    </thead>
-                    <tbody id="customersTableBody"></tbody>
-                  </table>
+            <div class="customer-list">
+              <h4>Clientes registrados</h4>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Nombre</th>
+                      <th>Documento</th>
+                      <th>Teléfono</th>
+                      <th>Órdenes previas</th>
+                      <th>Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody id="customersTableBody"></tbody>
+                </table>
+              </div>
+            </div>
+            <div id="customerDetail" class="customer-detail hidden" aria-live="polite">
+              <div class="customer-detail-header">
+                <div>
+                  <h4 id="customerDetailTitle">Detalle del cliente</h4>
+                  <p id="customerDetailSummary" class="muted small">
+                    Selecciona un cliente para ver su información.
+                  </p>
+                </div>
+                <button type="button" class="link-button" id="closeCustomerDetailButton">
+                  Cerrar
+                </button>
+              </div>
+              <div class="customer-order-history">
+                <h5>Órdenes registradas</h5>
+                <div id="customerOrderHistory" class="customer-order-history-list muted">
+                  Selecciona un cliente para ver sus órdenes anteriores.
                 </div>
               </div>
-              <div class="customer-column">
-                <div id="customerDetail" class="customer-detail hidden">
-                  <h4>Detalle del cliente</h4>
-                  <form id="updateCustomerForm" class="form-grid">
-                    <div class="form-row">
-                      <label for="updateCustomerName">Nombre completo</label>
-                      <input type="text" id="updateCustomerName" required />
-                    </div>
-                    <div class="form-row">
-                      <label for="updateCustomerDocument">Cédula o identificación</label>
-                      <input type="text" id="updateCustomerDocument" required />
-                    </div>
-                    <div class="form-row">
-                      <label for="updateCustomerPhone">Teléfono</label>
-                      <input type="text" id="updateCustomerPhone" />
-                    </div>
-                    <div class="form-row">
-                      <label>Conjuntos de medidas</label>
-                      <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
-                      <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">
-                        Agregar conjunto
-                      </button>
-                    </div>
-                    <div class="button-row">
-                      <button type="submit" class="primary">Guardar cambios</button>
-                      <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
-                    </div>
-                  </form>
+              <form id="updateCustomerForm" class="form-grid">
+                <div class="form-row">
+                  <label for="updateCustomerName">Nombre completo</label>
+                  <input type="text" id="updateCustomerName" required />
                 </div>
-              </div>
+                <div class="form-row">
+                  <label for="updateCustomerDocument">Cédula o identificación</label>
+                  <input type="text" id="updateCustomerDocument" required />
+                </div>
+                <div class="form-row">
+                  <label for="updateCustomerPhone">Teléfono</label>
+                  <input type="text" id="updateCustomerPhone" />
+                </div>
+                <div class="form-row">
+                  <label>Conjuntos de medidas</label>
+                  <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
+                  <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">
+                    Agregar conjunto
+                  </button>
+                </div>
+                <div class="button-row">
+                  <button type="submit" class="primary">Guardar cambios</button>
+                  <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
+                </div>
+              </form>
             </div>
           </section>
 
@@ -253,6 +306,47 @@
                   placeholder="Número de orden o cédula"
                   autocomplete="off"
                 />
+              </div>
+              <div class="table-pagination">
+                <label for="orderPageSize">Filas por página</label>
+                <div class="pagination-controls">
+                  <select id="orderPageSize">
+                    <option value="10" selected>10</option>
+                    <option value="15">15</option>
+                    <option value="20">20</option>
+                    <option value="25">25</option>
+                    <option value="30">30</option>
+                    <option value="35">35</option>
+                    <option value="40">40</option>
+                    <option value="45">45</option>
+                    <option value="50">50</option>
+                  </select>
+                  <div class="pagination-buttons">
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="orderPrevPage"
+                      aria-label="Página anterior de órdenes"
+                    >
+                      Anterior
+                    </button>
+                    <span
+                      id="orderPaginationInfo"
+                      class="pagination-info"
+                      aria-live="polite"
+                    >
+                      Mostrando 0-0 de 0
+                    </span>
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="orderNextPage"
+                      aria-label="Página siguiente de órdenes"
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
             <div class="table-wrapper">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -374,22 +374,97 @@ button[disabled] {
   color: var(--muted);
 }
 
-.customer-layout {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(0, 1fr);
+.customer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.customer-column {
+.customer-detail {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #f9fbfc;
+  margin-top: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
 
-@media (min-width: 960px) {
-  .customer-layout {
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1.25fr);
-  }
+.customer-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.customer-detail-header h4 {
+  margin: 0;
+}
+
+.customer-detail-header p {
+  margin: 0.4rem 0 0;
+}
+
+.customer-order-history h5 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.customer-order-history-list {
+  margin-top: 0.75rem;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: white;
+}
+
+.customer-order-history-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.customer-order-history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.customer-order-history-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.customer-order-history-item-header strong {
+  font-size: 1rem;
+}
+
+.customer-order-history-item-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.customer-order-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.customer-order-tags .tag {
+  margin: 0;
+}
+
+.tag.muted-tag {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
 }
 
 @media (max-width: 600px) {
@@ -398,7 +473,7 @@ button[disabled] {
     align-items: stretch;
   }
 
-  .customer-panel-actions button {
+  .customer-panel-actions > button {
     width: 100%;
   }
 
@@ -414,13 +489,33 @@ button[disabled] {
   .order-search input {
     width: 100%;
   }
-}
 
-.customer-detail {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.25rem;
-  background: #f9fbfc;
+  .table-pagination {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .pagination-controls {
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .pagination-buttons {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .pagination-button {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+
+  .pagination-info {
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .order-detail {
@@ -499,6 +594,64 @@ button[disabled] {
 
 .order-search input {
   width: min(260px, 100%);
+}
+
+.table-pagination {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-end;
+  min-width: 200px;
+}
+
+.table-pagination label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.pagination-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.pagination-controls select {
+  min-width: 90px;
+}
+
+.pagination-buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pagination-button {
+  border: 1px solid var(--border);
+  background: white;
+  color: var(--primary-dark);
+  padding: 0.35rem 0.85rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.pagination-button:hover:not(:disabled) {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+}
+
+.pagination-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .user-info {
@@ -588,6 +741,18 @@ th {
 }
 
 .order-row.is-selected td {
+  border-bottom-color: transparent;
+}
+
+.customer-row {
+  transition: background 0.2s ease;
+}
+
+.customer-row.is-selected {
+  background: rgba(31, 122, 140, 0.08);
+}
+
+.customer-row.is-selected td {
   border-bottom-color: transparent;
 }
 


### PR DESCRIPTION
## Summary
- relocate the customer detail panel below the list, remove the measurement count column, and surface past orders with chips and history entries
- add helpers that compute per-customer order history, update selection toggles, and keep the detail summary/reset states consistent
- display delivery dates with hour and minute information when available so recent deliveries surface precise timing

## Testing
- `cd frontend && node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68cde10b55a08332b48f16f709a69d85