### PR TITLE
Restringir la pestaña de creación de órdenes para sastres

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,7 +74,14 @@
 
           <nav class="dashboard-subnav">
             <button type="button" class="dashboard-tab active" data-tab="orderListPanel">Órdenes registradas</button>
-            <button type="button" class="dashboard-tab" data-tab="orderCreatePanel">Crear orden</button>
+            <button
+              type="button"
+              class="dashboard-tab"
+              data-tab="orderCreatePanel"
+              id="orderCreateTabButton"
+            >
+              Crear orden
+            </button>
             <button type="button" class="dashboard-tab" data-tab="customersPanel">Clientes</button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- añade un identificador al botón de la pestaña "Crear orden" para manipularlo desde JavaScript
- ajusta la lógica del panel para ocultar pestaña y sección de creación cuando el usuario es sastre y redirige a la lista
- evita envíos del formulario de creación cuando el panel está oculto y sincroniza el estado del botón de envío

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d16b16eca483329a20a27669256c98