### PR TITLE
Open Kanban orders in a dedicated detail page

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,6 +4,8 @@ const PAGE_SIZE_OPTIONS = [10, 15, 20, 25, 30, 35, 40, 45, 50];
 const ESTABLISHMENTS = ['Urdesa', 'Batan', 'Indie'];
 const ORDER_TASK_STATUS_PENDING = 'pendiente';
 const ORDER_TASK_STATUS_COMPLETED = 'completado';
+const KANBAN_FETCH_PAGE_SIZE = 100;
+const KANBAN_FALLBACK_STATUS = 'Sin estado';
 
 
 const state = {
@@ -25,6 +27,12 @@ const state = {
   orderPageSize: DEFAULT_PAGE_SIZE,
   customerTotal: 0,
   orderTotal: 0,
+  kanbanOrders: [],
+  kanbanLoading: false,
+  kanbanError: null,
+  kanbanSearchTerm: '',
+  kanbanNeedsRefresh: true,
+  kanbanLastUpdated: null,
   isCreateCustomerVisible: false,
   isCreateUserVisible: false,
   auditLogs: [],
@@ -97,6 +105,11 @@ const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
 const orderCreateTabButton = document.getElementById('orderCreateTabButton');
 const orderCreatePanel = document.getElementById('orderCreatePanel');
+const orderKanbanPanel = document.getElementById('orderKanbanPanel');
+const orderKanbanColumns = document.getElementById('orderKanbanColumns');
+const orderKanbanStatus = document.getElementById('orderKanbanStatus');
+const orderKanbanSearchInput = document.getElementById('orderKanbanSearchInput');
+const orderKanbanRefreshButton = document.getElementById('orderKanbanRefreshButton');
 const orderLookupForm = document.getElementById('orderLookupForm');
 const orderNumberInput = document.getElementById('orderNumber');
 const orderDocumentInput = document.getElementById('customerDocument');
@@ -314,6 +327,11 @@ function setActiveDashboardTab(tabId = 'orderListPanel') {
   });
   if (targetTab === 'usersPanel' && userRole === 'administrador') {
     loadUsers();
+  }
+  if (targetTab === 'orderKanbanPanel') {
+    ensureKanbanDataLoaded();
+  } else {
+    renderOrderKanban();
   }
   syncCreateOrderFormDisabled();
 }
@@ -1090,6 +1108,98 @@ function addMeasurementRow(data = { nombre: '', valor: '' }) {
   measurementsList.appendChild(row);
 }
 
+function highlightMeasurementRow(row) {
+  if (!row) return;
+  row.classList.add('is-highlighted');
+  setTimeout(() => {
+    row.classList.remove('is-highlighted');
+  }, 1500);
+}
+
+function ensureAvailableMeasurementSlot() {
+  if (!measurementsList) return;
+  const rows = Array.from(measurementsList.querySelectorAll('.measurement-row'));
+  const hasEmptyRow = rows.some((row) => {
+    const nameInput = row.querySelector('input[data-field="nombre"]');
+    const valueInput = row.querySelector('input[data-field="valor"]');
+    return (
+      nameInput &&
+      valueInput &&
+      !nameInput.value.trim() &&
+      !valueInput.value.trim()
+    );
+  });
+  if (!hasEmptyRow) {
+    addMeasurementRow();
+  }
+}
+
+function applyMeasurementToOrder(measurement) {
+  if (!measurementsList) {
+    return false;
+  }
+  if (!measurement) {
+    return false;
+  }
+  const nombreSource = measurement.nombre;
+  const valorSource = measurement.valor;
+  const nombre =
+    typeof nombreSource === 'string'
+      ? nombreSource.trim()
+      : nombreSource !== null && nombreSource !== undefined
+        ? nombreSource.toString().trim()
+        : '';
+  const valor =
+    typeof valorSource === 'string'
+      ? valorSource.trim()
+      : valorSource !== null && valorSource !== undefined
+        ? valorSource.toString().trim()
+        : '';
+  if (!nombre || !valor) {
+    return false;
+  }
+
+  const rows = Array.from(measurementsList.querySelectorAll('.measurement-row'));
+  let targetRow = rows.find((row) => {
+    const nameInput = row.querySelector('input[data-field="nombre"]');
+    const valueInput = row.querySelector('input[data-field="valor"]');
+    return (
+      nameInput &&
+      valueInput &&
+      !nameInput.value.trim() &&
+      !valueInput.value.trim()
+    );
+  });
+
+  if (!targetRow) {
+    addMeasurementRow({ nombre, valor });
+    targetRow = measurementsList.lastElementChild;
+  }
+
+  if (!targetRow) {
+    return false;
+  }
+
+  const nameInput = targetRow.querySelector('input[data-field="nombre"]');
+  const valueInput = targetRow.querySelector('input[data-field="valor"]');
+  if (!nameInput || !valueInput) {
+    return false;
+  }
+
+  nameInput.value = nombre;
+  valueInput.value = valor;
+
+  nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+  valueInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+  ensureAvailableMeasurementSlot();
+  highlightMeasurementRow(targetRow);
+  if (typeof targetRow.scrollIntoView === 'function') {
+    targetRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+  return true;
+}
+
 function ensureMeasurementRow() {
   if (measurementsList && measurementsList.children.length === 0) {
     addMeasurementRow();
@@ -1392,10 +1502,20 @@ function renderCustomerMeasurementOptions(customer) {
     tags.className = 'measurement-tags';
     if (set.measurements?.length) {
       set.measurements.forEach((item) => {
-        const tag = document.createElement('span');
-        tag.className = 'tag';
-        tag.textContent = `${item.nombre}: ${item.valor}`;
-        tags.appendChild(tag);
+        const tagButton = document.createElement('button');
+        tagButton.type = 'button';
+        tagButton.className = 'tag measurement-tag-button';
+        tagButton.textContent = `${item.nombre}: ${item.valor}`;
+        tagButton.title = 'Copiar esta medida a la orden';
+        tagButton.addEventListener('click', () => {
+          const applied = applyMeasurementToOrder(item);
+          if (applied) {
+            showToast(`Se copió la medida "${item.nombre}" a la orden.`, 'success');
+          } else {
+            showToast('No se pudo copiar la medida. Regístrala manualmente.', 'error');
+          }
+        });
+        tags.appendChild(tagButton);
       });
     } else {
       const empty = document.createElement('span');
@@ -1687,6 +1807,88 @@ async function loadOrders({ page, pageSize } = {}) {
   }
 }
 
+async function loadKanbanOrders({ force = false } = {}) {
+  if (!state.token) {
+    state.kanbanOrders = [];
+    state.kanbanLastUpdated = null;
+    state.kanbanNeedsRefresh = true;
+    renderOrderKanban();
+    return;
+  }
+
+  if (state.kanbanLoading) {
+    return;
+  }
+
+  if (!force && !state.kanbanNeedsRefresh && state.kanbanOrders.length) {
+    renderOrderKanban();
+    return;
+  }
+
+  state.kanbanLoading = true;
+  state.kanbanError = null;
+  renderOrderKanban();
+
+  const collected = [];
+  let page = 1;
+  let total = 0;
+
+  try {
+    while (true) {
+      const params = new URLSearchParams({
+        page: String(page),
+        page_size: String(KANBAN_FETCH_PAGE_SIZE),
+      });
+      const response = await apiFetch(`/orders?${params.toString()}`);
+      const items = Array.isArray(response?.items) ? response.items : [];
+      const reportedTotal = typeof response?.total === 'number' ? response.total : total;
+      if (reportedTotal) {
+        total = reportedTotal;
+      }
+      collected.push(...items);
+      if (collected.length >= total || !items.length) {
+        break;
+      }
+      page += 1;
+    }
+
+    state.kanbanOrders = collected;
+    state.kanbanLastUpdated = new Date().toISOString();
+    state.kanbanNeedsRefresh = false;
+    state.kanbanError = null;
+  } catch (error) {
+    state.kanbanError = error.message || 'No se pudieron cargar las órdenes.';
+    showToast(state.kanbanError, 'error');
+  } finally {
+    state.kanbanLoading = false;
+    renderOrderKanban();
+  }
+}
+
+function ensureKanbanDataLoaded() {
+  if (!state.token) {
+    renderOrderKanban();
+    return;
+  }
+  if (state.kanbanLoading) {
+    renderOrderKanban();
+    return;
+  }
+  if (state.kanbanNeedsRefresh || !state.kanbanOrders.length) {
+    loadKanbanOrders({ force: true });
+  } else {
+    renderOrderKanban();
+  }
+}
+
+function markKanbanDataStale() {
+  state.kanbanNeedsRefresh = true;
+  renderOrderKanban();
+  if (activeDashboardTab === 'orderKanbanPanel' && state.token && !state.kanbanLoading) {
+    loadKanbanOrders({ force: true });
+  }
+}
+
 async function loadCustomers({ page, pageSize } = {}) {
   if (!state.token) return null;
   const requestedPage = Number(page);
@@ -1876,6 +2078,12 @@ function handleLogout(auto = false) {
   state.orderPageSize = DEFAULT_PAGE_SIZE;
   state.customerTotal = 0;
   state.orderTotal = 0;
+  state.kanbanOrders = [];
+  state.kanbanLoading = false;
+  state.kanbanError = null;
+  state.kanbanSearchTerm = '';
+  state.kanbanNeedsRefresh = true;
+  state.kanbanLastUpdated = null;
   state.isCreateCustomerVisible = false;
   state.isCreateUserVisible = false;
   state.auditLogs = [];
@@ -1925,6 +2133,9 @@ function handleLogout(auto = false) {
   if (orderSearchInput) {
     orderSearchInput.value = '';
   }
+  if (orderKanbanSearchInput) {
+    orderKanbanSearchInput.value = '';
+  }
   if (customerPageSizeSelect) {
     customerPageSizeSelect.value = String(DEFAULT_PAGE_SIZE);
   }
@@ -1934,6 +2145,13 @@ function handleLogout(auto = false) {
   setCreateCustomerVisible(false);
   if (ordersTableBody) {
     ordersTableBody.innerHTML = '';
+  }
+  if (orderKanbanColumns) {
+    orderKanbanColumns.innerHTML = '';
+  }
+  if (orderKanbanStatus) {
+    orderKanbanStatus.textContent = '';
+    orderKanbanStatus.classList.add('hidden');
   }
   if (orderDetailVendorSelect) {
     populateVendorSelect(orderDetailVendorSelect);
@@ -1983,6 +2201,7 @@ function handleLogout(auto = false) {
   setActiveView('staff-view');
   renderUsers();
   renderOrderTasks();
+  renderOrderKanban();
   if (auto) {
     showToast('La sesión ha expirado, vuelve a iniciar sesión.', 'error');
   }
@@ -2591,6 +2810,7 @@ async function handleOrderUpdate(event) {
   const deliveryDateValueRaw = orderDetailDeliveryDateInput?.value || '';
   const deliveryDateValue = normalizeDateForApi(deliveryDateValueRaw);
   const invoiceValue = invoiceValueRaw || null;
+  let orderUpdatedSuccessfully = false;
   try {
     await apiFetch(`/orders/${state.selectedOrderId}`, {
       method: 'PATCH',
@@ -2609,6 +2829,7 @@ async function handleOrderUpdate(event) {
         origin_branch: originBranchValue,
       },
     });
+    orderUpdatedSuccessfully = true;
     if (affectedCustomerId) {
       delete state.customerOrdersCache[String(affectedCustomerId)];
       delete state.customerDisplayCache[String(affectedCustomerId)];
@@ -2628,6 +2849,9 @@ async function handleOrderUpdate(event) {
   } finally {
     if (submitButton) {
       submitButton.disabled = false;
+    }
+    if (orderUpdatedSuccessfully) {
+      markKanbanDataStale();
     }
   }
 }
@@ -2670,6 +2894,19 @@ if (orderSearchInput) {
     orderSearchDebounce = setTimeout(() => {
       loadOrders({ page: 1 });
     }, 250);
+  });
+}
+
+if (orderKanbanSearchInput) {
+  orderKanbanSearchInput.addEventListener('input', (event) => {
+    state.kanbanSearchTerm = event.target.value;
+    renderOrderKanban();
+  });
+}
+
+if (orderKanbanRefreshButton) {
+  orderKanbanRefreshButton.addEventListener('click', () => {
+    loadKanbanOrders({ force: true });
   });
 }
 
@@ -2930,6 +3167,7 @@ async function createOrder(event) {
   if (submitButton) {
     submitButton.disabled = true;
   }
+  let orderCreatedSuccessfully = false;
   try {
     await apiFetch('/orders', {
       method: 'POST',
@@ -2950,6 +3188,7 @@ async function createOrder(event) {
         tasks: orderTasks,
       },
     });
+    orderCreatedSuccessfully = true;
     delete state.customerOrdersCache[String(selectedCustomerId)];
     delete state.customerDisplayCache[String(selectedCustomerId)];
     await loadOrders();
@@ -2959,6 +3198,9 @@ async function createOrder(event) {
   } catch (error) {
     showToast(error.message, 'error');
   } finally {
+    if (orderCreatedSuccessfully) {
+      markKanbanDataStale();
+    }
     syncCreateOrderFormDisabled();
   }
 }
@@ -3203,6 +3445,296 @@ function updatePaginationControls({
   return normalizedPage;
 }
 
+
+function matchesKanbanSearch(order, normalizedSearch) {
+  if (!normalizedSearch) {
+    return true;
+  }
+  const searchableValues = [
+    order?.order_number,
+    order?.customer_name,
+    order?.customer_document,
+    order?.customer_contact,
+    order?.invoice_number,
+    order?.assigned_tailor?.full_name,
+    order?.assigned_vendor?.full_name,
+  ];
+  return searchableValues.some((value) => {
+    if (!value) return false;
+    return normalizeText(value).includes(normalizedSearch);
+  });
+}
+
+function createKanbanMetaItem(label, value) {
+  const item = document.createElement('div');
+  item.className = 'kanban-card-meta-item';
+  const labelElement = document.createElement('span');
+  labelElement.className = 'kanban-card-meta-label';
+  labelElement.textContent = `${label}:`;
+  const valueElement = document.createElement('span');
+  valueElement.className = 'kanban-card-meta-value';
+  valueElement.textContent = value || '—';
+  item.appendChild(labelElement);
+  item.appendChild(valueElement);
+  return item;
+}
+
+function getOrderDetailUrl(order) {
+  if (!order || order.id === undefined || order.id === null) {
+    return null;
+  }
+  if (typeof window === 'undefined' || typeof window.location === 'undefined') {
+    return `order.html?id=${encodeURIComponent(order.id)}`;
+  }
+  try {
+    const detailUrl = new URL('order.html', window.location.href);
+    detailUrl.searchParams.set('id', order.id);
+    if (order?.order_number) {
+      detailUrl.searchParams.set('number', order.order_number);
+    }
+    return detailUrl.toString();
+  } catch (error) {
+    let fallback = `order.html?id=${encodeURIComponent(order.id)}`;
+    if (order?.order_number) {
+      fallback += `&number=${encodeURIComponent(order.order_number)}`;
+    }
+    return fallback;
+  }
+}
+
+function createKanbanCard(order) {
+  const detailUrl = getOrderDetailUrl(order);
+  const card = detailUrl ? document.createElement('a') : document.createElement('article');
+  card.className = 'kanban-card';
+  if (order?.id !== undefined && order?.id !== null) {
+    card.dataset.orderId = String(order.id);
+  }
+  if (detailUrl) {
+    card.href = detailUrl;
+    card.target = '_blank';
+    card.rel = 'noopener noreferrer';
+    card.classList.add('is-clickable');
+    const labelParts = [];
+    if (order?.order_number) {
+      labelParts.push(`Orden ${order.order_number}`);
+    }
+    if (order?.customer_name) {
+      labelParts.push(order.customer_name);
+    }
+    card.setAttribute('aria-label', `Abrir detalle de ${labelParts.join(' · ') || 'la orden'}`);
+    card.title = 'Abrir información de la orden en una nueva pestaña';
+  }
+
+  const header = document.createElement('div');
+  header.className = 'kanban-card-header';
+  const orderNumber = document.createElement('span');
+  orderNumber.className = 'kanban-card-order';
+  orderNumber.textContent = order?.order_number || 'Sin número';
+  header.appendChild(orderNumber);
+  if (order?.status) {
+    header.appendChild(createStatusBadge(order.status));
+  }
+  card.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'kanban-card-body';
+  body.appendChild(createKanbanMetaItem('Cliente', order?.customer_name || '—'));
+  if (order?.customer_document) {
+    body.appendChild(createKanbanMetaItem('Documento', order.customer_document));
+  }
+  if (order?.assigned_tailor?.full_name) {
+    body.appendChild(createKanbanMetaItem('Sastre', order.assigned_tailor.full_name));
+  }
+  if (order?.assigned_vendor?.full_name) {
+    body.appendChild(createKanbanMetaItem('Vendedor', order.assigned_vendor.full_name));
+  }
+  card.appendChild(body);
+
+  const footer = document.createElement('div');
+  footer.className = 'kanban-card-footer';
+  const delivery = document.createElement('span');
+  delivery.className = 'kanban-card-delivery';
+  if (order?.delivery_date) {
+    delivery.textContent = formatDeliveryDateDisplay(order);
+    if (isDeliveryDateOverdue(order.delivery_date, order.status)) {
+      delivery.classList.add('overdue');
+    } else if (isDeliveryDateClose(order.delivery_date, order.status)) {
+      delivery.classList.add('due-soon');
+    }
+  } else {
+    delivery.textContent = 'Sin fecha de entrega';
+  }
+  footer.appendChild(delivery);
+
+  if (order?.updated_at) {
+    const updated = document.createElement('span');
+    updated.className = 'kanban-card-updated';
+    const time = document.createElement('time');
+    time.dateTime = order.updated_at;
+    time.textContent = formatDate(order.updated_at);
+    updated.textContent = 'Actualizado:';
+    updated.appendChild(document.createTextNode(' '));
+    updated.appendChild(time);
+    footer.appendChild(updated);
+  }
+
+  card.appendChild(footer);
+  return card;
+}
+
+function renderOrderKanban() {
+  if (!orderKanbanColumns) {
+    return;
+  }
+
+  if (orderKanbanSearchInput && orderKanbanSearchInput.value !== state.kanbanSearchTerm) {
+    orderKanbanSearchInput.value = state.kanbanSearchTerm;
+  }
+
+  orderKanbanColumns.innerHTML = '';
+  if (orderKanbanStatus) {
+    orderKanbanStatus.textContent = '';
+    orderKanbanStatus.classList.add('hidden');
+  }
+
+  if (!state.token) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = 'Inicia sesión para ver el tablero de órdenes.';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  if (state.kanbanLoading) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = 'Cargando tablero Kanban...';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  if (state.kanbanError) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = state.kanbanError;
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  const orders = Array.isArray(state.kanbanOrders) ? state.kanbanOrders : [];
+  if (!orders.length) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = state.kanbanNeedsRefresh
+        ? 'Carga el tablero para ver las órdenes registradas.'
+        : 'No hay órdenes registradas.';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  const normalizedSearch = normalizeText(state.kanbanSearchTerm);
+  const filteredOrders = normalizedSearch
+    ? orders.filter((order) => matchesKanbanSearch(order, normalizedSearch))
+    : orders;
+
+  if (!filteredOrders.length) {
+    if (orderKanbanStatus) {
+      orderKanbanStatus.textContent = 'No se encontraron órdenes que coincidan con la búsqueda actual.';
+      orderKanbanStatus.classList.remove('hidden');
+    }
+    return;
+  }
+
+  const orderedStatuses = [];
+  const seenStatuses = new Set();
+
+  const appendStatus = (status) => {
+    const label = status && status.toString().trim() ? status : KANBAN_FALLBACK_STATUS;
+    if (!seenStatuses.has(label)) {
+      seenStatuses.add(label);
+      orderedStatuses.push(label);
+    }
+  };
+
+  if (Array.isArray(state.statuses) && state.statuses.length) {
+    state.statuses.forEach(appendStatus);
+  }
+  filteredOrders.forEach((order) => appendStatus(order?.status));
+
+  if (!seenStatuses.size) {
+    orderedStatuses.push(KANBAN_FALLBACK_STATUS);
+  }
+
+  const groupedByStatus = new Map();
+  orderedStatuses.forEach((status) => {
+    groupedByStatus.set(status, []);
+  });
+
+  filteredOrders.forEach((order) => {
+    const label = order?.status && order.status.toString().trim()
+      ? order.status
+      : KANBAN_FALLBACK_STATUS;
+    if (!groupedByStatus.has(label)) {
+      groupedByStatus.set(label, []);
+      orderedStatuses.push(label);
+    }
+    groupedByStatus.get(label).push(order);
+  });
+
+  orderedStatuses.forEach((status) => {
+    const column = document.createElement('section');
+    column.className = 'kanban-column';
+    column.dataset.status = status || KANBAN_FALLBACK_STATUS;
+
+    const header = document.createElement('div');
+    header.className = 'kanban-column-header';
+    const title = document.createElement('h4');
+    title.className = 'kanban-column-title';
+    title.textContent = status || KANBAN_FALLBACK_STATUS;
+    header.appendChild(title);
+
+    const count = document.createElement('span');
+    count.className = 'kanban-column-count';
+    const ordersForStatus = groupedByStatus.get(status) || [];
+    count.textContent = String(ordersForStatus.length);
+    header.appendChild(count);
+
+    column.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'kanban-column-body';
+
+    if (!ordersForStatus.length) {
+      body.classList.add('is-empty');
+      const emptyMessage = document.createElement('p');
+      emptyMessage.textContent = 'Sin órdenes en este estado.';
+      body.appendChild(emptyMessage);
+    } else {
+      ordersForStatus.sort(compareOrdersForDisplay).forEach((order) => {
+        body.appendChild(createKanbanCard(order));
+      });
+    }
+
+    column.appendChild(body);
+    orderKanbanColumns.appendChild(column);
+  });
+
+  if (orderKanbanStatus) {
+    const messages = [];
+    if (state.kanbanNeedsRefresh) {
+      messages.push('El tablero contiene información en caché. Actualízalo para ver los últimos cambios.');
+    }
+    if (state.kanbanLastUpdated) {
+      messages.push(`Última actualización: ${formatDate(state.kanbanLastUpdated)}.`);
+    }
+    if (messages.length) {
+      orderKanbanStatus.textContent = messages.join(' ');
+      orderKanbanStatus.classList.remove('hidden');
+    } else {
+      orderKanbanStatus.classList.add('hidden');
+    }
+  }
+}
 
 function renderOrders() {
   if (!ordersTableBody) return;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,6 +77,14 @@
             <button
               type="button"
               class="dashboard-tab"
+              data-tab="orderKanbanPanel"
+              id="orderKanbanTabButton"
+            >
+              Kanban de órdenes
+            </button>
+            <button
+              type="button"
+              class="dashboard-tab"
               data-tab="orderCreatePanel"
               id="orderCreateTabButton"
             >
@@ -493,6 +501,39 @@
                 </div>
               </form>
             </div>
+          </section>
+
+          <section class="card dashboard-panel hidden" id="orderKanbanPanel">
+            <div class="kanban-header">
+              <div>
+                <h3>Kanban de órdenes</h3>
+                <p class="muted small">
+                  Visualiza las órdenes agrupadas por estado y refresca el tablero para obtener los
+                  datos más recientes.
+                </p>
+              </div>
+              <div class="kanban-actions">
+                <button type="button" class="secondary" id="orderKanbanRefreshButton">
+                  Actualizar tablero
+                </button>
+              </div>
+            </div>
+            <div class="kanban-controls">
+              <div class="kanban-search">
+                <label for="orderKanbanSearchInput">Buscar</label>
+                <input
+                  type="search"
+                  id="orderKanbanSearchInput"
+                  placeholder="Número de orden, cliente o cédula"
+                  autocomplete="off"
+                />
+              </div>
+              <p class="muted small">
+                La búsqueda se aplica localmente sobre los resultados cargados en el tablero.
+              </p>
+            </div>
+            <div id="orderKanbanStatus" class="kanban-status muted hidden" aria-live="polite"></div>
+            <div id="orderKanbanColumns" class="kanban-board" aria-live="polite"></div>
           </section>
 
           <section class="card dashboard-panel hidden" id="usersPanel">

--- a/frontend/order-detail.js
+++ b/frontend/order-detail.js
@@ -1,0 +1,560 @@
+const API_BASE_URL = window.API_BASE_URL || 'http://localhost:8000';
+const TOKEN_STORAGE_KEY = 'sastreria.authToken';
+const ORDER_TASK_STATUS_PENDING = 'pendiente';
+const ORDER_TASK_STATUS_COMPLETED = 'completado';
+
+const headingNumberElement = document.getElementById('orderHeadingNumber');
+const headingCreatedElement = document.getElementById('orderHeadingCreated');
+const headingUpdatedElement = document.getElementById('orderHeadingUpdated');
+const headingStatusElement = document.getElementById('orderHeadingStatus');
+const statusMessageElement = document.getElementById('orderDetailStatusMessage');
+const contentElement = document.getElementById('orderDetailContent');
+const summaryCustomerElement = document.getElementById('orderSummaryCustomer');
+const summaryDocumentElement = document.getElementById('orderSummaryDocument');
+const summaryContactElement = document.getElementById('orderSummaryContact');
+const summaryInvoiceElement = document.getElementById('orderSummaryInvoice');
+const summaryOriginElement = document.getElementById('orderSummaryOrigin');
+const summaryDeliveryElement = document.getElementById('orderSummaryDelivery');
+const summaryTailorElement = document.getElementById('orderSummaryTailor');
+const summaryVendorElement = document.getElementById('orderSummaryVendor');
+const notesElement = document.getElementById('orderDetailNotes');
+const measurementsElement = document.getElementById('orderDetailMeasurements');
+const tasksContainerElement = document.getElementById('orderDetailTasks');
+const currentYearElement = document.getElementById('currentYear');
+
+function setCurrentYear() {
+  if (currentYearElement) {
+    currentYearElement.textContent = String(new Date().getFullYear());
+  }
+}
+
+function readStoredToken() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+  try {
+    const storedToken = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (typeof storedToken !== 'string') {
+      return null;
+    }
+    const trimmed = storedToken.trim();
+    return trimmed ? trimmed : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function parseOrderId() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const rawId = params.get('id');
+  if (!rawId) {
+    return null;
+  }
+  const numericId = Number(rawId);
+  return Number.isFinite(numericId) && numericId > 0 ? numericId : null;
+}
+
+function applyInitialOrderNumberFromQuery() {
+  if (typeof window === 'undefined' || !headingNumberElement) {
+    return;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const orderNumber = params.get('number');
+  if (orderNumber) {
+    headingNumberElement.textContent = orderNumber;
+    document.title = `Orden ${orderNumber} | Portal de Sastrería`;
+  }
+}
+
+function setStatusMessage(message, type = 'info') {
+  if (!statusMessageElement) {
+    return;
+  }
+  const normalizedMessage = message ? message.toString().trim() : '';
+  statusMessageElement.classList.remove('loading', 'error', 'success');
+  if (!normalizedMessage) {
+    statusMessageElement.textContent = '';
+    statusMessageElement.classList.add('hidden');
+    return;
+  }
+  statusMessageElement.textContent = normalizedMessage;
+  statusMessageElement.classList.remove('hidden');
+  if (type === 'loading') {
+    statusMessageElement.classList.add('loading');
+  } else if (type === 'error') {
+    statusMessageElement.classList.add('error');
+  } else if (type === 'success') {
+    statusMessageElement.classList.add('success');
+  }
+}
+
+function clearStatusMessage() {
+  setStatusMessage('');
+}
+
+function showContent() {
+  if (contentElement) {
+    contentElement.classList.remove('hidden');
+  }
+}
+
+function hideContent() {
+  if (contentElement) {
+    contentElement.classList.add('hidden');
+  }
+}
+
+function formatDate(dateString) {
+  try {
+    return new Date(dateString).toLocaleString('es-EC', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+  } catch (error) {
+    return dateString || '';
+  }
+}
+
+function formatDateOnly(dateString) {
+  try {
+    return new Date(dateString).toLocaleDateString('es-EC', {
+      dateStyle: 'medium',
+    });
+  } catch (error) {
+    return dateString || '';
+  }
+}
+
+function hasExplicitTimeComponent(value) {
+  if (!value) {
+    return false;
+  }
+  if (value instanceof Date) {
+    return true;
+  }
+  if (typeof value === 'string') {
+    return /T\d{2}:\d{2}| \d{2}:\d{2}/.test(value);
+  }
+  return false;
+}
+
+function isOrderDelivered(status) {
+  return typeof status === 'string' && status.trim().toLowerCase() === 'entregado';
+}
+
+function formatDeliveryDateLabel(order) {
+  if (!order?.delivery_date) {
+    return '';
+  }
+  const deliveryValue = order.delivery_date;
+  if (hasExplicitTimeComponent(deliveryValue)) {
+    return formatDate(deliveryValue);
+  }
+  const dateLabel = formatDateOnly(deliveryValue);
+  if (isOrderDelivered(order.status) && order.updated_at) {
+    const updated = new Date(order.updated_at);
+    if (!Number.isNaN(updated.getTime())) {
+      const timeLabel = updated.toLocaleTimeString('es-EC', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return `${dateLabel} · ${timeLabel}`;
+    }
+  }
+  return dateLabel;
+}
+
+function getStatusBadgeVariant(status) {
+  if (!status) {
+    return 'neutral';
+  }
+  const normalized = status.toString().trim().toLowerCase();
+  if (!normalized) {
+    return 'neutral';
+  }
+  if (normalized.includes('entreg')) {
+    return 'success';
+  }
+  if (normalized.includes('cancel') || normalized.includes('anulad')) {
+    return 'danger';
+  }
+  if (normalized.includes('pend') || normalized.includes('espera')) {
+    return 'warning';
+  }
+  if (
+    normalized.includes('listo') ||
+    normalized.includes('termin') ||
+    normalized.includes('produc') ||
+    normalized.includes('proceso')
+  ) {
+    return 'info';
+  }
+  return 'neutral';
+}
+
+function createStatusBadgeElement(status) {
+  const badge = document.createElement('span');
+  badge.className = 'status-badge';
+  const text = status && status.toString().trim() ? status : 'Sin estado';
+  badge.textContent = text;
+  badge.classList.add(`status-${getStatusBadgeVariant(status)}`);
+  return badge;
+}
+
+function createTaskStatusBadge(status) {
+  const badge = document.createElement('span');
+  badge.className = 'status-badge';
+  const normalized = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  if (normalized === ORDER_TASK_STATUS_COMPLETED) {
+    badge.textContent = 'Completado';
+    badge.classList.add('status-success');
+  } else {
+    badge.textContent = 'Pendiente';
+    badge.classList.add('status-warning');
+  }
+  return badge;
+}
+
+function setSummaryField(element, value, fallback = '—') {
+  if (!element) {
+    return;
+  }
+  const normalized = value === null || value === undefined
+    ? ''
+    : value.toString().trim();
+  if (normalized) {
+    element.textContent = normalized;
+    element.classList.remove('muted');
+  } else {
+    element.textContent = fallback;
+    element.classList.add('muted');
+  }
+}
+
+function renderNotes(notes) {
+  if (!notesElement) return;
+  const normalized = typeof notes === 'string' ? notes.trim() : '';
+  if (normalized) {
+    notesElement.textContent = normalized;
+    notesElement.classList.remove('muted');
+  } else {
+    notesElement.textContent = 'Sin notas registradas.';
+    notesElement.classList.add('muted');
+  }
+}
+
+function renderMeasurements(measurements) {
+  if (!measurementsElement) return;
+  measurementsElement.innerHTML = '';
+  measurementsElement.classList.remove('muted');
+  if (!Array.isArray(measurements) || !measurements.length) {
+    measurementsElement.textContent = 'Sin medidas registradas.';
+    measurementsElement.classList.add('muted');
+    return;
+  }
+  measurements.forEach((measurement) => {
+    if (!measurement) return;
+    const nameValue = measurement.nombre;
+    const valueValue = measurement.valor;
+    const name =
+      typeof nameValue === 'string'
+        ? nameValue.trim()
+        : nameValue !== null && nameValue !== undefined
+          ? nameValue.toString().trim()
+          : '';
+    const value =
+      typeof valueValue === 'string'
+        ? valueValue.trim()
+        : valueValue !== null && valueValue !== undefined
+          ? valueValue.toString().trim()
+          : '';
+    if (!name && !value) {
+      return;
+    }
+    const tag = document.createElement('span');
+    tag.className = 'tag';
+    const label = name && value ? `${name}: ${value}` : name || value;
+    tag.textContent = label;
+    measurementsElement.appendChild(tag);
+  });
+  if (!measurementsElement.children.length) {
+    measurementsElement.textContent = 'Sin medidas registradas.';
+    measurementsElement.classList.add('muted');
+  }
+}
+
+function getTimeValue(value) {
+  if (!value) return 0;
+  const date = new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function sortTasks(tasks) {
+  return [...tasks].sort((a, b) => {
+    const priority = (task) =>
+      typeof task?.status === 'string' && task.status.trim().toLowerCase() === ORDER_TASK_STATUS_COMPLETED
+        ? 1
+        : 0;
+    const priorityDiff = priority(a) - priority(b);
+    if (priorityDiff !== 0) {
+      return priorityDiff;
+    }
+    return getTimeValue(a?.created_at) - getTimeValue(b?.created_at);
+  });
+}
+
+function renderTasks(tasks, { loading = false, error = null } = {}) {
+  if (!tasksContainerElement) return;
+  tasksContainerElement.innerHTML = '';
+  tasksContainerElement.classList.remove('muted', 'order-detail-error');
+  if (loading) {
+    tasksContainerElement.textContent = 'Cargando checklist de producción...';
+    tasksContainerElement.classList.add('muted');
+    return;
+  }
+  if (error) {
+    tasksContainerElement.textContent = error;
+    tasksContainerElement.classList.add('order-detail-error');
+    return;
+  }
+  if (!Array.isArray(tasks) || !tasks.length) {
+    tasksContainerElement.textContent = 'No hay tareas registradas para esta orden.';
+    tasksContainerElement.classList.add('muted');
+    return;
+  }
+  const list = document.createElement('ul');
+  list.className = 'order-detail-task-list';
+  sortTasks(tasks).forEach((task) => {
+    const item = document.createElement('li');
+    item.className = 'order-detail-task';
+    const normalizedStatus = typeof task?.status === 'string' ? task.status.trim().toLowerCase() : '';
+    if (normalizedStatus === ORDER_TASK_STATUS_COMPLETED) {
+      item.classList.add('is-completed');
+    } else {
+      item.classList.add('is-pending');
+    }
+
+    const header = document.createElement('div');
+    header.className = 'order-detail-task-header';
+    header.appendChild(createTaskStatusBadge(task?.status));
+    if (task?.updated_at) {
+      const updated = document.createElement('span');
+      updated.className = 'order-detail-task-meta';
+      updated.textContent = `Actualizado: ${formatDate(task.updated_at)}`;
+      header.appendChild(updated);
+    }
+    item.appendChild(header);
+
+    const description = document.createElement('p');
+    description.className = 'order-detail-task-description';
+    description.textContent = task?.description?.trim()
+      ? task.description.trim()
+      : 'Sin descripción registrada.';
+    item.appendChild(description);
+
+    const metaParts = [];
+    if (task?.responsible?.full_name) {
+      metaParts.push(`Responsable: ${task.responsible.full_name}`);
+    }
+    if (task?.created_at) {
+      metaParts.push(`Creada: ${formatDate(task.created_at)}`);
+    }
+    if (metaParts.length) {
+      const meta = document.createElement('p');
+      meta.className = 'order-detail-task-meta';
+      meta.textContent = metaParts.join(' • ');
+      item.appendChild(meta);
+    }
+
+    list.appendChild(item);
+  });
+  tasksContainerElement.appendChild(list);
+}
+
+function updateDocumentTitle(order) {
+  if (!order) {
+    document.title = 'Detalle de la orden | Portal de Sastrería';
+    return;
+  }
+  const number = order.order_number || (order.id ? `#${order.id}` : '');
+  if (number) {
+    document.title = `Orden ${number} | Portal de Sastrería`;
+  } else {
+    document.title = 'Detalle de la orden | Portal de Sastrería';
+  }
+}
+
+function renderOrder(order) {
+  if (!order) {
+    return;
+  }
+  updateDocumentTitle(order);
+  const orderNumber = order.order_number || (order.id ? `#${order.id}` : '—');
+  if (headingNumberElement) {
+    headingNumberElement.textContent = orderNumber;
+  }
+  if (headingCreatedElement) {
+    setSummaryField(headingCreatedElement, order.created_at ? formatDate(order.created_at) : '', '—');
+  }
+  if (headingUpdatedElement) {
+    setSummaryField(headingUpdatedElement, order.updated_at ? formatDate(order.updated_at) : '', '—');
+  }
+  if (headingStatusElement) {
+    headingStatusElement.innerHTML = '';
+    headingStatusElement.appendChild(createStatusBadgeElement(order.status));
+  }
+
+  setSummaryField(summaryCustomerElement, order.customer_name || '', 'Sin registrar');
+  setSummaryField(summaryDocumentElement, order.customer_document || '', 'Sin registrar');
+  setSummaryField(summaryContactElement, order.customer_contact || '', 'Sin registrar');
+  setSummaryField(summaryInvoiceElement, order.invoice_number || '', 'Sin número registrado');
+  setSummaryField(summaryOriginElement, order.origin_branch || '', 'Sin definir');
+  const deliveryLabel = formatDeliveryDateLabel(order);
+  setSummaryField(summaryDeliveryElement, deliveryLabel || '', 'Sin fecha de entrega');
+  setSummaryField(
+    summaryTailorElement,
+    order.assigned_tailor?.full_name || '',
+    'Sin asignar'
+  );
+  setSummaryField(
+    summaryVendorElement,
+    order.assigned_vendor?.full_name || '',
+    'Sin asignar'
+  );
+
+  renderNotes(order.notes);
+  renderMeasurements(order.measurements);
+}
+
+function extractErrorMessage(data) {
+  if (!data) {
+    return '';
+  }
+  if (Array.isArray(data.detail)) {
+    return data.detail
+      .map((item) => {
+        if (item?.msg) return item.msg;
+        if (item?.detail) return item.detail;
+        if (item?.message) return item.message;
+        if (typeof item === 'string') return item;
+        try {
+          return JSON.stringify(item);
+        } catch (error) {
+          return '';
+        }
+      })
+      .filter(Boolean)
+      .join(' ');
+  }
+  if (typeof data.detail === 'string') {
+    return data.detail;
+  }
+  if (data.detail?.msg) {
+    return data.detail.msg;
+  }
+  if (data.detail?.message) {
+    return data.detail.message;
+  }
+  if (typeof data.message === 'string') {
+    return data.message;
+  }
+  if (typeof data === 'string') {
+    return data;
+  }
+  return '';
+}
+
+async function fetchWithAuth(path, token) {
+  const headers = { Accept: 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  let response;
+  try {
+    response = await fetch(`${API_BASE_URL}${path}`, { headers });
+  } catch (networkError) {
+    throw new Error('No se pudo conectar con el servidor. Intenta nuevamente.');
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  const contentType = response.headers.get('content-type') || '';
+  let data = null;
+  if (contentType.includes('application/json')) {
+    try {
+      data = await response.json();
+    } catch (parseError) {
+      data = null;
+    }
+  } else {
+    data = await response.text();
+  }
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Tu sesión ha expirado. Inicia sesión nuevamente.');
+    }
+    if (response.status === 404) {
+      throw new Error('No encontramos la orden solicitada.');
+    }
+    const message = extractErrorMessage(data) || 'Error al cargar la información.';
+    throw new Error(message);
+  }
+  return data;
+}
+
+async function fetchOrder(orderId, token) {
+  return fetchWithAuth(`/orders/${orderId}`, token);
+}
+
+async function fetchOrderTasks(orderId, token) {
+  const data = await fetchWithAuth(`/orders/${orderId}/tasks`, token);
+  return Array.isArray(data) ? data : [];
+}
+
+async function loadOrderDetails(orderId, token) {
+  setStatusMessage('Cargando información de la orden...', 'loading');
+  try {
+    const order = await fetchOrder(orderId, token);
+    if (!order) {
+      throw new Error('No se pudo cargar la información de la orden.');
+    }
+    renderOrder(order);
+    showContent();
+    clearStatusMessage();
+    try {
+      renderTasks([], { loading: true });
+      const tasks = await fetchOrderTasks(orderId, token);
+      renderTasks(tasks);
+    } catch (taskError) {
+      renderTasks([], { error: taskError.message || 'No se pudo cargar el checklist.' });
+    }
+  } catch (error) {
+    hideContent();
+    setStatusMessage(error.message || 'No se pudo cargar la información de la orden.', 'error');
+  }
+}
+
+function initialise() {
+  setCurrentYear();
+  applyInitialOrderNumberFromQuery();
+  const orderId = parseOrderId();
+  if (!orderId) {
+    setStatusMessage(
+      'No se especificó una orden válida. Regresa al panel y selecciona una orden.',
+      'error'
+    );
+    return;
+  }
+  const token = readStoredToken();
+  if (!token) {
+    setStatusMessage('Inicia sesión en el panel para ver la información de la orden.', 'error');
+    return;
+  }
+  loadOrderDetails(orderId, token);
+}
+
+initialise();

--- a/frontend/order.html
+++ b/frontend/order.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Detalle de la orden | Portal de Sastrería</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="container order-detail-top">
+        <h1>Portal de Sastrería</h1>
+        <a class="link-button" href="index.html">Volver al panel</a>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="card order-detail-card">
+        <div class="order-detail-page-header">
+          <div class="order-detail-heading">
+            <h2>
+              Orden <span id="orderHeadingNumber" class="order-detail-number">—</span>
+            </h2>
+            <p class="muted small">
+              Registrada: <span id="orderHeadingCreated">—</span>
+              · Última actualización: <span id="orderHeadingUpdated">—</span>
+            </p>
+          </div>
+          <div id="orderHeadingStatus" class="order-detail-status"></div>
+        </div>
+
+        <div
+          id="orderDetailStatusMessage"
+          class="order-detail-status-message hidden"
+          role="status"
+          aria-live="polite"
+        ></div>
+
+        <div id="orderDetailContent" class="order-detail-content hidden">
+          <section class="order-detail-section">
+            <h3>Resumen de la orden</h3>
+            <dl class="order-detail-summary-grid">
+              <div class="order-detail-summary-item">
+                <dt>Cliente</dt>
+                <dd id="orderSummaryCustomer">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Documento</dt>
+                <dd id="orderSummaryDocument">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Contacto</dt>
+                <dd id="orderSummaryContact">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Factura</dt>
+                <dd id="orderSummaryInvoice">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Establecimiento</dt>
+                <dd id="orderSummaryOrigin">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Fecha de entrega</dt>
+                <dd id="orderSummaryDelivery">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Sastre asignado</dt>
+                <dd id="orderSummaryTailor">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Vendedor asignado</dt>
+                <dd id="orderSummaryVendor">—</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section class="order-detail-section">
+            <h3>Notas</h3>
+            <p id="orderDetailNotes" class="order-detail-notes muted">
+              Sin notas registradas.
+            </p>
+          </section>
+
+          <section class="order-detail-section">
+            <h3>Medidas registradas</h3>
+            <div id="orderDetailMeasurements" class="measurement-tags muted">
+              Sin medidas registradas.
+            </div>
+          </section>
+
+          <section class="order-detail-section">
+            <h3>Checklist de producción</h3>
+            <div id="orderDetailTasks" class="order-detail-task-container muted">
+              Cargando checklist de producción...
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="container footer">
+      <small>
+        © <span id="currentYear"></span> Portal de Sastrería. Todos los derechos reservados.
+      </small>
+    </footer>
+
+    <script src="order-detail.js"></script>
+  </body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -253,6 +253,18 @@ button.link-button:hover {
   color: var(--primary);
 }
 
+a.link-button {
+  color: var(--primary-dark);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+}
+
+a.link-button:hover {
+  color: var(--primary);
+}
+
 button[disabled] {
   opacity: 0.6;
   cursor: not-allowed;
@@ -730,6 +742,193 @@ button[disabled] {
   margin-top: 0;
 }
 
+.order-detail-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-top h1 {
+  font-size: 1.6rem;
+  margin: 0;
+}
+
+.order-detail-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-detail-heading h2 {
+  margin: 0;
+}
+
+.order-detail-heading .muted {
+  margin: 0;
+}
+
+.order-detail-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-status-message {
+  margin-top: 1.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: #f1f5f9;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.order-detail-status-message.loading {
+  background: rgba(31, 122, 140, 0.12);
+  color: var(--primary-dark);
+}
+
+.order-detail-status-message.error {
+  background: rgba(197, 48, 48, 0.12);
+  color: var(--danger);
+}
+
+.order-detail-status-message.success {
+  background: rgba(47, 133, 90, 0.14);
+  color: var(--success);
+}
+
+.order-detail-content {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.order-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-detail-section h3 {
+  margin: 0;
+}
+
+.order-detail-summary-grid {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.order-detail-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-detail-summary-item dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+}
+
+.order-detail-summary-item dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.order-detail-notes {
+  margin: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.order-detail-task-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-detail-task-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-detail-task {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-detail-task.is-completed {
+  border-color: rgba(47, 133, 90, 0.35);
+  background: rgba(47, 133, 90, 0.08);
+}
+
+.order-detail-task.is-pending {
+  border-color: rgba(255, 127, 80, 0.35);
+  background: rgba(255, 127, 80, 0.08);
+}
+
+.order-detail-task-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-task-description {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.order-detail-task-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .order-detail-summary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .button-row {
   display: flex;
   flex-wrap: wrap;
@@ -748,6 +947,223 @@ button[disabled] {
 .order-panel-controls p {
   margin: 0;
   max-width: 48ch;
+}
+
+.kanban-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.kanban-header h3 {
+  margin-bottom: 0.25rem;
+}
+
+.kanban-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.kanban-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.kanban-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.kanban-search label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.kanban-search input {
+  width: min(280px, 100%);
+}
+
+.kanban-status {
+  margin-bottom: 1rem;
+}
+
+.kanban-board {
+  display: flex;
+  gap: 1rem;
+  align-items: stretch;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.kanban-column {
+  background: #f9fbfc;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  min-width: clamp(220px, 24vw, 280px);
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+
+.kanban-column-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.kanban-column-title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.kanban-column-count {
+  font-size: 0.9rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.kanban-column-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.kanban-column-body.is-empty {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.kanban-card {
+  background: white;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  box-shadow: 0 20px 45px rgba(15, 76, 92, 0.08);
+  border: 1px solid rgba(31, 122, 140, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.kanban-card.is-clickable {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.kanban-card.is-clickable:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 48px rgba(15, 76, 92, 0.12);
+}
+
+.kanban-card.is-clickable:focus-visible {
+  outline: 3px solid rgba(31, 122, 140, 0.35);
+  outline-offset: 3px;
+  transform: translateY(-2px);
+  box-shadow: 0 20px 52px rgba(15, 76, 92, 0.16);
+}
+
+.kanban-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.kanban-card-order {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--primary-dark);
+  word-break: break-word;
+}
+
+.kanban-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.kanban-card-meta-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  line-height: 1.4;
+}
+
+.kanban-card-meta-label {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.kanban-card-meta-value {
+  color: var(--text);
+}
+
+.kanban-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.kanban-card-delivery {
+  font-weight: 600;
+}
+
+.kanban-card-updated {
+  margin-left: auto;
+  font-size: 0.8rem;
+}
+
+.kanban-card-updated time {
+  font-style: normal;
+}
+
+@media (max-width: 768px) {
+  .kanban-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .kanban-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .kanban-actions button {
+    width: 100%;
+  }
+
+  .kanban-controls {
+    align-items: stretch;
+  }
+
+  .kanban-board {
+    padding-bottom: 1rem;
+  }
 }
 
 .order-search {
@@ -1010,6 +1426,43 @@ th {
 
 .measurement-row button {
   border: none;
+}
+
+.measurement-row.is-highlighted {
+  animation: measurementRowFlash 1.5s ease-out;
+  border-radius: 12px;
+}
+
+@keyframes measurementRowFlash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(15, 76, 92, 0.45);
+  }
+  60% {
+    box-shadow: 0 0 0 9px rgba(15, 76, 92, 0);
+  }
+  100% {
+    box-shadow: none;
+  }
+}
+
+.measurement-tag-button {
+  border: none;
+  background: rgba(31, 122, 140, 0.12);
+  color: var(--primary-dark);
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.measurement-tag-button:hover {
+  background: rgba(31, 122, 140, 0.24);
+  transform: translateY(-1px);
+}
+
+.measurement-tag-button:focus-visible {
+  outline: 3px solid rgba(31, 122, 140, 0.35);
+  outline-offset: 2px;
+  background: rgba(31, 122, 140, 0.26);
 }
 
 .order-task-input-label {


### PR DESCRIPTION
## Summary
- make Kanban cards open a standalone order detail page and style them as interactive links
- allow copying individual saved measurements into the create-order form with visual feedback
- add an external order detail view that fetches and renders full order information, notes, measurements, and checklist items

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31f837bb083328e9eb9e86a2b2d56