### PR TITLE
Add populateNewOrderTaskResponsibles guard

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -874,6 +874,21 @@ function populateTailorSelect(selectElement, selectedId = '') {
   });
 }
 
+function populateNewOrderTaskResponsibles() {
+  if (!newOrderTasksList) return;
+
+  const responsibleSelects = newOrderTasksList.querySelectorAll(
+    'select[data-role="task-responsible"], select[data-field="responsible"]'
+  );
+
+  if (!responsibleSelects.length) return;
+
+  responsibleSelects.forEach((selectElement) => {
+    const selectedValue = selectElement.value || '';
+    populateTailorSelect(selectElement, selectedValue);
+  });
+}
+
 function populateEstablishmentSelect(selectElement, selectedValue = '') {
   if (!selectElement) return;
   const normalizedSelected = selectedValue || '';


### PR DESCRIPTION
## Summary
- add a populateNewOrderTaskResponsibles helper that safely repopulates task responsible selects when they exist
- prevent the ReferenceError during login by defining the legacy helper that loadTailors still invokes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1bcd2a79083328e81a6b1578433a6