### PR TITLE
Require configuring SECRET_KEY for backend

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -22,6 +22,20 @@ source .venv/bin/activate  # En Windows: .venv\\Scripts\\activate
 pip install -r requirements.txt
 ```
 
+Define la clave secreta JWT en un archivo `.env` dentro de la carpeta `backend` (o como
+variable de entorno) antes de iniciar la API:
+
+```bash
+cat <<'EOF' > .env
+SECRET_KEY="pon-aqui-una-clave-de-al-menos-32-caracteres"
+EOF
+# También puedes exportarla directamente:
+export SECRET_KEY="pon-aqui-una-clave-de-al-menos-32-caracteres"
+```
+
+La aplicación fallará con un mensaje descriptivo si `SECRET_KEY` no está definida o es
+demasiado corta.
+
 Crear el primer usuario administrador:
 
 ```bash


### PR DESCRIPTION
## Summary
- make the backend settings fail fast when SECRET_KEY is missing or shorter than 32 characters
- add README instructions to configure the secret via environment variable or .env file

## Testing
- PYTHONPATH=. python - <<'PY'
from app.config import get_settings
get_settings()
PY
- SECRET_KEY=0123456789abcdef0123456789abcdef PYTHONPATH=. python - <<'PY'
from app.config import get_settings
settings = get_settings()
print(settings.secret_key)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d07e49dc2c83328c95ef48f23c8bb1