### PR TITLE
Improve table accessibility on small screens

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1321,17 +1321,21 @@ function renderCustomers() {
 
 
     const nameCell = document.createElement('td');
+    nameCell.dataset.label = 'Nombre';
     nameCell.textContent = displayData.name || '—';
 
     const documentCell = document.createElement('td');
+    documentCell.dataset.label = 'Documento';
     documentCell.textContent = displayData.document || '—';
 
     const phoneCell = document.createElement('td');
+    phoneCell.dataset.label = 'Teléfono';
     phoneCell.textContent = displayData.contact || '—';
 
 
     const orderCountCell = document.createElement('td');
     orderCountCell.className = 'customer-order-count-cell';
+    orderCountCell.dataset.label = 'Órdenes';
     if (orderCount > 0) {
       const badge = document.createElement('span');
       badge.className = 'customer-order-count-badge';
@@ -1346,6 +1350,7 @@ function renderCustomers() {
     }
 
     const actionsCell = document.createElement('td');
+    actionsCell.dataset.label = 'Acciones';
     const viewButton = document.createElement('button');
     viewButton.type = 'button';
     viewButton.className = 'secondary';
@@ -2210,18 +2215,23 @@ function renderOrders() {
     }
 
     const orderCell = document.createElement('td');
+    orderCell.dataset.label = 'Orden';
     orderCell.innerHTML = `<strong>${order.order_number}</strong>`;
 
     const customerCell = document.createElement('td');
+    customerCell.dataset.label = 'Cliente';
     customerCell.textContent = order.customer_name || '—';
 
     const statusCell = document.createElement('td');
+    statusCell.dataset.label = 'Estado';
     statusCell.appendChild(createStatusBadge(order.status));
 
     const createdCell = document.createElement('td');
+    createdCell.dataset.label = 'Fecha de ingreso';
     createdCell.textContent = formatDate(order.created_at);
 
     const deliveryCell = document.createElement('td');
+    deliveryCell.dataset.label = 'Fecha de entrega';
     if (order.delivery_date) {
       const deliveryLabel = formatDeliveryDateDisplay(order) || formatDateOnly(order.delivery_date);
       deliveryCell.textContent = deliveryLabel;
@@ -2235,6 +2245,7 @@ function renderOrders() {
     }
 
     const actionsCell = document.createElement('td');
+    actionsCell.dataset.label = 'Acciones';
     const detailButton = document.createElement('button');
     detailButton.type = 'button';
     detailButton.className = 'secondary';

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1010,3 +1010,106 @@ th {
     padding: 0.6rem;
   }
 }
+
+@media (max-width: 640px) {
+  .table-wrapper {
+    overflow-x: visible;
+  }
+
+  .table-wrapper table {
+    border: 0;
+  }
+
+  .table-wrapper thead {
+    display: none;
+  }
+
+  .table-wrapper tbody {
+    display: block;
+  }
+
+  .table-wrapper tbody tr {
+    display: block;
+    background: white;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    margin-bottom: 1rem;
+    box-shadow: 0 18px 32px rgba(15, 76, 92, 0.08);
+    overflow: hidden;
+  }
+
+  .table-wrapper tbody tr:last-of-type {
+    margin-bottom: 0;
+  }
+
+  .table-wrapper tbody tr td {
+    display: block;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .table-wrapper tbody tr td:last-child {
+    border-bottom: none;
+  }
+
+  .table-wrapper tbody tr td[data-label]::before {
+    content: attr(data-label);
+    display: block;
+    font-weight: 600;
+    color: var(--muted);
+    margin-bottom: 0.35rem;
+    font-size: 0.8rem;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+  }
+
+  .table-wrapper tbody tr td[data-label='Acciones'] button {
+    width: 100%;
+  }
+
+  .customer-order-count-cell {
+    text-align: left;
+  }
+
+  .order-row.is-selected,
+  .customer-row.is-selected {
+    border-color: var(--primary);
+    box-shadow: 0 20px 36px rgba(15, 76, 92, 0.12);
+    margin-bottom: 0;
+  }
+
+  .order-detail-row,
+  .customer-detail-row {
+    display: block;
+    margin-top: -0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .order-detail-row td,
+  .customer-detail-row td {
+    display: block;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 12px 12px;
+    background: #f9fbfc;
+    box-shadow: 0 20px 36px rgba(15, 76, 92, 0.12);
+  }
+
+  .order-detail,
+  .customer-detail {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    padding: 1.5rem 1.25rem;
+    box-shadow: none;
+    margin: 0;
+  }
+
+  .order-detail .button-row,
+  .customer-detail .button-row {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add `data-label` attributes to customer and order table cells so column context is available in responsive layouts
- introduce a mobile-focused media query that hides table headers, renders rows as stacked cards, and surfaces the `data-label` value with `::before`
- tweak order and customer detail row styling to remain aligned with the new card presentation and keep action controls usable on small screens

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0820368d48332b24143798ba8caba