### PR TITLE
Add Kanban board for managing orders

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,6 +4,8 @@ const PAGE_SIZE_OPTIONS = [10, 15, 20, 25, 30, 35, 40, 45, 50];
 const ESTABLISHMENTS = ['Urdesa', 'Batan', 'Indie'];
 const ORDER_TASK_STATUS_PENDING = 'pendiente';
 const ORDER_TASK_STATUS_COMPLETED = 'completado';
+const KANBAN_FETCH_PAGE_SIZE = 100;
+const KANBAN_FALLBACK_STATUS = 'Sin estado';
 
 
 const state = {
@@ -25,6 +27,12 @@ const state = {
   orderPageSize: DEFAULT_PAGE_SIZE,
   customerTotal: 0,
   orderTotal: 0,
+  kanbanOrders: [],
+  kanbanLoading: false,
+  kanbanError: null,
+  kanbanSearchTerm: '',
+  kanbanNeedsRefresh: true,
+  kanbanLastUpdated: null,
   isCreateCustomerVisible: false,
   isCreateUserVisible: false,
   auditLogs: [],
@@ -97,6 +105,11 @@ const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
 const orderCreateTabButton = document.getElementById('orderCreateTabButton');
 const orderCreatePanel = document.getElementById('orderCreatePanel');
+const orderKanbanPanel = document.getElementById('orderKanbanPanel');
+const orderKanbanColumns = document.getElementById('orderKanbanColumns');
+const orderKanbanStatus = document.getElementById('orderKanbanStatus');
+const orderKanbanSearchInput = document.getElementById('orderKanbanSearchInput');
+const orderKanbanRefreshButton = document.getElementById('orderKanbanRefreshButton');
 const orderLookupForm = document.getElementById('orderLookupForm');
 const orderNumberInput = document.getElementById('orderNumber');
 const orderDocumentInput = document.getElementById('customerDocument');
@@ -314,6 +327,11 @@ function setActiveDashboardTab(tabId = 'orderListPanel') {
   });
   if (targetTab === 'usersPanel' && userRole === 'administrador') {
     loadUsers();
+  }
+  if (targetTab === 'orderKanbanPanel') {
+    ensureKanbanDataLoaded();
+  } else {
+    renderOrderKanban();
   }
   syncCreateOrderFormDisabled();
 }
@@ -1687,6 +1705,88 @@ async function loadOrders({ page, pageSize } = {}) {
   }
 }
 
+async function loadKanbanOrders({ force = false } = {}) {
+  if (!state.token) {
+    state.kanbanOrders = [];
+    state.kanbanLastUpdated = null;
+    state.kanbanNeedsRefresh = true;
+    renderOrderKanban();
+    return;
+  }
+
+  if (state.kanbanLoading) {
+    return;
+  }
+
+  if (!force && !state.kanbanNeedsRefresh && state.kanbanOrders.length) {
+    renderOrderKanban();
+    return;
+  }
+
+  state.kanbanLoading = true;
+  state.kanbanError = null;
+  renderOrderKanban();
+
+  const collected = [];
+  let page = 1;
+  let total = 0;
+
+  try {
+    while (true) {
+      const params = new URLSearchParams({
+        page: String(page),
+        page_size: String(KANBAN_FETCH_PAGE_SIZE),
+      });
+      const response = await apiFetch(`/orders?${params.toString()}`);
+      const items = Array.isArray(response?.items) ? response.items : [];
+      const reportedTotal = typeof response?.total === 'number' ? response.total : total;
+      if (reportedTotal) {
+        total = reportedTotal;
+      }
+      collected.push(...items);
+      if (collected.length >= total || !items.length) {
+        break;
+      }
+      page += 1;
+    }
+
+    state.kanbanOrders = collected;
+    state.kanbanLastUpdated = new Date().toISOString();
+    state.kanbanNeedsRefresh = false;
+    state.kanbanError = null;
+  } catch (error) {
+    state.kanbanError = error.message || 'No se pudieron cargar las órdenes.';
+    showToast(state.kanbanError, 'error');
+  } finally {
+    state.kanbanLoading = false;
+    renderOrderKanban();
+  }
+}
+
+function ensureKanbanDataLoaded() {
+  if (!state.token) {
+    renderOrderKanban();
+    return;
+  }
+  if (state.kanbanLoading) {
+    renderOrderKanban();
+    return;
+  }
+  if (state.kanbanNeedsRefresh || !state.kanbanOrders.length) {
+    loadKanbanOrders({ force: true });
+  } else {
+    renderOrderKanban();
+  }
+}
+
+function markKanbanDataStale() {
+  state.kanbanNeedsRefresh = true;
+  renderOrderKanban();
+  if (activeDashboardTab === 'orderKanbanPanel' && state.token && !state.kanbanLoading) {
+    loadKanbanOrders({ force: true });
+  }
+}
+
 async function loadCustomers({ page, pageSize } = {}) {
   if (!state.token) return null;
   const requestedPage = Number(page);
@@ -1876,6 +1976,12 @@ function handleLogout(auto = false) {
   state.orderPageSize = DEFAULT_PAGE_SIZE;
   state.customerTotal = 0;
   state.orderTotal = 0;
+  state.kanbanOrders = [];
+  state.kanbanLoading = false;
+  state.kanbanError = null;
+  state.kanbanSearchTerm = '';
+  state.kanbanNeedsRefresh = true;
+  state.kanbanLastUpdated = null;
   state.isCreateCustomerVisible = false;
   state.isCreateUserVisible = false;
   state.auditLogs = [];
@@ -1925,6 +2031,9 @@ function handleLogout(auto = false) {
   if (orderSearchInput) {
     orderSearchInput.value = '';
   }
+  if (orderKanbanSearchInput) {
+    orderKanbanSearchInput.value = '';
+  }
   if (customerPageSizeSelect) {
     customerPageSizeSelect.value = String(DEFAULT_PAGE_SIZE);
   }
@@ -1934,6 +2043,13 @@ function handleLogout(auto = false) {
   setCreateCustomerVisible(false);
   if (ordersTableBody) {
     ordersTableBody.innerHTML = '';
+  }
+  if (orderKanbanColumns) {
+    orderKanbanColumns.innerHTML = '';
+  }
+  if (orderKanbanStatus) {
+    orderKanbanStatus.textContent = '';
+    orderKanbanStatus.classList.add('hidden');
   }
   if (orderDetailVendorSelect) {
     populateVendorSelect(orderDetailVendorSelect);
@@ -1983,6 +2099,7 @@ function handleLogout(auto = false) {
   setActiveView('staff-view');
   renderUsers();
   renderOrderTasks();
+  renderOrderKanban();
   if (auto) {
     showToast('La sesión ha expirado, vuelve a iniciar sesión.', 'error');
   }
@@ -2591,6 +2708,7 @@ async function handleOrderUpdate(event) {
   const deliveryDateValueRaw = orderDetailDeliveryDateInput?.value || '';
   const deliveryDateValue = normalizeDateForApi(deliveryDateValueRaw);
   const invoiceValue = invoiceValueRaw || null;
+  let orderUpdatedSuccessfully = false;
   try {
     await apiFetch(`/orders/${state.selectedOrderId}`, {
       method: 'PATCH',
@@ -2609,6 +2727,7 @@ async function handleOrderUpdate(event) {
         origin_branch: originBranchValue,
       },
     });
+    orderUpdatedSuccessfully = true;
     if (affectedCustomerId) {
       delete state.customerOrdersCache[String(affectedCustomerId)];
       delete state.customerDisplayCache[String(affectedCustomerId)];
@@ -2628,6 +2747,9 @@ async function handleOrderUpdate(event) {
   } finally {
     if (submitButton) {
       submitButton.disabled = false;
+    }
+    if (orderUpdatedSuccessfully) {
+      markKanbanDataStale();
     }
   }
 }
@@ -2670,6 +2792,19 @@ if (orderSearchInput) {
     orderSearchDebounce = setTimeout(() => {
       loadOrders({ page: 1 });
     }, 250);
+  });
+}
+
+if (orderKanbanSearchInput) {
+  orderKanbanSearchInput.addEventListener('input', (event) => {
+    state.kanbanSearchTerm = event.target.value;
+    renderOrderKanban();
+  });
+}
+
+if (orderKanbanRefreshButton) {
+  orderKanbanRefreshButton.addEventListener('click', () => {
+    loadKanbanOrders({ force: true });
   });
 }
 
@@ -2930,6 +3065,7 @@ async function createOrder(event) {
   if (submitButton) {
     submitButton.disabled = true;
   }
+  let orderCreatedSuccessfully = false;
   try {
     await apiFetch('/orders', {
       method: 'POST',
@@ -2950,6 +3086,7 @@ async function createOrder(event) {
         tasks: orderTasks,
       },
     });
+    orderCreatedSuccessfully = true;
     delete state.customerOrdersCache[String(selectedCustomerId)];
     delete state.customerDisplayCache[String(selectedCustomerId)];
     await loadOrders();
@@ -2959,6 +3096,9 @@ async function createOrder(event) {
   } catch (error) {
     showToast(error.message, 'error');
   } finally {
+    if (orderCreatedSuccessfully) {
+      markKanbanDataStale();
+    }
     syncCreateOrderFormDisabled();
   }
 }
@@ -3203,6 +3343,257 @@ function updatePaginationControls({
   return normalizedPage;
 }
 
+
+function matchesKanbanSearch(order, normalizedSearch) {
+  if (!normalizedSearch) {
+    return true;
+  }
+  const searchableValues = [
+    order?.order_number,
+    order?.customer_name,
+    order?.customer_document,
+    order?.customer_contact,
+    order?.invoice_number,
+    order?.assigned_tailor?.full_name,
+    order?.assigned_vendor?.full_name,
+  ];
+  return searchableValues.some((value) => {
+    if (!value) return false;
+    return normalizeText(value).includes(normalizedSearch);
+  });
+}
+
+function createKanbanMetaItem(label, value) {
+  const item = document.createElement('div');
+  item.className = 'kanban-card-meta-item';
+  const labelElement = document.createElement('span');
+  labelElement.className = 'kanban-card-meta-label';
+  labelElement.textContent = `${label}:`;
+  const valueElement = document.createElement('span');
+  valueElement.className = 'kanban-card-meta-value';
+  valueElement.textContent = value || '—';
+  item.appendChild(labelElement);
+  item.appendChild(valueElement);
+  return item;
+}
+
+function createKanbanCard(order) {
+  const card = document.createElement('article');
+  card.className = 'kanban-card';
+  if (order?.id !== undefined && order?.id !== null) {
+    card.dataset.orderId = String(order.id);
+  }
+
+  const header = document.createElement('div');
+  header.className = 'kanban-card-header';
+  const orderNumber = document.createElement('span');
+  orderNumber.className = 'kanban-card-order';
+  orderNumber.textContent = order?.order_number || 'Sin número';
+  header.appendChild(orderNumber);
+  if (order?.status) {
+    header.appendChild(createStatusBadge(order.status));
+  }
+  card.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'kanban-card-body';
+  body.appendChild(createKanbanMetaItem('Cliente', order?.customer_name || '—'));
+  if (order?.customer_document) {
+    body.appendChild(createKanbanMetaItem('Documento', order.customer_document));
+  }
+  if (order?.assigned_tailor?.full_name) {
+    body.appendChild(createKanbanMetaItem('Sastre', order.assigned_tailor.full_name));
+  }
+  if (order?.assigned_vendor?.full_name) {
+    body.appendChild(createKanbanMetaItem('Vendedor', order.assigned_vendor.full_name));
+  }
+  card.appendChild(body);
+
+  const footer = document.createElement('div');
+  footer.className = 'kanban-card-footer';
+  const delivery = document.createElement('span');
+  delivery.className = 'kanban-card-delivery';
+  if (order?.delivery_date) {
+    delivery.textContent = formatDeliveryDateDisplay(order);
+    if (isDeliveryDateOverdue(order.delivery_date, order.status)) {
+      delivery.classList.add('overdue');
+    } else if (isDeliveryDateClose(order.delivery_date, order.status)) {
+      delivery.classList.add('due-soon');
+    }
+  } else {
+    delivery.textContent = 'Sin fecha de entrega';
+  }
+  footer.appendChild(delivery);
+
+  if (order?.updated_at) {
+    const updated = document.createElement('span');
+    updated.className = 'kanban-card-updated';
+    const time = document.createElement('time');
+    time.dateTime = order.updated_at;
+    time.textContent = formatDate(order.updated_at);
+    updated.textContent = 'Actualizado:';
+    updated.appendChild(document.createTextNode(' '));
+    updated.appendChild(time);
+    footer.appendChild(updated);
+  }
+
+  card.appendChild(footer);
+  return card;
+}
+
+function renderOrderKanban() {
+  if (!orderKanbanColumns) {
+    return;
+  }
+
+  if (orderKanbanSearchInput && orderKanbanSearchInput.value !== state.kanbanSearchTerm) {
+    orderKanbanSearchInput.value = state.kanbanSearchTerm;
+  }
+
+  orderKanbanColumns.innerHTML = '';
+  if (orderKanbanStatus) {
+    orderKanbanStatus.textContent = '';
+    orderKanbanStatus.classList.add('hidden');
+  }
+
+  if (!state.token) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = 'Inicia sesión para ver el tablero de órdenes.';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  if (state.kanbanLoading) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = 'Cargando tablero Kanban...';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  if (state.kanbanError) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = state.kanbanError;
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  const orders = Array.isArray(state.kanbanOrders) ? state.kanbanOrders : [];
+  if (!orders.length) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = state.kanbanNeedsRefresh
+        ? 'Carga el tablero para ver las órdenes registradas.'
+        : 'No hay órdenes registradas.';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  const normalizedSearch = normalizeText(state.kanbanSearchTerm);
+  const filteredOrders = normalizedSearch
+    ? orders.filter((order) => matchesKanbanSearch(order, normalizedSearch))
+    : orders;
+
+  if (!filteredOrders.length) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = 'No se encontraron órdenes que coincidan con la búsqueda actual.';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  const orderedStatuses = [];
+  const seenStatuses = new Set();
+
+  const appendStatus = (status) => {
+    const label = status && status.toString().trim() ? status : KANBAN_FALLBACK_STATUS;
+    if (!seenStatuses.has(label)) {
+      seenStatuses.add(label);
+      orderedStatuses.push(label);
+    }
+  };
+
+  if (Array.isArray(state.statuses) && state.statuses.length) {
+    state.statuses.forEach(appendStatus);
+  }
+  filteredOrders.forEach((order) => appendStatus(order?.status));
+
+  if (!seenStatuses.size) {
+    orderedStatuses.push(KANBAN_FALLBACK_STATUS);
+  }
+
+  const groupedByStatus = new Map();
+  orderedStatuses.forEach((status) => {
+    groupedByStatus.set(status, []);
+  });
+
+  filteredOrders.forEach((order) => {
+    const label = order?.status && order.status.toString().trim()
+      ? order.status
+      : KANBAN_FALLBACK_STATUS;
+    if (!groupedByStatus.has(label)) {
+      groupedByStatus.set(label, []);
+      orderedStatuses.push(label);
+    }
+    groupedByStatus.get(label).push(order);
+  });
+
+  orderedStatuses.forEach((status) => {
+    const column = document.createElement('section');
+    column.className = 'kanban-column';
+    column.dataset.status = status || KANBAN_FALLBACK_STATUS;
+
+    const header = document.createElement('div');
+    header.className = 'kanban-column-header';
+    const title = document.createElement('h4');
+    title.className = 'kanban-column-title';
+    title.textContent = status || KANBAN_FALLBACK_STATUS;
+    header.appendChild(title);
+
+    const count = document.createElement('span');
+    count.className = 'kanban-column-count';
+    const ordersForStatus = groupedByStatus.get(status) || [];
+    count.textContent = String(ordersForStatus.length);
+    header.appendChild(count);
+
+    column.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'kanban-column-body';
+
+    if (!ordersForStatus.length) {
+      body.classList.add('is-empty');
+      const emptyMessage = document.createElement('p');
+      emptyMessage.textContent = 'Sin órdenes en este estado.';
+      body.appendChild(emptyMessage);
+    } else {
+      ordersForStatus.sort(compareOrdersForDisplay).forEach((order) => {
+        body.appendChild(createKanbanCard(order));
+      });
+    }
+
+    column.appendChild(body);
+    orderKanbanColumns.appendChild(column);
+  });
+
+  if (orderKanbanStatus) {
+    const messages = [];
+    if (state.kanbanNeedsRefresh) {
+      messages.push('El tablero contiene información en caché. Actualízalo para ver los últimos cambios.');
+    }
+    if (state.kanbanLastUpdated) {
+      messages.push(`Última actualización: ${formatDate(state.kanbanLastUpdated)}.`);
+    }
+    if (messages.length) {
+      orderKanbanStatus.textContent = messages.join(' ');
+      orderKanbanStatus.classList.remove('hidden');
+    } else {
+      orderKanbanStatus.classList.add('hidden');
+    }
+  }
+}
 
 function renderOrders() {
   if (!ordersTableBody) return;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,6 +77,14 @@
             <button
               type="button"
               class="dashboard-tab"
+              data-tab="orderKanbanPanel"
+              id="orderKanbanTabButton"
+            >
+              Kanban de órdenes
+            </button>
+            <button
+              type="button"
+              class="dashboard-tab"
               data-tab="orderCreatePanel"
               id="orderCreateTabButton"
             >
@@ -493,6 +501,39 @@
                 </div>
               </form>
             </div>
+          </section>
+
+          <section class="card dashboard-panel hidden" id="orderKanbanPanel">
+            <div class="kanban-header">
+              <div>
+                <h3>Kanban de órdenes</h3>
+                <p class="muted small">
+                  Visualiza las órdenes agrupadas por estado y refresca el tablero para obtener los
+                  datos más recientes.
+                </p>
+              </div>
+              <div class="kanban-actions">
+                <button type="button" class="secondary" id="orderKanbanRefreshButton">
+                  Actualizar tablero
+                </button>
+              </div>
+            </div>
+            <div class="kanban-controls">
+              <div class="kanban-search">
+                <label for="orderKanbanSearchInput">Buscar</label>
+                <input
+                  type="search"
+                  id="orderKanbanSearchInput"
+                  placeholder="Número de orden, cliente o cédula"
+                  autocomplete="off"
+                />
+              </div>
+              <p class="muted small">
+                La búsqueda se aplica localmente sobre los resultados cargados en el tablero.
+              </p>
+            </div>
+            <div id="orderKanbanStatus" class="kanban-status muted hidden" aria-live="polite"></div>
+            <div id="orderKanbanColumns" class="kanban-board" aria-live="polite"></div>
           </section>
 
           <section class="card dashboard-panel hidden" id="usersPanel">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -750,6 +750,204 @@ button[disabled] {
   max-width: 48ch;
 }
 
+.kanban-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.kanban-header h3 {
+  margin-bottom: 0.25rem;
+}
+
+.kanban-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.kanban-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.kanban-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.kanban-search label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.kanban-search input {
+  width: min(280px, 100%);
+}
+
+.kanban-status {
+  margin-bottom: 1rem;
+}
+
+.kanban-board {
+  display: flex;
+  gap: 1rem;
+  align-items: stretch;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.kanban-column {
+  background: #f9fbfc;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  min-width: clamp(220px, 24vw, 280px);
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+
+.kanban-column-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.kanban-column-title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.kanban-column-count {
+  font-size: 0.9rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.kanban-column-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.kanban-column-body.is-empty {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.kanban-card {
+  background: white;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  box-shadow: 0 20px 45px rgba(15, 76, 92, 0.08);
+  border: 1px solid rgba(31, 122, 140, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.kanban-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.kanban-card-order {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--primary-dark);
+  word-break: break-word;
+}
+
+.kanban-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.kanban-card-meta-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  line-height: 1.4;
+}
+
+.kanban-card-meta-label {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.kanban-card-meta-value {
+  color: var(--text);
+}
+
+.kanban-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.kanban-card-delivery {
+  font-weight: 600;
+}
+
+.kanban-card-updated {
+  margin-left: auto;
+  font-size: 0.8rem;
+}
+
+.kanban-card-updated time {
+  font-style: normal;
+}
+
+@media (max-width: 768px) {
+  .kanban-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .kanban-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .kanban-actions button {
+    width: 100%;
+  }
+
+  .kanban-controls {
+    align-items: stretch;
+  }
+
+  .kanban-board {
+    padding-bottom: 1rem;
+  }
+}
+
 .order-search {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a Kanban-specific dashboard tab and panel to review orders grouped by status
- implement frontend state, fetching and rendering logic for the Kanban board with search and refresh support
- style the Kanban board with responsive layouts matching the existing dashboard aesthetics

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31f837bb083328e9eb9e86a2b2d56