### PR TITLE
Improve toast accessibility for assistive tech

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -174,8 +174,12 @@ if (currentYearElement) {
 
 function showToast(message, type = 'info') {
   if (!toastElement) return;
+  const isError = type === 'error';
+  toastElement.setAttribute('role', isError ? 'alert' : 'status');
+  toastElement.setAttribute('aria-live', isError ? 'assertive' : 'polite');
+  toastElement.textContent = '';
   toastElement.textContent = message;
-  toastElement.className = `toast show ${type === 'error' ? 'error' : type === 'success' ? 'success' : ''}`;
+  toastElement.className = `toast show ${isError ? 'error' : type === 'success' ? 'success' : ''}`;
   setTimeout(() => {
     toastElement.classList.remove('show', 'success', 'error');
   }, 3500);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -457,7 +457,13 @@
       </section>
     </main>
 
-    <div id="toast" class="toast hidden"></div>
+    <div
+      id="toast"
+      class="toast hidden"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    ></div>
 
     <footer class="container footer">
       <small>© <span id="currentYear"></span> Portal de Sastrería. Todos los derechos reservados.</small>


### PR DESCRIPTION
## Summary
- add ARIA role, live region, and atomic attributes to the toast container
- update toast announcements to switch role/liveness for errors and reset content before new messages

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0820c1fb88332b056a48b24323b56