### PR TITLE
Add branch tracking and inline customer details

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -54,6 +54,8 @@ def serialize_order(order: Optional[models.Order]) -> Optional[Dict[str, Any]]:
         "notes": order.notes,
         "assigned_tailor_id": order.assigned_tailor_id,
         "delivery_date": order.delivery_date.isoformat() if order.delivery_date else None,
+        "invoice_number": order.invoice_number,
+        "origin_branch": order.origin_branch.value if order.origin_branch else None,
         "created_at": order.created_at.isoformat() if order.created_at else None,
         "updated_at": order.updated_at.isoformat() if order.updated_at else None,
     }
@@ -243,6 +245,8 @@ def create_order(db: Session, order_in: schemas.OrderCreate) -> models.Order:
         notes=order_in.notes,
         assigned_tailor_id=order_in.assigned_tailor_id,
         delivery_date=order_in.delivery_date,
+        invoice_number=order_in.invoice_number,
+        origin_branch=order_in.origin_branch,
     )
     db.add(db_order)
     db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -27,6 +27,14 @@ class OrderStatus(str, enum.Enum):
     ENTREGADO = "Entregado"
 
 
+class Establishment(str, enum.Enum):
+    """Physical branches that can originate an order."""
+
+    URDESA = "Urdesa"
+    BATAN = "Batan"
+    INDIE = "Indie"
+
+
 class User(Base):
     """Registered system user."""
 
@@ -61,6 +69,8 @@ class Order(Base):
     notes = Column(Text, nullable=True)
     assigned_tailor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     delivery_date = Column(Date, nullable=True)
+    origin_branch = Column(Enum(Establishment), nullable=True)
+    invoice_number = Column(String(50), nullable=True)
     created_at = Column(DateTime(timezone=True), default=now, nullable=False)
     updated_at = Column(
         DateTime(timezone=True),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
-from .models import OrderStatus, UserRole
+from .models import Establishment, OrderStatus, UserRole
 
 
 class Token(BaseModel):
@@ -103,10 +103,12 @@ class OrderBase(BaseModel):
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
     delivery_date: Optional[date] = None
+    invoice_number: Optional[str] = None
+    origin_branch: Optional[Establishment] = None
 
 
 class OrderCreate(OrderBase):
-    pass
+    origin_branch: Establishment
 
 
 class OrderUpdate(BaseModel):
@@ -119,6 +121,8 @@ class OrderUpdate(BaseModel):
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
     delivery_date: Optional[date] = None
+    invoice_number: Optional[str] = None
+    origin_branch: Optional[Establishment] = None
 
 
 class OrderPublic(BaseModel):
@@ -130,6 +134,8 @@ class OrderPublic(BaseModel):
     updated_at: datetime
     delivery_date: Optional[date] = None
     measurements: List[MeasurementItem] = Field(default_factory=list)
+    invoice_number: Optional[str] = None
+    origin_branch: Optional[Establishment] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,13 +92,54 @@
                 <h3>Gestión de clientes</h3>
                 <p class="muted">Consulta, busca y administra la información de tus clientes.</p>
               </div>
-              <div class="customer-panel-actions">
-                <div class="customer-search">
-                  <label for="customerSearchInput">Buscar</label>
-                  <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
-                </div>
-                <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
+            <div class="customer-panel-actions">
+              <div class="customer-search">
+                <label for="customerSearchInput">Buscar</label>
+                <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
               </div>
+              <div class="table-pagination">
+                <label for="customerPageSize">Filas por página</label>
+                <div class="pagination-controls">
+                  <select id="customerPageSize">
+                    <option value="10" selected>10</option>
+                    <option value="15">15</option>
+                    <option value="20">20</option>
+                    <option value="25">25</option>
+                    <option value="30">30</option>
+                    <option value="35">35</option>
+                    <option value="40">40</option>
+                    <option value="45">45</option>
+                    <option value="50">50</option>
+                  </select>
+                  <div class="pagination-buttons">
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="customerPrevPage"
+                      aria-label="Página anterior de clientes"
+                    >
+                      Anterior
+                    </button>
+                    <span
+                      id="customerPaginationInfo"
+                      class="pagination-info"
+                      aria-live="polite"
+                    >
+                      Mostrando 0-0 de 0
+                    </span>
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="customerNextPage"
+                      aria-label="Página siguiente de clientes"
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
+            </div>
             </div>
             <div id="createCustomerSection" class="customer-create hidden">
               <div class="customer-create-header">
@@ -128,54 +169,66 @@
                 </div>
               </form>
             </div>
-            <div class="customer-layout">
-              <div class="customer-column">
-                <h4>Clientes registrados</h4>
-                <div class="table-wrapper">
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Nombre</th>
-                        <th>Documento</th>
-                        <th>Teléfono</th>
-                        <th>Medidas</th>
-                        <th>Acciones</th>
-                      </tr>
-                    </thead>
-                    <tbody id="customersTableBody"></tbody>
-                  </table>
+            <div class="customer-list">
+              <h4>Clientes registrados</h4>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Nombre</th>
+                      <th>Documento</th>
+                      <th>Teléfono</th>
+                      <th>Órdenes</th>
+                      <th>Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody id="customersTableBody"></tbody>
+                </table>
+              </div>
+            </div>
+            <div id="customerDetail" class="customer-detail hidden" aria-live="polite">
+              <div class="customer-detail-header">
+                <div>
+                  <h4 id="customerDetailTitle">Detalle del cliente</h4>
+                  <p id="customerDetailSummary" class="muted small">
+                    Selecciona un cliente para ver su información.
+                  </p>
+                </div>
+                <button type="button" class="link-button" id="closeCustomerDetailButton">
+                  Cerrar
+                </button>
+              </div>
+              <div class="customer-order-history">
+                <h5>Órdenes registradas</h5>
+                <div id="customerOrderHistory" class="customer-order-history-list muted">
+                  Selecciona un cliente para ver sus órdenes anteriores.
                 </div>
               </div>
-              <div class="customer-column">
-                <div id="customerDetail" class="customer-detail hidden">
-                  <h4>Detalle del cliente</h4>
-                  <form id="updateCustomerForm" class="form-grid">
-                    <div class="form-row">
-                      <label for="updateCustomerName">Nombre completo</label>
-                      <input type="text" id="updateCustomerName" required />
-                    </div>
-                    <div class="form-row">
-                      <label for="updateCustomerDocument">Cédula o identificación</label>
-                      <input type="text" id="updateCustomerDocument" required />
-                    </div>
-                    <div class="form-row">
-                      <label for="updateCustomerPhone">Teléfono</label>
-                      <input type="text" id="updateCustomerPhone" />
-                    </div>
-                    <div class="form-row">
-                      <label>Conjuntos de medidas</label>
-                      <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
-                      <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">
-                        Agregar conjunto
-                      </button>
-                    </div>
-                    <div class="button-row">
-                      <button type="submit" class="primary">Guardar cambios</button>
-                      <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
-                    </div>
-                  </form>
+              <form id="updateCustomerForm" class="form-grid">
+                <div class="form-row">
+                  <label for="updateCustomerName">Nombre completo</label>
+                  <input type="text" id="updateCustomerName" required />
                 </div>
-              </div>
+                <div class="form-row">
+                  <label for="updateCustomerDocument">Cédula o identificación</label>
+                  <input type="text" id="updateCustomerDocument" required />
+                </div>
+                <div class="form-row">
+                  <label for="updateCustomerPhone">Teléfono</label>
+                  <input type="text" id="updateCustomerPhone" />
+                </div>
+                <div class="form-row">
+                  <label>Conjuntos de medidas</label>
+                  <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
+                  <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">
+                    Agregar conjunto
+                  </button>
+                </div>
+                <div class="button-row">
+                  <button type="submit" class="primary">Guardar cambios</button>
+                  <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
+                </div>
+              </form>
             </div>
           </section>
 
@@ -185,6 +238,10 @@
               <div class="form-row">
                 <label for="newOrderNumber">Número de orden</label>
                 <input type="text" id="newOrderNumber" required />
+              </div>
+              <div class="form-row">
+                <label for="newOrderInvoice">Número de factura</label>
+                <input type="text" id="newOrderInvoice" placeholder="Ej. FAC-2024-00001" />
               </div>
               <div class="form-row">
                 <label for="orderCustomerSelect">Cliente</label>
@@ -209,8 +266,14 @@
                 <select id="newOrderStatus"></select>
               </div>
               <div class="form-row">
-                <label for="newOrderDeliveryDate">Fecha de entrega</label>
-                <input type="date" id="newOrderDeliveryDate" />
+                <label for="newOrderOrigin">Establecimiento remitente</label>
+                <select id="newOrderOrigin" required>
+                  <option value="">Selecciona un establecimiento</option>
+                </select>
+              </div>
+              <div class="form-row">
+                <label for="newOrderDeliveryDate">Fecha y hora de entrega</label>
+                <input type="datetime-local" id="newOrderDeliveryDate" />
               </div>
               <div class="form-row">
                 <label>Medidas guardadas del cliente</label>
@@ -254,6 +317,47 @@
                   autocomplete="off"
                 />
               </div>
+              <div class="table-pagination">
+                <label for="orderPageSize">Filas por página</label>
+                <div class="pagination-controls">
+                  <select id="orderPageSize">
+                    <option value="10" selected>10</option>
+                    <option value="15">15</option>
+                    <option value="20">20</option>
+                    <option value="25">25</option>
+                    <option value="30">30</option>
+                    <option value="35">35</option>
+                    <option value="40">40</option>
+                    <option value="45">45</option>
+                    <option value="50">50</option>
+                  </select>
+                  <div class="pagination-buttons">
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="orderPrevPage"
+                      aria-label="Página anterior de órdenes"
+                    >
+                      Anterior
+                    </button>
+                    <span
+                      id="orderPaginationInfo"
+                      class="pagination-info"
+                      aria-live="polite"
+                    >
+                      Mostrando 0-0 de 0
+                    </span>
+                    <button
+                      type="button"
+                      class="pagination-button"
+                      id="orderNextPage"
+                      aria-label="Página siguiente de órdenes"
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
             <div class="table-wrapper">
               <table>
@@ -296,6 +400,10 @@
                   <input type="text" id="orderDetailContact" />
                 </div>
                 <div class="form-row">
+                  <label for="orderDetailInvoice">Número de factura</label>
+                  <input type="text" id="orderDetailInvoice" />
+                </div>
+                <div class="form-row">
                   <label for="orderDetailStatus">Estado</label>
                   <select id="orderDetailStatus"></select>
                 </div>
@@ -304,8 +412,12 @@
                   <select id="orderDetailTailor"></select>
                 </div>
                 <div class="form-row">
-                  <label for="orderDetailDeliveryDate">Fecha de entrega</label>
-                  <input type="date" id="orderDetailDeliveryDate" />
+                  <label for="orderDetailOrigin">Establecimiento remitente</label>
+                  <select id="orderDetailOrigin"></select>
+                </div>
+                <div class="form-row">
+                  <label for="orderDetailDeliveryDate">Fecha y hora de entrega</label>
+                  <input type="datetime-local" id="orderDetailDeliveryDate" />
                 </div>
                 <div class="form-row">
                   <label for="orderDetailNotes">Notas</label>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -374,22 +374,107 @@ button[disabled] {
   color: var(--muted);
 }
 
-.customer-layout {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(0, 1fr);
+.customer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.customer-column {
+.customer-detail {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #f9fbfc;
+  margin-top: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
 }
 
-@media (min-width: 960px) {
-  .customer-layout {
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1.25fr);
-  }
+.customer-detail-row td {
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.customer-detail-cell {
+  padding: 0;
+}
+
+.customer-detail-cell .customer-detail {
+  margin: 0;
+}
+
+.customer-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.customer-detail-header h4 {
+  margin: 0;
+}
+
+.customer-detail-header p {
+  margin: 0.4rem 0 0;
+}
+
+.customer-order-history h5 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.customer-order-history-list {
+  margin-top: 0.75rem;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: white;
+}
+
+.customer-order-history-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.customer-order-history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.customer-order-history-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.customer-order-history-item-header strong {
+  font-size: 1rem;
+}
+
+.customer-order-history-item-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.customer-order-history-item-invoice {
+  margin: 0;
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+
+.tag.muted-tag {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
 }
 
 @media (max-width: 600px) {
@@ -398,7 +483,7 @@ button[disabled] {
     align-items: stretch;
   }
 
-  .customer-panel-actions button {
+  .customer-panel-actions > button {
     width: 100%;
   }
 
@@ -414,13 +499,33 @@ button[disabled] {
   .order-search input {
     width: 100%;
   }
-}
 
-.customer-detail {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.25rem;
-  background: #f9fbfc;
+  .table-pagination {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .pagination-controls {
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .pagination-buttons {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .pagination-button {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+
+  .pagination-info {
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .order-detail {
@@ -499,6 +604,64 @@ button[disabled] {
 
 .order-search input {
   width: min(260px, 100%);
+}
+
+.table-pagination {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-end;
+  min-width: 200px;
+}
+
+.table-pagination label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.pagination-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.pagination-controls select {
+  min-width: 90px;
+}
+
+.pagination-buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pagination-button {
+  border: 1px solid var(--border);
+  background: white;
+  color: var(--primary-dark);
+  padding: 0.35rem 0.85rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.pagination-button:hover:not(:disabled) {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+}
+
+.pagination-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .user-info {
@@ -589,6 +752,35 @@ th {
 
 .order-row.is-selected td {
   border-bottom-color: transparent;
+}
+
+.customer-row {
+  transition: background 0.2s ease;
+}
+
+.customer-row.is-selected {
+  background: rgba(31, 122, 140, 0.08);
+}
+
+.customer-row.is-selected td {
+  border-bottom-color: transparent;
+}
+
+.customer-order-count-cell {
+  text-align: center;
+}
+
+.customer-order-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(31, 122, 140, 0.18);
+  color: var(--primary-dark);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .order-detail-row td {


### PR DESCRIPTION
## Summary
- extend orders with invoice numbers and origin branches across the backend models, schemas, CRUD helpers, and seeding utilities
- capture the sending establishment and optional invoice number when creating or updating orders while surfacing invoice data in customer order history
- rework the customer table to show order counts and expand rows inline to display client details and previous orders only when selected

## Testing
- `cd frontend && node --check app.js`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cde10b55a08332b48f16f709a69d85