### PR TITLE
Add order task checklist

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -62,6 +62,18 @@ def serialize_order(order: Optional[models.Order]) -> Optional[Dict[str, Any]]:
     }
 
 
+def serialize_order_task(task: Optional[models.OrderTask]) -> Optional[Dict[str, Any]]:
+    if task is None:
+        return None
+    return {
+        "id": task.id,
+        "order_id": task.order_id,
+        "description": task.description,
+        "status": task.status.value if task.status else None,
+        "responsible_id": task.responsible_id,
+    }
+
+
 # Audit log operations ------------------------------------------------------
 
 def create_audit_log(
@@ -383,3 +395,60 @@ def update_order(db: Session, db_order: models.Order, order_update: schemas.Orde
 def delete_order(db: Session, db_order: models.Order) -> None:
     db.delete(db_order)
     db.commit()
+
+
+# Order task operations -----------------------------------------------------
+
+
+def list_order_tasks(db: Session, *, order_id: int) -> List[models.OrderTask]:
+    return (
+        db.query(models.OrderTask)
+        .options(joinedload(models.OrderTask.responsible))
+        .filter(models.OrderTask.order_id == order_id)
+        .order_by(models.OrderTask.created_at.asc())
+        .all()
+    )
+
+
+def create_order_task(
+    db: Session, *, order_id: int, task_in: schemas.OrderTaskCreate
+) -> models.OrderTask:
+    db_task = models.OrderTask(
+        order_id=order_id,
+        description=task_in.description,
+        status=task_in.status,
+        responsible_id=task_in.responsible_id,
+    )
+    db.add(db_task)
+    db.commit()
+    db.refresh(db_task)
+    return db_task
+
+
+def get_order_task(
+    db: Session, *, order_id: int, task_id: int
+) -> Optional[models.OrderTask]:
+    return (
+        db.query(models.OrderTask)
+        .options(joinedload(models.OrderTask.responsible))
+        .filter(
+            models.OrderTask.id == task_id,
+            models.OrderTask.order_id == order_id,
+        )
+        .first()
+    )
+
+
+def update_order_task(
+    db: Session, db_task: models.OrderTask, task_update: schemas.OrderTaskUpdate
+) -> models.OrderTask:
+    data = task_update.model_dump(exclude_unset=True)
+    if "description" in data:
+        db_task.description = data["description"]
+    if "status" in data:
+        db_task.status = data["status"]
+    if "responsible_id" in data:
+        db_task.responsible_id = data["responsible_id"]
+    db.commit()
+    db.refresh(db_task)
+    return db_task

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -21,3 +21,7 @@ def staff_required():
 
 def vendor_or_admin_required():
     return auth.require_roles(models.UserRole.ADMIN, models.UserRole.VENDEDOR)
+
+
+def tailor_or_admin_required():
+    return auth.require_roles(models.UserRole.ADMIN, models.UserRole.SASTRE)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
-from .models import Establishment, OrderStatus, UserRole
+from .models import Establishment, OrderStatus, OrderTaskStatus, UserRole
 
 
 class Token(BaseModel):
@@ -148,6 +148,33 @@ class OrderRead(OrderPublic):
     customer: Optional[CustomerSummary]
     assigned_tailor: Optional[UserOut]
     created_at: datetime
+
+
+class OrderTaskBase(BaseModel):
+    description: str = Field(..., min_length=1, max_length=255)
+
+
+class OrderTaskCreate(OrderTaskBase):
+    status: OrderTaskStatus = OrderTaskStatus.PENDING
+    responsible_id: Optional[int] = None
+
+
+class OrderTaskUpdate(BaseModel):
+    description: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    status: Optional[OrderTaskStatus] = None
+    responsible_id: Optional[int] = None
+
+
+class OrderTaskRead(OrderTaskBase):
+    id: int
+    order_id: int
+    status: OrderTaskStatus
+    responsible_id: Optional[int] = None
+    responsible: Optional[UserOut] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class PaginatedCustomers(BaseModel):

--- a/backend/tests/test_order_tailor_validation.py
+++ b/backend/tests/test_order_tailor_validation.py
@@ -1,5 +1,8 @@
+import os
 import sys
 from pathlib import Path
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
 
 import pytest
 from fastapi import HTTPException

--- a/backend/tests/test_order_tasks.py
+++ b/backend/tests/test_order_tasks.py
@@ -1,0 +1,142 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import auth, dependencies, main, models, schemas
+from app.database import Base
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def create_user(session, username: str, role: models.UserRole) -> models.User:
+    user = models.User(
+        username=username,
+        full_name=username.title(),
+        role=role,
+        password_hash=auth.get_password_hash("secret"),
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def create_customer_with_order(session) -> models.Order:
+    customer = models.Customer(
+        full_name="Cliente Demo",
+        document_id="1234567890",
+        phone="0990000000",
+    )
+    session.add(customer)
+    session.commit()
+    session.refresh(customer)
+
+    order = models.Order(
+        order_number="ORD-500",
+        customer_id=customer.id,
+        customer_name=customer.full_name,
+        customer_document=customer.document_id,
+        customer_contact=customer.phone,
+        status=models.OrderStatus.EN_TIENDA_BATAN,
+        measurements=[],
+        origin_branch=models.Establishment.BATAN,
+    )
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return order
+
+
+def test_tailor_can_create_task_and_vendor_cannot_modify(db_session):
+    tailor = create_user(db_session, "tailor", models.UserRole.SASTRE)
+    vendor = create_user(db_session, "vendor", models.UserRole.VENDEDOR)
+    order = create_customer_with_order(db_session)
+
+    asyncio.run(dependencies.tailor_or_admin_required()(tailor))
+    created = main.create_order_task_endpoint(
+        order.id,
+        schemas.OrderTaskCreate(description="Coser mangas"),
+        db_session,
+        tailor,
+    )
+    assert created.description == "Coser mangas"
+    assert created.status == models.OrderTaskStatus.PENDING
+    assert created.order_id == order.id
+    assert db_session.query(models.OrderTask).count() == 1
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(dependencies.tailor_or_admin_required()(vendor))
+    assert exc_info.value.status_code == 403
+    assert db_session.query(models.OrderTask).count() == 1
+
+
+def test_status_update_requires_tailor_and_logs_audit(db_session):
+    tailor = create_user(db_session, "tailor", models.UserRole.SASTRE)
+    admin = create_user(db_session, "admin", models.UserRole.ADMIN)
+    vendor = create_user(db_session, "vendor", models.UserRole.VENDEDOR)
+    order = create_customer_with_order(db_session)
+
+    asyncio.run(dependencies.tailor_or_admin_required()(tailor))
+    task = main.create_order_task_endpoint(
+        order.id,
+        schemas.OrderTaskCreate(description="Marcar dobladillos"),
+        db_session,
+        tailor,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(dependencies.tailor_or_admin_required()(vendor))
+    assert exc_info.value.status_code == 403
+
+    asyncio.run(dependencies.tailor_or_admin_required()(admin))
+    updated = main.update_order_task_endpoint(
+        order.id,
+        task.id,
+        schemas.OrderTaskUpdate(status=models.OrderTaskStatus.COMPLETED),
+        db_session,
+        admin,
+    )
+    assert updated.status == models.OrderTaskStatus.COMPLETED
+
+    stored_task = db_session.query(models.OrderTask).filter_by(id=task.id).one()
+    assert stored_task.status == models.OrderTaskStatus.COMPLETED
+
+    logs = (
+        db_session.query(models.AuditLog)
+        .filter(models.AuditLog.entity_type == "order_task", models.AuditLog.entity_id == task.id)
+        .order_by(models.AuditLog.timestamp.asc())
+        .all()
+    )
+    status_logs = [log for log in logs if log.action == "update_status"]
+    assert status_logs, "Debe registrarse un log de auditoría para el cambio de estado"
+    last_status_log = status_logs[-1]
+    assert last_status_log.before == {"status": models.OrderTaskStatus.PENDING.value}
+    assert last_status_log.after == {"status": models.OrderTaskStatus.COMPLETED.value}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,6 +2,8 @@ const API_BASE_URL = window.API_BASE_URL || 'http://localhost:8000';
 const DEFAULT_PAGE_SIZE = 10;
 const PAGE_SIZE_OPTIONS = [10, 15, 20, 25, 30, 35, 40, 45, 50];
 const ESTABLISHMENTS = ['Urdesa', 'Batan', 'Indie'];
+const ORDER_TASK_STATUS_PENDING = 'pendiente';
+const ORDER_TASK_STATUS_COMPLETED = 'completado';
 
 
 const state = {
@@ -26,6 +28,10 @@ const state = {
   auditLogs: [],
   selectedCustomerId: null,
   selectedOrderId: null,
+  orderTasks: [],
+  orderTasksOrderId: null,
+  orderTasksLoading: false,
+  orderTasksRequestId: 0,
   customerRequestId: 0,
   orderRequestId: 0,
   customerOptionsRequestId: 0,
@@ -142,6 +148,11 @@ const orderDetailOriginSelect = document.getElementById('orderDetailOrigin');
 const orderDetailDeliveryDateInput = document.getElementById('orderDetailDeliveryDate');
 const orderDetailNotesTextarea = document.getElementById('orderDetailNotes');
 const orderDetailMeasurementsContainer = document.getElementById('orderDetailMeasurements');
+const orderTasksList = document.getElementById('orderTasksList');
+const orderTaskForm = document.getElementById('orderTaskForm');
+const orderTaskDescriptionInput = document.getElementById('orderTaskDescription');
+const orderTaskResponsibleSelect = document.getElementById('orderTaskResponsible');
+const orderTasksPermissionsNotice = document.getElementById('orderTasksPermissionsNotice');
 const closeOrderDetailButton = document.getElementById('closeOrderDetailButton');
 const toastElement = document.getElementById('toast');
 const currentYearElement = document.getElementById('currentYear');
@@ -385,6 +396,263 @@ function formatDeliveryDateDisplay(order) {
     }
   }
   return dateLabel;
+}
+
+function canModifyOrderTasks() {
+  const role = state.user?.role;
+  return role === 'administrador' || role === 'sastre';
+}
+
+function sortOrderTasks(tasks) {
+  return [...tasks].sort((a, b) => {
+    const aTime = new Date(a?.created_at ?? 0).getTime();
+    const bTime = new Date(b?.created_at ?? 0).getTime();
+    const aInvalid = Number.isNaN(aTime);
+    const bInvalid = Number.isNaN(bTime);
+    if (aInvalid && bInvalid) {
+      return (a?.id ?? 0) - (b?.id ?? 0);
+    }
+    if (aInvalid) return 1;
+    if (bInvalid) return -1;
+    if (aTime === bTime) {
+      return (a?.id ?? 0) - (b?.id ?? 0);
+    }
+    return aTime - bTime;
+  });
+}
+
+function resetOrderTasksState() {
+  state.orderTasks = [];
+  state.orderTasksOrderId = null;
+  state.orderTasksLoading = false;
+  state.orderTasksRequestId = 0;
+  renderOrderTasks();
+}
+
+function renderOrderTasks() {
+  if (!orderTasksList) return;
+  const selectedOrderId = state.selectedOrderId;
+  const tasksBelongToSelection =
+    selectedOrderId !== null && state.orderTasksOrderId === selectedOrderId;
+  const canModify = canModifyOrderTasks();
+  const shouldShowForm = tasksBelongToSelection && canModify;
+
+  if (orderTaskForm) {
+    orderTaskForm.classList.toggle('hidden', !shouldShowForm);
+  }
+  if (orderTaskDescriptionInput) {
+    orderTaskDescriptionInput.disabled = !canModify;
+  }
+  if (orderTaskResponsibleSelect) {
+    orderTaskResponsibleSelect.disabled = !canModify;
+  }
+  if (orderTasksPermissionsNotice) {
+    const showNotice = tasksBelongToSelection && !canModify;
+    orderTasksPermissionsNotice.classList.toggle('hidden', !showNotice);
+  }
+
+  if (!tasksBelongToSelection) {
+    orderTasksList.classList.add('muted');
+    orderTasksList.textContent =
+      selectedOrderId === null
+        ? 'Selecciona una orden para ver el checklist.'
+        : 'Cargando checklist...';
+    return;
+  }
+
+  if (state.orderTasksLoading) {
+    orderTasksList.classList.add('muted');
+    orderTasksList.textContent = 'Cargando checklist...';
+    return;
+  }
+
+  const tasks = Array.isArray(state.orderTasks) ? state.orderTasks : [];
+  orderTasksList.innerHTML = '';
+  if (!tasks.length) {
+    orderTasksList.classList.add('muted');
+    orderTasksList.textContent = 'No hay tareas registradas.';
+    return;
+  }
+
+  orderTasksList.classList.remove('muted');
+  const list = document.createElement('ul');
+  list.className = 'order-task-list';
+
+  tasks.forEach((task) => {
+    const item = document.createElement('li');
+    item.className = 'order-task-item';
+
+    const label = document.createElement('label');
+    label.className = 'order-task-label';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = task.status === ORDER_TASK_STATUS_COMPLETED;
+    checkbox.disabled = !canModify;
+    checkbox.addEventListener('change', () => handleOrderTaskToggle(task.id, checkbox));
+    label.appendChild(checkbox);
+
+    const description = document.createElement('span');
+    description.className = 'order-task-description';
+    description.textContent = task.description || '';
+    label.appendChild(description);
+
+    item.appendChild(label);
+
+    const meta = document.createElement('div');
+    meta.className = 'order-task-meta';
+
+    const responsible = document.createElement('span');
+    responsible.className = 'order-task-responsible';
+    responsible.textContent = task.responsible?.full_name
+      ? `Responsable: ${task.responsible.full_name}`
+      : 'Responsable: Sin asignar';
+    meta.appendChild(responsible);
+
+    if (task.updated_at) {
+      const updated = document.createElement('span');
+      updated.className = 'order-task-updated';
+      updated.textContent = `Actualizado: ${formatDate(task.updated_at)}`;
+      meta.appendChild(updated);
+    }
+
+    item.appendChild(meta);
+    list.appendChild(item);
+  });
+
+  orderTasksList.appendChild(list);
+}
+
+async function refreshOrderTasks(orderId) {
+  if (!state.token) return;
+  const requestId = Date.now();
+  state.orderTasksRequestId = requestId;
+  state.orderTasksOrderId = orderId;
+  state.orderTasksLoading = true;
+  renderOrderTasks();
+  try {
+    const tasks = await apiFetch(`/orders/${orderId}/tasks`);
+    if (state.orderTasksRequestId !== requestId) {
+      return;
+    }
+    const normalized = Array.isArray(tasks) ? tasks : [];
+    state.orderTasks = sortOrderTasks(normalized);
+  } catch (error) {
+    if (state.orderTasksRequestId === requestId) {
+      state.orderTasks = [];
+      showToast(error.message, 'error');
+    }
+  } finally {
+    if (state.orderTasksRequestId === requestId) {
+      state.orderTasksLoading = false;
+      renderOrderTasks();
+    }
+  }
+}
+
+function applyOrderTaskUpdate(updatedTask) {
+  if (!updatedTask || typeof updatedTask !== 'object') return;
+  if (state.orderTasksOrderId !== updatedTask.order_id) {
+    return;
+  }
+  const tasks = Array.isArray(state.orderTasks) ? [...state.orderTasks] : [];
+  const index = tasks.findIndex((task) => task.id === updatedTask.id);
+  if (index === -1) {
+    tasks.push(updatedTask);
+  } else {
+    tasks[index] = updatedTask;
+  }
+  state.orderTasks = sortOrderTasks(tasks);
+  renderOrderTasks();
+}
+
+async function handleOrderTaskToggle(taskId, checkbox) {
+  if (state.selectedOrderId === null || !checkbox) {
+    return;
+  }
+  if (!canModifyOrderTasks()) {
+    renderOrderTasks();
+    return;
+  }
+  if (state.orderTasksOrderId !== state.selectedOrderId) {
+    checkbox.checked = state.orderTasks.find((task) => task.id === taskId)?.status === ORDER_TASK_STATUS_COMPLETED;
+    checkbox.disabled = !canModifyOrderTasks();
+    return;
+  }
+  const currentTask = state.orderTasks.find((task) => task.id === taskId);
+  const previousStatus = currentTask?.status || ORDER_TASK_STATUS_PENDING;
+  const desiredStatus = checkbox.checked
+    ? ORDER_TASK_STATUS_COMPLETED
+    : ORDER_TASK_STATUS_PENDING;
+  if (desiredStatus === previousStatus) {
+    checkbox.disabled = !canModifyOrderTasks();
+    return;
+  }
+  checkbox.disabled = true;
+  try {
+    const updatedTask = await apiFetch(`/orders/${state.selectedOrderId}/tasks/${taskId}`, {
+      method: 'PATCH',
+      body: { status: desiredStatus },
+    });
+    applyOrderTaskUpdate(updatedTask);
+    showToast('Checklist actualizado.', 'success');
+  } catch (error) {
+    checkbox.checked = previousStatus === ORDER_TASK_STATUS_COMPLETED;
+    showToast(error.message, 'error');
+  } finally {
+    checkbox.disabled = !canModifyOrderTasks();
+  }
+}
+
+async function handleOrderTaskCreate(event) {
+  event.preventDefault();
+  if (state.selectedOrderId === null) {
+    showToast('Selecciona una orden antes de agregar tareas.', 'error');
+    return;
+  }
+  if (state.orderTasksOrderId !== state.selectedOrderId) {
+    showToast('Selecciona una orden antes de agregar tareas.', 'error');
+    return;
+  }
+  if (!canModifyOrderTasks()) {
+    showToast('No tienes permisos para modificar el checklist.', 'error');
+    return;
+  }
+  const descriptionValue = orderTaskDescriptionInput?.value.trim() || '';
+  if (!descriptionValue) {
+    showToast('Ingresa la descripción de la tarea.', 'error');
+    return;
+  }
+  const responsibleValue = orderTaskResponsibleSelect?.value || '';
+  const submitButton = orderTaskForm?.querySelector('button[type="submit"]');
+  if (submitButton) {
+    submitButton.disabled = true;
+  }
+  try {
+    const body = { description: descriptionValue };
+    if (responsibleValue) {
+      body.responsible_id = Number(responsibleValue);
+    }
+    const newTask = await apiFetch(`/orders/${state.selectedOrderId}/tasks`, {
+      method: 'POST',
+      body,
+    });
+    applyOrderTaskUpdate(newTask);
+    if (orderTaskDescriptionInput) {
+      orderTaskDescriptionInput.value = '';
+      orderTaskDescriptionInput.focus();
+    }
+    if (orderTaskResponsibleSelect) {
+      orderTaskResponsibleSelect.value = '';
+    }
+    showToast('Tarea añadida al checklist.', 'success');
+  } catch (error) {
+    showToast(error.message, 'error');
+  } finally {
+    if (submitButton) {
+      submitButton.disabled = false;
+    }
+  }
 }
 
 async function apiFetch(path, { method = 'GET', body, headers = {}, auth = true } = {}) {
@@ -875,6 +1143,7 @@ function updateUserInfo() {
   if (!isAdmin && activeDashboardTab === 'auditLogPanel') {
     setActiveDashboardTab('orderListPanel');
   }
+  renderOrderTasks();
 }
 
 function showDashboard() {
@@ -992,6 +1261,7 @@ async function loadTailors() {
     showToast(error.message, 'error');
   }
   populateTailorSelect(assignTailorSelect);
+  populateTailorSelect(orderTaskResponsibleSelect);
   if (orderDetailTailorSelect) {
     const selectedValue =
       orderDetailTailorSelect.value ||
@@ -1223,6 +1493,10 @@ function handleLogout(auto = false) {
   state.auditLogs = [];
   state.selectedCustomerId = null;
   state.selectedOrderId = null;
+  state.orderTasks = [];
+  state.orderTasksOrderId = null;
+  state.orderTasksLoading = false;
+  state.orderTasksRequestId = 0;
   state.customerRequestId = 0;
   state.orderRequestId = 0;
   state.customerOptionsRequestId = 0;
@@ -1234,6 +1508,9 @@ function handleLogout(auto = false) {
   }
   if (assignTailorSelect) {
     populateTailorSelect(assignTailorSelect);
+  }
+  if (orderTaskResponsibleSelect) {
+    populateTailorSelect(orderTaskResponsibleSelect);
   }
   if (orderCustomerSelect) {
     populateCustomerSelect(orderCustomerSelect);
@@ -1295,6 +1572,7 @@ function handleLogout(auto = false) {
   });
   updateNavigationForAuth();
   setActiveView('staff-view');
+  renderOrderTasks();
   if (auto) {
     showToast('La sesión ha expirado, vuelve a iniciar sesión.', 'error');
   }
@@ -1769,6 +2047,10 @@ function populateOrderDetail(order, options = {}) {
   const { skipRender = false, focusOnDetail = true } = options;
 
   state.selectedOrderId = order.id;
+  state.orderTasksOrderId = order.id;
+  state.orderTasksLoading = true;
+  state.orderTasks = [];
+  renderOrderTasks();
   if (orderDetailNumberElement) {
     orderDetailNumberElement.textContent = order.order_number;
   }
@@ -1831,6 +2113,8 @@ function populateOrderDetail(order, options = {}) {
       });
     }
   }
+
+  refreshOrderTasks(order.id);
 }
 
 function clearOrderDetail(options = {}) {
@@ -1855,6 +2139,8 @@ function clearOrderDetail(options = {}) {
     orderDetailMeasurementsContainer.innerHTML = '';
     orderDetailMeasurementsContainer.classList.add('muted');
   }
+
+  resetOrderTasksState();
 
   removeOrderDetailRow();
   orderDetail.classList.add('hidden');
@@ -2034,6 +2320,10 @@ if (closeCreateCustomerButton) {
 
 if (updateOrderForm) {
   updateOrderForm.addEventListener('submit', handleOrderUpdate);
+}
+
+if (orderTaskForm) {
+  orderTaskForm.addEventListener('submit', handleOrderTaskCreate);
 }
 
 if (closeOrderDetailButton) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -427,6 +427,29 @@
                   <label>Medidas</label>
                   <div id="orderDetailMeasurements" class="measurement-tags muted"></div>
                 </div>
+                <div class="form-row">
+                  <label>Checklist de producción</label>
+                  <div id="orderTasksContainer" class="order-tasks-container">
+                    <div id="orderTasksList" class="order-tasks-list muted">
+                      Selecciona una orden para ver el checklist.
+                    </div>
+                    <form id="orderTaskForm" class="order-task-form hidden">
+                      <div class="order-task-fields">
+                        <input
+                          type="text"
+                          id="orderTaskDescription"
+                          placeholder="Descripción de la tarea"
+                          aria-label="Descripción de la tarea"
+                        />
+                        <select id="orderTaskResponsible" aria-label="Responsable"></select>
+                        <button type="submit" class="secondary">Agregar</button>
+                      </div>
+                    </form>
+                    <p id="orderTasksPermissionsNotice" class="muted small hidden">
+                      Solo los sastres o administradores pueden modificar el checklist.
+                    </p>
+                  </div>
+                </div>
                 <div class="button-row">
                   <button type="submit" class="primary">Guardar cambios</button>
                 </div>


### PR DESCRIPTION
## Summary
- add a persistent OrderTask model, schemas, CRUD helpers, and REST endpoints with audit logging restricted to tailors and admins
- integrate the order detail view with the checklist API to load, create, and update tasks from the frontend
- cover the new checklist functionality with backend tests and ensure existing tests run by configuring SECRET_KEY for the suite

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d16b1921608332b317fc5a7fe0fd9f