### PR TITLE
Fix bcrypt version attribute compatibility

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import Optional
 
+import bcrypt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
@@ -13,6 +15,9 @@ from . import models, schemas
 from .timezone import now
 
 settings = get_settings()
+
+if not hasattr(bcrypt, "__about__"):
+    bcrypt.__about__ = SimpleNamespace(__version__=getattr(bcrypt, "__version__", ""))
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")


### PR DESCRIPTION
## Summary
- ensure the runtime bcrypt module exposes the __about__.__version__ attribute expected by passlib

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31ce649c48332b87b1b38e3b410bc