### PR TITLE
Validate assigned tailor on order creation and updates

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 pydantic>=2
 pydantic-settings>=2.0.0
+pytest

--- a/backend/tests/test_order_tailor_validation.py
+++ b/backend/tests/test_order_tailor_validation.py
@@ -1,0 +1,106 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import auth, main, models, schemas
+from app.database import Base
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def admin_user(db_session):
+    user = models.User(
+        username="admin",
+        full_name="Admin",
+        role=models.UserRole.ADMIN,
+        password_hash=auth.get_password_hash("secret"),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def customer(db_session):
+    customer = models.Customer(
+        full_name="Cliente Ejemplo",
+        document_id="1234567890",
+        phone="0999999999",
+    )
+    db_session.add(customer)
+    db_session.commit()
+    db_session.refresh(customer)
+    return customer
+
+
+def test_create_order_with_invalid_tailor_id(db_session, admin_user, customer):
+    order_in = schemas.OrderCreate(
+        order_number="ORD-100",
+        customer_id=customer.id,
+        origin_branch=models.Establishment.BATAN,
+        assigned_tailor_id=999,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        main.create_order_endpoint(order_in, db_session, admin_user)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "El sastre asignado no existe"
+
+
+def test_update_order_rejects_non_tailor_assignment(db_session, admin_user, customer):
+    created_order = main.create_order_endpoint(
+        schemas.OrderCreate(
+            order_number="ORD-200",
+            customer_id=customer.id,
+            origin_branch=models.Establishment.URDESA,
+        ),
+        db_session,
+        admin_user,
+    )
+
+    non_tailor = models.User(
+        username="vend",
+        full_name="Vendedor",
+        role=models.UserRole.VENDEDOR,
+        password_hash=auth.get_password_hash("secret"),
+    )
+    db_session.add(non_tailor)
+    db_session.commit()
+    db_session.refresh(non_tailor)
+
+    with pytest.raises(HTTPException) as exc_info:
+        main.update_order_endpoint(
+            created_order.id,
+            schemas.OrderUpdate(assigned_tailor_id=non_tailor.id),
+            db_session,
+            admin_user,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "El usuario asignado no es un sastre"


### PR DESCRIPTION
## Summary
- add a shared validator that checks assigned tailors exist and have the sastre role before persisting an order
- invoke the validator from both the create and update order endpoints, allowing null assignments
- cover invalid tailor id and non-tailor assignment scenarios with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d07e31f938833283fcfdd5aec9577b