### PR TITLE
Add tailor authorization tests for order endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -353,6 +353,11 @@ def create_order_endpoint(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(vendor_or_admin_required()),
 ):
+    if current_user.role not in {models.UserRole.ADMIN, models.UserRole.VENDEDOR}:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No tiene permisos para realizar esta acción",
+        )
     if crud.get_order_by_number(db, order_in.order_number):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ya existe una orden con ese número")
     customer = crud.get_customer(db, order_in.customer_id)

--- a/backend/tests/test_order_tailor_validation.py
+++ b/backend/tests/test_order_tailor_validation.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -58,6 +58,20 @@ def customer(db_session):
     return customer
 
 
+@pytest.fixture
+def tailor_user(db_session):
+    user = models.User(
+        username="tailor",
+        full_name="Sastre Ejemplo",
+        role=models.UserRole.SASTRE,
+        password_hash=auth.get_password_hash("secret"),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
 def test_create_order_with_invalid_tailor_id(db_session, admin_user, customer):
     order_in = schemas.OrderCreate(
         order_number="ORD-100",
@@ -104,3 +118,39 @@ def test_update_order_rejects_non_tailor_assignment(db_session, admin_user, cust
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "El usuario asignado no es un sastre"
+
+
+def test_create_order_forbidden_for_tailor(db_session, tailor_user, customer):
+    order_in = schemas.OrderCreate(
+        order_number="ORD-300",
+        customer_id=customer.id,
+        origin_branch=models.Establishment.URDESA,
+        assigned_tailor_id=tailor_user.id,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        main.create_order_endpoint(order_in, db_session, tailor_user)
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.detail == "No tiene permisos para realizar esta acción"
+
+
+def test_tailor_can_update_order(db_session, admin_user, tailor_user, customer):
+    created_order = main.create_order_endpoint(
+        schemas.OrderCreate(
+            order_number="ORD-400",
+            customer_id=customer.id,
+            origin_branch=models.Establishment.BATAN,
+        ),
+        db_session,
+        admin_user,
+    )
+
+    updated_order = main.update_order_endpoint(
+        created_order.id,
+        schemas.OrderUpdate(assigned_tailor_id=tailor_user.id),
+        db_session,
+        tailor_user,
+    )
+
+    assert updated_order.assigned_tailor_id == tailor_user.id


### PR DESCRIPTION
## Summary
- add a dedicated fixture for tailor users in the order validation tests and cover their permissions
- document allowed tailor updates and forbid order creation by tailors through a new authorization check

## Testing
- SECRET_KEY=abcdefghijklmnopqrstuvwxyz123456 pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16b18459c83329ce2e0ce4aac1e85