### PR TITLE
Ajustes responsivos para vistas móviles

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -20,11 +20,14 @@ body {
   margin: 0;
   background: #f7fafc;
   color: var(--text);
+  overflow-x: hidden;
 }
 
 .container {
-  width: min(1100px, 94vw);
+  width: 100%;
+  max-width: 1100px;
   margin: 0 auto;
+  padding: 0 clamp(1rem, 4vw, 2.5rem);
 }
 
 .top-bar {
@@ -91,7 +94,7 @@ body {
 }
 
 main {
-  padding: 2.5rem 0;
+  padding: clamp(1.75rem, 4vw, 2.5rem) 0;
 }
 
 .view {
@@ -105,7 +108,7 @@ main {
 .card {
   background: white;
   border-radius: 18px;
-  padding: 1.8rem;
+  padding: clamp(1.25rem, 4vw, 1.8rem);
   margin-bottom: 2rem;
   box-shadow: 0 25px 60px rgba(15, 76, 92, 0.08);
 }
@@ -495,14 +498,60 @@ button[disabled] {
 }
 
 @media (max-width: 600px) {
+  .top-bar {
+    padding: 1rem 0;
+  }
+
+  .top-bar h1 {
+    font-size: 1.5rem;
+  }
+
+  .main-nav {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .main-nav-buttons {
+    width: 100%;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .nav-button,
+  .login-button {
+    width: 100%;
+  }
+
+  .login-button {
+    margin-left: 0;
+  }
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .dashboard-subnav {
+    width: 100%;
+  }
+
+  .dashboard-tab {
+    flex: 1 1 120px;
+    text-align: center;
+  }
+
   .customer-panel-header > :first-child {
     flex-basis: 100%;
   }
 
   .customer-panel-actions {
     width: 100%;
+    flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
+    gap: 0.75rem;
   }
 
   .customer-panel-actions > button {
@@ -512,6 +561,7 @@ button[disabled] {
   .order-panel-controls {
     flex-direction: column;
     align-items: stretch;
+    gap: 0.75rem;
   }
 
   .order-search {
@@ -537,6 +587,7 @@ button[disabled] {
     width: 100%;
     justify-content: space-between;
     flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
   .pagination-button {
@@ -548,34 +599,10 @@ button[disabled] {
     width: 100%;
     text-align: center;
   }
-}
 
-
-  .table-pagination {
-    width: 100%;
-    align-items: flex-start;
-  }
-
-  .pagination-controls {
-    width: 100%;
-    justify-content: space-between;
-    gap: 0.75rem;
-  }
-
-  .pagination-buttons {
-    width: 100%;
-    justify-content: space-between;
-    flex-wrap: wrap;
-  }
-
-  .pagination-button {
-    flex: 1 1 auto;
-    text-align: center;
-  }
-
-  .pagination-info {
-    width: 100%;
-    text-align: center;
+  .toast {
+    left: clamp(1rem, 6vw, 2rem);
+    right: clamp(1rem, 6vw, 2rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- add interior padding to the layout container and prevent horizontal scrolling on mobile
- tweak main and card spacing with clamp-based values for better adaptation to smaller screens
- enhance the mobile layout of navigation, dashboard, pagination controls and toast positioning

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2ec0555788332bfef80d92cf5e3ca