### PR TITLE
Serve frontend from backend application

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,20 +59,33 @@ Al finalizar, se mostrará un resumen con los registros creados y las credencial
 Iniciar la API:
 
 ```bash
-uvicorn app.main:app --reload
+python -m app.main
 ```
 
-La documentación interactiva estará disponible en `http://localhost:8000/docs`.
+Por defecto el servidor escucha en `127.0.0.1:8000`. Para exponerlo en otro host o
+puerto (por ejemplo al desplegar en un servidor), define las variables de entorno
+`API_HOST`, `API_PORT` y opcionalmente `API_RELOAD` en tu `.env` o antes de ejecutar
+el comando. Ejemplo para escuchar en todas las interfaces:
 
-### 2. Preparar el frontend
+```bash
+export API_HOST=0.0.0.0
+export API_PORT=8000
+python -m app.main
+```
 
-El frontend es una SPA ligera sin dependencias externas. Desde la carpeta `frontend` ejecuta:
+La documentación interactiva estará disponible en `http://<host>:<puerto>/docs`.
+
+### 2. Acceder al frontend
+
+Con el backend en ejecución, visita `http://<host>:<puerto>` (por defecto `http://127.0.0.1:8000`) para utilizar el portal web. La aplicación FastAPI sirve directamente los archivos estáticos del frontend.
+
+Si prefieres ejecutar el frontend desde un servidor estático independiente (por ejemplo para desarrollo), desde la carpeta `frontend` ejecuta:
 
 ```bash
 python -m http.server 5173
 ```
 
-Luego visita `http://localhost:5173` en tu navegador. Asegúrate de que el backend esté funcionando en `http://localhost:8000`.
+Luego visita `http://localhost:5173` en tu navegador. Asegúrate de que el backend esté funcionando en `http://localhost:8000` o configura `API_BASE_URL` según se describe más adelante.
 
 ## Roles disponibles
 
@@ -98,7 +111,7 @@ frontend/      # Portal HTML/JS/CSS
 
 ## Variables útiles
 
-Si necesitas cambiar la URL del backend para el frontend, define `API_BASE_URL` antes de cargar `app.js`:
+El frontend detecta automáticamente la URL del backend utilizando el mismo origen desde el que se sirve la página. Si ejecutas la interfaz en un servidor distinto al de la API (por ejemplo `http://localhost:5173`), define `API_BASE_URL` antes de cargar `app.js`:
 
 ```html
 <script>

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,20 @@ class Settings(BaseSettings):
         default_factory=lambda: ["http://localhost:5173", "http://127.0.0.1:5173"],
         description="Origins allowed to make CORS requests.",
     )
+    api_host: str = Field(
+        "127.0.0.1",
+        description="Host interface where the API should listen.",
+    )
+    api_port: int = Field(
+        8000,
+        ge=0,
+        le=65535,
+        description="Port number where the API should listen.",
+    )
+    api_reload: bool = Field(
+        False,
+        description="Enable auto reload when running the development server via python -m app.main.",
+    )
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,4 +1,19 @@
-const API_BASE_URL = window.API_BASE_URL || 'http://localhost:8000';
+function resolveDefaultApiBaseUrl() {
+  if (typeof window === 'undefined') {
+    return 'http://localhost:8000';
+  }
+  const { protocol, hostname, port } = window.location;
+  const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  if (isLocalhost && port && port !== '8000') {
+    return `${protocol}//${hostname}:8000`;
+  }
+  if (port) {
+    return `${protocol}//${hostname}:${port}`;
+  }
+  return `${protocol}//${hostname}`;
+}
+
+const API_BASE_URL = window.API_BASE_URL || resolveDefaultApiBaseUrl();
 const DEFAULT_PAGE_SIZE = 10;
 const PAGE_SIZE_OPTIONS = [10, 15, 20, 25, 30, 35, 40, 45, 50];
 const ESTABLISHMENTS = ['Urdesa', 'Batan', 'Indie'];


### PR DESCRIPTION
## Summary
- serve the SPA assets directly from the FastAPI application so the portal is available at the API host and port
- detect the default API base URL in the frontend from the current origin while keeping support for overriding it
- document the new access method and optional standalone frontend server in the README

## Testing
- `SECRET_KEY=abcdefghijklmnopqrstuvwxyz123456 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d08d8c5ba08332bc752bd31b8267c0