### PR TITLE
docs: document --role option for create_admin script

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -42,6 +42,10 @@ Crear el primer usuario administrador:
 python create_admin.py --username admin --password cambialo --full-name "Administrador"
 ```
 
+Si necesitas crear un usuario inicial con otro rol, añade la opción `--role` con uno de
+los valores disponibles (`admin`, `sales`, `tailor`). El valor predeterminado es
+`admin`.
+
 Poblar la base de datos con información de ejemplo (opcional):
 
 ```bash


### PR DESCRIPTION
## Summary
- document the optional --role flag in the administrator bootstrap instructions
- mention the available role values and default behavior

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68d171278908833286de4d5c0ee76ef2