### PR TITLE
Add admin users tab and vendor assignment

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -58,6 +58,7 @@ def serialize_order(order: Optional[models.Order]) -> Optional[Dict[str, Any]]:
         "measurements": order.measurements,
         "notes": order.notes,
         "assigned_tailor_id": order.assigned_tailor_id,
+        "assigned_vendor_id": order.assigned_vendor_id,
         "delivery_date": order.delivery_date.isoformat() if order.delivery_date else None,
         "invoice_number": order.invoice_number,
         "origin_branch": order.origin_branch.value if order.origin_branch else None,
@@ -308,6 +309,7 @@ def create_order(db: Session, order_in: schemas.OrderCreate) -> models.Order:
         measurements=_measurements_to_dicts(order_in.measurements),
         notes=order_in.notes,
         assigned_tailor_id=order_in.assigned_tailor_id,
+        assigned_vendor_id=order_in.assigned_vendor_id,
         delivery_date=order_in.delivery_date,
         invoice_number=order_in.invoice_number,
         origin_branch=order_in.origin_branch,
@@ -338,6 +340,7 @@ def get_order(db: Session, order_id: int) -> Optional[models.Order]:
         db.query(models.Order)
         .options(
             joinedload(models.Order.assigned_tailor),
+            joinedload(models.Order.assigned_vendor),
             joinedload(models.Order.customer).joinedload(models.Customer.measurements),
         )
         .filter(models.Order.id == order_id)
@@ -377,6 +380,7 @@ def get_orders(
     items_query = (
         query.options(
             joinedload(models.Order.assigned_tailor),
+            joinedload(models.Order.assigned_vendor),
             joinedload(models.Order.customer).joinedload(models.Customer.measurements),
         )
         .order_by(models.Order.created_at.desc())

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -58,6 +58,11 @@ class User(Base):
         back_populates="assigned_tailor",
         foreign_keys="Order.assigned_tailor_id",
     )
+    sales_orders = relationship(
+        "Order",
+        back_populates="assigned_vendor",
+        foreign_keys="Order.assigned_vendor_id",
+    )
 
 
 class Order(Base):
@@ -75,6 +80,7 @@ class Order(Base):
     measurements = Column(JSON, nullable=False, default=list)
     notes = Column(Text, nullable=True)
     assigned_tailor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    assigned_vendor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     delivery_date = Column(Date, nullable=True)
     origin_branch = Column(Enum(Establishment), nullable=True)
     invoice_number = Column(String(50), nullable=True)
@@ -86,7 +92,16 @@ class Order(Base):
         nullable=False,
     )
 
-    assigned_tailor = relationship("User", back_populates="assigned_orders")
+    assigned_tailor = relationship(
+        "User",
+        back_populates="assigned_orders",
+        foreign_keys=[assigned_tailor_id],
+    )
+    assigned_vendor = relationship(
+        "User",
+        back_populates="sales_orders",
+        foreign_keys=[assigned_vendor_id],
+    )
     customer = relationship("Customer", back_populates="orders")
     tasks = relationship(
         "OrderTask",

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -105,6 +105,7 @@ class OrderBase(BaseModel):
     measurements: List[MeasurementItem] = Field(default_factory=list)
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    assigned_vendor_id: Optional[int] = None
     delivery_date: Optional[date] = None
     invoice_number: Optional[str] = None
     origin_branch: Optional[Establishment] = None
@@ -129,6 +130,7 @@ class OrderUpdate(BaseModel):
     measurements: Optional[List[MeasurementItem]] = None
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    assigned_vendor_id: Optional[int] = None
     delivery_date: Optional[date] = None
     invoice_number: Optional[str] = None
     origin_branch: Optional[Establishment] = None
@@ -155,6 +157,7 @@ class OrderRead(OrderPublic):
     customer_contact: Optional[str]
     customer: Optional[CustomerSummary]
     assigned_tailor: Optional[UserOut]
+    assigned_vendor: Optional[UserOut]
     created_at: datetime
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -86,6 +86,14 @@
             <button
               type="button"
               class="dashboard-tab admin-only hidden"
+              data-tab="usersPanel"
+              id="usersTabButton"
+            >
+              Usuarios
+            </button>
+            <button
+              type="button"
+              class="dashboard-tab admin-only hidden"
               data-tab="auditLogPanel"
               id="auditLogTabButton"
             >
@@ -312,6 +320,12 @@
                   <option value="">Sin asignar</option>
                 </select>
               </div>
+              <div class="form-row">
+                <label for="assignVendor">Asignar a vendedor</label>
+                <select id="assignVendor">
+                  <option value="">Sin asignar</option>
+                </select>
+              </div>
               <button type="submit" class="primary">Guardar orden</button>
             </form>
           </section>
@@ -428,6 +442,10 @@
                   <select id="orderDetailTailor"></select>
                 </div>
                 <div class="form-row">
+                  <label for="orderDetailVendor">Vendedor asignado</label>
+                  <select id="orderDetailVendor"></select>
+                </div>
+                <div class="form-row">
                   <label for="orderDetailOrigin">Establecimiento remitente</label>
                   <select id="orderDetailOrigin"></select>
                 </div>
@@ -474,6 +492,23 @@
                   <button type="submit" class="primary">Guardar cambios</button>
                 </div>
               </form>
+            </div>
+          </section>
+
+          <section class="card dashboard-panel hidden" id="usersPanel">
+            <h3>Usuarios registrados</h3>
+            <p class="muted small">Consulta los usuarios autorizados y su rol dentro del sistema.</p>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Usuario</th>
+                    <th>Nombre completo</th>
+                    <th>Rol</th>
+                  </tr>
+                </thead>
+                <tbody id="usersTableBody"></tbody>
+              </table>
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- add vendor assignment support to orders with validation and persistence in the backend
- expose an admin-only user listing endpoint and cover the new behaviour with tests
- surface an admin Users tab in the UI and allow assigning vendors when creating or editing orders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2f11ceb4c8332bb6c48488fd17263