### PR TITLE
Allow configuring API host and port

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,10 +59,21 @@ Al finalizar, se mostrará un resumen con los registros creados y las credencial
 Iniciar la API:
 
 ```bash
-uvicorn app.main:app --reload
+python -m app.main
 ```
 
-La documentación interactiva estará disponible en `http://localhost:8000/docs`.
+Por defecto el servidor escucha en `127.0.0.1:8000`. Para exponerlo en otro host o
+puerto (por ejemplo al desplegar en un servidor), define las variables de entorno
+`API_HOST`, `API_PORT` y opcionalmente `API_RELOAD` en tu `.env` o antes de ejecutar
+el comando. Ejemplo para escuchar en todas las interfaces:
+
+```bash
+export API_HOST=0.0.0.0
+export API_PORT=8000
+python -m app.main
+```
+
+La documentación interactiva estará disponible en `http://<host>:<puerto>/docs`.
 
 ### 2. Preparar el frontend
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,20 @@ class Settings(BaseSettings):
         default_factory=lambda: ["http://localhost:5173", "http://127.0.0.1:5173"],
         description="Origins allowed to make CORS requests.",
     )
+    api_host: str = Field(
+        "127.0.0.1",
+        description="Host interface where the API should listen.",
+    )
+    api_port: int = Field(
+        8000,
+        ge=0,
+        le=65535,
+        description="Port number where the API should listen.",
+    )
+    api_reload: bool = Field(
+        False,
+        description="Enable auto reload when running the development server via python -m app.main.",
+    )
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -458,3 +458,14 @@ def list_audit_logs_endpoint(
 ):
     _ = current_user
     return crud.list_audit_logs(db, limit=limit)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "app.main:app",
+        host=settings.api_host,
+        port=settings.api_port,
+        reload=settings.api_reload,
+    )


### PR DESCRIPTION
## Summary
- add configurable API host, port, and reload options to the backend settings
- expose a python -m app.main entry point that reads those settings when starting uvicorn
- document how to run the API on a custom host/port in the README

## Testing
- `SECRET_KEY=abcdefghijklmnopqrstuvwxyz123456 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68d08d8c5ba08332bc752bd31b8267c0