### PR TITLE
Automatically add assigned vendor column for legacy databases

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -58,6 +58,7 @@ def serialize_order(order: Optional[models.Order]) -> Optional[Dict[str, Any]]:
         "measurements": order.measurements,
         "notes": order.notes,
         "assigned_tailor_id": order.assigned_tailor_id,
+        "assigned_vendor_id": order.assigned_vendor_id,
         "delivery_date": order.delivery_date.isoformat() if order.delivery_date else None,
         "invoice_number": order.invoice_number,
         "origin_branch": order.origin_branch.value if order.origin_branch else None,
@@ -308,6 +309,7 @@ def create_order(db: Session, order_in: schemas.OrderCreate) -> models.Order:
         measurements=_measurements_to_dicts(order_in.measurements),
         notes=order_in.notes,
         assigned_tailor_id=order_in.assigned_tailor_id,
+        assigned_vendor_id=order_in.assigned_vendor_id,
         delivery_date=order_in.delivery_date,
         invoice_number=order_in.invoice_number,
         origin_branch=order_in.origin_branch,
@@ -338,6 +340,7 @@ def get_order(db: Session, order_id: int) -> Optional[models.Order]:
         db.query(models.Order)
         .options(
             joinedload(models.Order.assigned_tailor),
+            joinedload(models.Order.assigned_vendor),
             joinedload(models.Order.customer).joinedload(models.Customer.measurements),
         )
         .filter(models.Order.id == order_id)
@@ -377,6 +380,7 @@ def get_orders(
     items_query = (
         query.options(
             joinedload(models.Order.assigned_tailor),
+            joinedload(models.Order.assigned_vendor),
             joinedload(models.Order.customer).joinedload(models.Customer.measurements),
         )
         .order_by(models.Order.created_at.desc())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from .dependencies import (
     tailor_or_admin_required,
     vendor_or_admin_required,
 )
+from .migrations import apply_schema_upgrades
 
 settings = get_settings()
 
@@ -25,6 +26,7 @@ MAX_PAGE_SIZE = 200
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     Base.metadata.create_all(bind=engine)
+    apply_schema_upgrades(engine)
     yield
 
 
@@ -74,6 +76,27 @@ def _validate_assigned_tailor(
             detail="El usuario asignado no es un sastre",
         )
     return tailor
+
+
+def _validate_assigned_vendor(
+    db: Session, assigned_vendor_id: Optional[int]
+) -> Optional[models.User]:
+    """Ensure the provided vendor id exists and belongs to a vendor user."""
+
+    if assigned_vendor_id is None:
+        return None
+    vendor = crud.get_user(db, assigned_vendor_id)
+    if not vendor:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="El vendedor asignado no existe",
+        )
+    if vendor.role != models.UserRole.VENDEDOR:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="El usuario asignado no es un vendedor",
+        )
+    return vendor
 
 
 def _get_order_or_404(db: Session, order_id: int) -> models.Order:
@@ -149,6 +172,15 @@ def read_tailors(
 ):
     _ = current_user
     return crud.get_users(db, role=models.UserRole.SASTRE)
+
+
+@app.get("/users/vendors", response_model=List[schemas.UserOut])
+def read_vendors(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(vendor_or_admin_required()),
+):
+    _ = current_user
+    return crud.get_users(db, role=models.UserRole.VENDEDOR)
 
 
 @app.patch("/users/{user_id}", response_model=schemas.UserOut)
@@ -405,6 +437,14 @@ def create_order_endpoint(
     if order_data.get("customer_contact") in (None, ""):
         order_data["customer_contact"] = customer.phone
     _validate_assigned_tailor(db, order_data.get("assigned_tailor_id"))
+    assigned_vendor_id = order_data.get("assigned_vendor_id")
+    if assigned_vendor_id is None and current_user.role == models.UserRole.VENDEDOR:
+        assigned_vendor_id = current_user.id
+        order_data["assigned_vendor_id"] = assigned_vendor_id
+    else:
+        order_data["assigned_vendor_id"] = assigned_vendor_id
+    if order_data.get("assigned_vendor_id") is not None:
+        _validate_assigned_vendor(db, order_data["assigned_vendor_id"])
     order = crud.create_order(db, schemas.OrderCreate(**order_data))
     crud.create_audit_log(
         db,
@@ -453,6 +493,8 @@ def update_order_endpoint(
             update_data["customer_contact"] = new_customer.phone
     if "assigned_tailor_id" in update_data:
         _validate_assigned_tailor(db, update_data["assigned_tailor_id"])
+    if "assigned_vendor_id" in update_data:
+        _validate_assigned_vendor(db, update_data["assigned_vendor_id"])
     before = crud.serialize_order(order)
     updated_order = crud.update_order(db, order, schemas.OrderUpdate(**update_data))
     crud.create_audit_log(

--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -1,0 +1,41 @@
+"""Database schema utilities for lightweight upgrades."""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+
+
+def ensure_assigned_vendor_column(engine: Engine) -> None:
+    """Add the assigned_vendor_id column to orders if it is missing.
+
+    Existing installations created before vendor assignment support do not
+    include this column. The application now depends on it being present, so we
+    add it lazily during startup when the orders table already exists.
+    """
+
+    inspector = inspect(engine)
+    table_names = set(inspector.get_table_names())
+    if "orders" not in table_names:
+        return
+
+    column_names = {column["name"] for column in inspector.get_columns("orders")}
+    if "assigned_vendor_id" in column_names:
+        return
+
+    if engine.dialect.name == "sqlite":
+        ddl = "ALTER TABLE orders ADD COLUMN assigned_vendor_id INTEGER"
+    else:
+        ddl = (
+            "ALTER TABLE orders "
+            "ADD COLUMN assigned_vendor_id INTEGER REFERENCES users(id)"
+        )
+
+    with engine.begin() as connection:
+        connection.execute(text(ddl))
+
+
+def apply_schema_upgrades(engine: Engine) -> None:
+    """Apply idempotent schema upgrades required by the application."""
+
+    ensure_assigned_vendor_column(engine)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -58,6 +58,11 @@ class User(Base):
         back_populates="assigned_tailor",
         foreign_keys="Order.assigned_tailor_id",
     )
+    sales_orders = relationship(
+        "Order",
+        back_populates="assigned_vendor",
+        foreign_keys="Order.assigned_vendor_id",
+    )
 
 
 class Order(Base):
@@ -75,6 +80,7 @@ class Order(Base):
     measurements = Column(JSON, nullable=False, default=list)
     notes = Column(Text, nullable=True)
     assigned_tailor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    assigned_vendor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     delivery_date = Column(Date, nullable=True)
     origin_branch = Column(Enum(Establishment), nullable=True)
     invoice_number = Column(String(50), nullable=True)
@@ -86,7 +92,16 @@ class Order(Base):
         nullable=False,
     )
 
-    assigned_tailor = relationship("User", back_populates="assigned_orders")
+    assigned_tailor = relationship(
+        "User",
+        back_populates="assigned_orders",
+        foreign_keys=[assigned_tailor_id],
+    )
+    assigned_vendor = relationship(
+        "User",
+        back_populates="sales_orders",
+        foreign_keys=[assigned_vendor_id],
+    )
     customer = relationship("Customer", back_populates="orders")
     tasks = relationship(
         "OrderTask",

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -105,6 +105,7 @@ class OrderBase(BaseModel):
     measurements: List[MeasurementItem] = Field(default_factory=list)
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    assigned_vendor_id: Optional[int] = None
     delivery_date: Optional[date] = None
     invoice_number: Optional[str] = None
     origin_branch: Optional[Establishment] = None
@@ -129,6 +130,7 @@ class OrderUpdate(BaseModel):
     measurements: Optional[List[MeasurementItem]] = None
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
+    assigned_vendor_id: Optional[int] = None
     delivery_date: Optional[date] = None
     invoice_number: Optional[str] = None
     origin_branch: Optional[Establishment] = None
@@ -155,6 +157,7 @@ class OrderRead(OrderPublic):
     customer_contact: Optional[str]
     customer: Optional[CustomerSummary]
     assigned_tailor: Optional[UserOut]
+    assigned_vendor: Optional[UserOut]
     created_at: datetime
 
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine, inspect, text
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import migrations
+
+
+def create_legacy_schema(engine):
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY)"))
+        connection.execute(
+            text(
+                """
+                CREATE TABLE orders (
+                    id INTEGER PRIMARY KEY,
+                    order_number VARCHAR(50) NOT NULL,
+                    customer_id INTEGER NOT NULL,
+                    customer_name VARCHAR(100) NOT NULL,
+                    customer_document VARCHAR(50),
+                    customer_contact VARCHAR(255),
+                    status VARCHAR(50) NOT NULL,
+                    measurements TEXT NOT NULL,
+                    notes TEXT,
+                    assigned_tailor_id INTEGER,
+                    delivery_date DATE,
+                    origin_branch VARCHAR(50),
+                    invoice_number VARCHAR(50),
+                    created_at DATETIME NOT NULL,
+                    updated_at DATETIME NOT NULL
+                )
+                """
+            )
+        )
+
+
+def test_apply_schema_upgrades_adds_vendor_column(tmp_path):
+    database_path = tmp_path / "legacy.db"
+    engine = create_engine(f"sqlite:///{database_path}")
+    create_legacy_schema(engine)
+
+    inspector = inspect(engine)
+    column_names = {column["name"] for column in inspector.get_columns("orders")}
+    assert "assigned_vendor_id" not in column_names
+
+    migrations.apply_schema_upgrades(engine)
+
+    inspector = inspect(engine)
+    column_names = {column["name"] for column in inspector.get_columns("orders")}
+    assert "assigned_vendor_id" in column_names
+
+    # Running the upgrade again should be a no-op
+    migrations.apply_schema_upgrades(engine)
+    inspector = inspect(engine)
+    column_names = {column["name"] for column in inspector.get_columns("orders")}
+    assert "assigned_vendor_id" in column_names
+
+
+def test_apply_schema_upgrades_handles_missing_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'empty.db'}")
+    # Should not raise even if the orders table is absent
+    migrations.apply_schema_upgrades(engine)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -86,6 +86,14 @@
             <button
               type="button"
               class="dashboard-tab admin-only hidden"
+              data-tab="usersPanel"
+              id="usersTabButton"
+            >
+              Usuarios
+            </button>
+            <button
+              type="button"
+              class="dashboard-tab admin-only hidden"
               data-tab="auditLogPanel"
               id="auditLogTabButton"
             >
@@ -312,6 +320,12 @@
                   <option value="">Sin asignar</option>
                 </select>
               </div>
+              <div class="form-row">
+                <label for="assignVendor">Asignar a vendedor</label>
+                <select id="assignVendor">
+                  <option value="">Sin asignar</option>
+                </select>
+              </div>
               <button type="submit" class="primary">Guardar orden</button>
             </form>
           </section>
@@ -428,6 +442,10 @@
                   <select id="orderDetailTailor"></select>
                 </div>
                 <div class="form-row">
+                  <label for="orderDetailVendor">Vendedor asignado</label>
+                  <select id="orderDetailVendor"></select>
+                </div>
+                <div class="form-row">
                   <label for="orderDetailOrigin">Establecimiento remitente</label>
                   <select id="orderDetailOrigin"></select>
                 </div>
@@ -474,6 +492,23 @@
                   <button type="submit" class="primary">Guardar cambios</button>
                 </div>
               </form>
+            </div>
+          </section>
+
+          <section class="card dashboard-panel hidden" id="usersPanel">
+            <h3>Usuarios registrados</h3>
+            <p class="muted small">Consulta los usuarios autorizados y su rol dentro del sistema.</p>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Usuario</th>
+                    <th>Nombre completo</th>
+                    <th>Rol</th>
+                  </tr>
+                </thead>
+                <tbody id="usersTableBody"></tbody>
+              </table>
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- create a lightweight migrations module that adds the missing assigned_vendor_id column when the API starts
- invoke the schema upgrade hook during the FastAPI lifespan to prevent runtime failures on existing databases
- add regression tests that cover the upgrade behaviour and ensure it is idempotent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2f11ceb4c8332bb6c48488fd17263