### PR TITLE
Pin bcrypt dependency to pre-4.0 releases

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.110.0
 uvicorn[standard]==0.29.0
 SQLAlchemy==2.0.25
 python-jose[cryptography]==3.3.0
+bcrypt<4.0
 passlib[bcrypt]==1.7.4
 pydantic>=2
 pydantic-settings>=2.0.0


### PR DESCRIPTION
## Summary
- add an explicit bcrypt<4.0 requirement to keep compatibility with passlib

## Testing
- SECRET_KEY=abcdefghijklmnopqrstuvwxyz123456 pytest

------
https://chatgpt.com/codex/tasks/task_e_68d087d289bc83329fd5efb0c250e692