### PR TITLE
Allow editing orders from the detail view and trim delivered Kanban records

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,6 +77,14 @@
             <button
               type="button"
               class="dashboard-tab"
+              data-tab="orderKanbanPanel"
+              id="orderKanbanTabButton"
+            >
+              Kanban de órdenes
+            </button>
+            <button
+              type="button"
+              class="dashboard-tab"
               data-tab="orderCreatePanel"
               id="orderCreateTabButton"
             >
@@ -493,6 +501,39 @@
                 </div>
               </form>
             </div>
+          </section>
+
+          <section class="card dashboard-panel hidden" id="orderKanbanPanel">
+            <div class="kanban-header">
+              <div>
+                <h3>Kanban de órdenes</h3>
+                <p class="muted small">
+                  Visualiza las órdenes agrupadas por estado y refresca el tablero para obtener los
+                  datos más recientes.
+                </p>
+              </div>
+              <div class="kanban-actions">
+                <button type="button" class="secondary" id="orderKanbanRefreshButton">
+                  Actualizar tablero
+                </button>
+              </div>
+            </div>
+            <div class="kanban-controls">
+              <div class="kanban-search">
+                <label for="orderKanbanSearchInput">Buscar</label>
+                <input
+                  type="search"
+                  id="orderKanbanSearchInput"
+                  placeholder="Número de orden, cliente o cédula"
+                  autocomplete="off"
+                />
+              </div>
+              <p class="muted small">
+                La búsqueda se aplica localmente sobre los resultados cargados en el tablero.
+              </p>
+            </div>
+            <div id="orderKanbanStatus" class="kanban-status muted hidden" aria-live="polite"></div>
+            <div id="orderKanbanColumns" class="kanban-board" aria-live="polite"></div>
           </section>
 
           <section class="card dashboard-panel hidden" id="usersPanel">

--- a/frontend/order-detail.js
+++ b/frontend/order-detail.js
@@ -1,0 +1,1090 @@
+const API_BASE_URL = window.API_BASE_URL || 'http://localhost:8000';
+const TOKEN_STORAGE_KEY = 'sastreria.authToken';
+const ORDER_TASK_STATUS_PENDING = 'pendiente';
+const ORDER_TASK_STATUS_COMPLETED = 'completado';
+const ESTABLISHMENTS = ['Urdesa', 'Batan', 'Indie'];
+
+const headingNumberElement = document.getElementById('orderHeadingNumber');
+const headingCreatedElement = document.getElementById('orderHeadingCreated');
+const headingUpdatedElement = document.getElementById('orderHeadingUpdated');
+const headingStatusElement = document.getElementById('orderHeadingStatus');
+const statusMessageElement = document.getElementById('orderDetailStatusMessage');
+const contentElement = document.getElementById('orderDetailContent');
+const summaryCustomerElement = document.getElementById('orderSummaryCustomer');
+const summaryDocumentElement = document.getElementById('orderSummaryDocument');
+const summaryContactElement = document.getElementById('orderSummaryContact');
+const summaryInvoiceElement = document.getElementById('orderSummaryInvoice');
+const summaryOriginElement = document.getElementById('orderSummaryOrigin');
+const summaryDeliveryElement = document.getElementById('orderSummaryDelivery');
+const summaryTailorElement = document.getElementById('orderSummaryTailor');
+const summaryVendorElement = document.getElementById('orderSummaryVendor');
+const notesElement = document.getElementById('orderDetailNotes');
+const measurementsElement = document.getElementById('orderDetailMeasurements');
+const tasksContainerElement = document.getElementById('orderDetailTasks');
+const currentYearElement = document.getElementById('currentYear');
+const orderEditFormElement = document.getElementById('orderEditForm');
+const orderEditContactInput = document.getElementById('orderEditContact');
+const orderEditInvoiceInput = document.getElementById('orderEditInvoice');
+const orderEditStatusSelect = document.getElementById('orderEditStatus');
+const orderEditTailorSelect = document.getElementById('orderEditTailor');
+const orderEditVendorSelect = document.getElementById('orderEditVendor');
+const orderEditOriginSelect = document.getElementById('orderEditOrigin');
+const orderEditDeliveryInput = document.getElementById('orderEditDelivery');
+const orderEditNotesTextarea = document.getElementById('orderEditNotes');
+const orderEditFeedbackElement = document.getElementById('orderEditFeedback');
+const orderEditPermissionsNotice = document.getElementById('orderEditPermissionsNotice');
+
+const detailState = {
+  orderId: null,
+  token: null,
+  order: null,
+  user: null,
+  statuses: [],
+  tailors: [],
+  vendors: [],
+  editingAllowed: false,
+  catalogWarnings: [],
+};
+
+function setCurrentYear() {
+  if (currentYearElement) {
+    currentYearElement.textContent = String(new Date().getFullYear());
+  }
+}
+
+function readStoredToken() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+  try {
+    const storedToken = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (typeof storedToken !== 'string') {
+      return null;
+    }
+    const trimmed = storedToken.trim();
+    return trimmed ? trimmed : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function parseOrderId() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const rawId = params.get('id');
+  if (!rawId) {
+    return null;
+  }
+  const numericId = Number(rawId);
+  return Number.isFinite(numericId) && numericId > 0 ? numericId : null;
+}
+
+function applyInitialOrderNumberFromQuery() {
+  if (typeof window === 'undefined' || !headingNumberElement) {
+    return;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const orderNumber = params.get('number');
+  if (orderNumber) {
+    headingNumberElement.textContent = orderNumber;
+    document.title = `Orden ${orderNumber} | Portal de Sastrería`;
+  }
+}
+
+function setStatusMessage(message, type = 'info') {
+  if (!statusMessageElement) {
+    return;
+  }
+  const normalizedMessage = message ? message.toString().trim() : '';
+  statusMessageElement.classList.remove('loading', 'error', 'success');
+  if (!normalizedMessage) {
+    statusMessageElement.textContent = '';
+    statusMessageElement.classList.add('hidden');
+    return;
+  }
+  statusMessageElement.textContent = normalizedMessage;
+  statusMessageElement.classList.remove('hidden');
+  if (type === 'loading') {
+    statusMessageElement.classList.add('loading');
+  } else if (type === 'error') {
+    statusMessageElement.classList.add('error');
+  } else if (type === 'success') {
+    statusMessageElement.classList.add('success');
+  }
+}
+
+function clearStatusMessage() {
+  setStatusMessage('');
+}
+
+function showContent() {
+  if (contentElement) {
+    contentElement.classList.remove('hidden');
+  }
+}
+
+function hideContent() {
+  if (contentElement) {
+    contentElement.classList.add('hidden');
+  }
+}
+
+function formatDate(dateString) {
+  try {
+    return new Date(dateString).toLocaleString('es-EC', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+  } catch (error) {
+    return dateString || '';
+  }
+}
+
+function formatDateOnly(dateString) {
+  try {
+    return new Date(dateString).toLocaleDateString('es-EC', {
+      dateStyle: 'medium',
+    });
+  } catch (error) {
+    return dateString || '';
+  }
+}
+
+function formatDateTimeForInput(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function toInputDateTimeValue(value) {
+  if (!value) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return formatDateTimeForInput(value);
+  }
+  if (typeof value === 'number') {
+    return formatDateTimeForInput(new Date(value));
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '';
+    }
+    const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})[T\s](\d{2}):(\d{2})/);
+    if (match) {
+      const [, datePart, hourPart, minutePart] = match;
+      return `${datePart}T${hourPart}:${minutePart}`;
+    }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      return `${trimmed}T00:00`;
+    }
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatDateTimeForInput(parsed);
+    }
+  }
+  return '';
+}
+
+function formatDateForApi(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function normalizeDateForApi(value) {
+  if (!value) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return formatDateForApi(value);
+  }
+  if (typeof value === 'number') {
+    return formatDateForApi(new Date(value));
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '';
+    }
+    const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (match) {
+      return match[1];
+    }
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatDateForApi(parsed);
+    }
+  }
+  return '';
+}
+
+function hasExplicitTimeComponent(value) {
+  if (!value) {
+    return false;
+  }
+  if (value instanceof Date) {
+    return true;
+  }
+  if (typeof value === 'string') {
+    return /T\d{2}:\d{2}| \d{2}:\d{2}/.test(value);
+  }
+  return false;
+}
+
+function isOrderDelivered(status) {
+  return typeof status === 'string' && status.trim().toLowerCase() === 'entregado';
+}
+
+function formatDeliveryDateLabel(order) {
+  if (!order?.delivery_date) {
+    return '';
+  }
+  const deliveryValue = order.delivery_date;
+  if (hasExplicitTimeComponent(deliveryValue)) {
+    return formatDate(deliveryValue);
+  }
+  const dateLabel = formatDateOnly(deliveryValue);
+  if (isOrderDelivered(order.status) && order.updated_at) {
+    const updated = new Date(order.updated_at);
+    if (!Number.isNaN(updated.getTime())) {
+      const timeLabel = updated.toLocaleTimeString('es-EC', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return `${dateLabel} · ${timeLabel}`;
+    }
+  }
+  return dateLabel;
+}
+
+function getStatusBadgeVariant(status) {
+  if (!status) {
+    return 'neutral';
+  }
+  const normalized = status.toString().trim().toLowerCase();
+  if (!normalized) {
+    return 'neutral';
+  }
+  if (normalized.includes('entreg')) {
+    return 'success';
+  }
+  if (normalized.includes('cancel') || normalized.includes('anulad')) {
+    return 'danger';
+  }
+  if (normalized.includes('pend') || normalized.includes('espera')) {
+    return 'warning';
+  }
+  if (
+    normalized.includes('listo') ||
+    normalized.includes('termin') ||
+    normalized.includes('produc') ||
+    normalized.includes('proceso')
+  ) {
+    return 'info';
+  }
+  return 'neutral';
+}
+
+function createStatusBadgeElement(status) {
+  const badge = document.createElement('span');
+  badge.className = 'status-badge';
+  const text = status && status.toString().trim() ? status : 'Sin estado';
+  badge.textContent = text;
+  badge.classList.add(`status-${getStatusBadgeVariant(status)}`);
+  return badge;
+}
+
+function createTaskStatusBadge(status) {
+  const badge = document.createElement('span');
+  badge.className = 'status-badge';
+  const normalized = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  if (normalized === ORDER_TASK_STATUS_COMPLETED) {
+    badge.textContent = 'Completado';
+    badge.classList.add('status-success');
+  } else {
+    badge.textContent = 'Pendiente';
+    badge.classList.add('status-warning');
+  }
+  return badge;
+}
+
+function setSummaryField(element, value, fallback = '—') {
+  if (!element) {
+    return;
+  }
+  const normalized = value === null || value === undefined
+    ? ''
+    : value.toString().trim();
+  if (normalized) {
+    element.textContent = normalized;
+    element.classList.remove('muted');
+  } else {
+    element.textContent = fallback;
+    element.classList.add('muted');
+  }
+}
+
+function renderNotes(notes) {
+  if (!notesElement) return;
+  const normalized = typeof notes === 'string' ? notes.trim() : '';
+  if (normalized) {
+    notesElement.textContent = normalized;
+    notesElement.classList.remove('muted');
+  } else {
+    notesElement.textContent = 'Sin notas registradas.';
+    notesElement.classList.add('muted');
+  }
+}
+
+function renderMeasurements(measurements) {
+  if (!measurementsElement) return;
+  measurementsElement.innerHTML = '';
+  measurementsElement.classList.remove('muted');
+  if (!Array.isArray(measurements) || !measurements.length) {
+    measurementsElement.textContent = 'Sin medidas registradas.';
+    measurementsElement.classList.add('muted');
+    return;
+  }
+  measurements.forEach((measurement) => {
+    if (!measurement) return;
+    const nameValue = measurement.nombre;
+    const valueValue = measurement.valor;
+    const name =
+      typeof nameValue === 'string'
+        ? nameValue.trim()
+        : nameValue !== null && nameValue !== undefined
+          ? nameValue.toString().trim()
+          : '';
+    const value =
+      typeof valueValue === 'string'
+        ? valueValue.trim()
+        : valueValue !== null && valueValue !== undefined
+          ? valueValue.toString().trim()
+          : '';
+    if (!name && !value) {
+      return;
+    }
+    const tag = document.createElement('span');
+    tag.className = 'tag';
+    const label = name && value ? `${name}: ${value}` : name || value;
+    tag.textContent = label;
+    measurementsElement.appendChild(tag);
+  });
+  if (!measurementsElement.children.length) {
+    measurementsElement.textContent = 'Sin medidas registradas.';
+    measurementsElement.classList.add('muted');
+  }
+}
+
+function parseSelectNumber(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function getTrimmedOrNull(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function addCatalogWarning(message) {
+  const normalized = message ? message.toString().trim() : '';
+  if (!normalized) {
+    return;
+  }
+  if (!detailState.catalogWarnings.includes(normalized)) {
+    detailState.catalogWarnings.push(normalized);
+  }
+}
+
+function canEditOrder() {
+  const role = detailState.user?.role;
+  if (!role) {
+    return false;
+  }
+  const normalized = role.toString().trim().toLowerCase();
+  return normalized === 'administrador' || normalized === 'vendedor';
+}
+
+function updateEditPermissions() {
+  const allowed = canEditOrder();
+  detailState.editingAllowed = allowed;
+  if (orderEditPermissionsNotice) {
+    if (allowed) {
+      orderEditPermissionsNotice.classList.add('hidden');
+      orderEditPermissionsNotice.textContent = '';
+    } else {
+      orderEditPermissionsNotice.textContent =
+        'Tu rol no permite modificar la orden desde esta vista.';
+      orderEditPermissionsNotice.classList.remove('hidden');
+    }
+  }
+  if (orderEditFormElement) {
+    if (!allowed) {
+      orderEditFormElement.classList.add('hidden');
+      orderEditFormElement.classList.remove('is-disabled');
+    }
+  }
+  if (!allowed && orderEditFeedbackElement) {
+    orderEditFeedbackElement.textContent = '';
+    orderEditFeedbackElement.classList.add('hidden');
+    orderEditFeedbackElement.classList.remove('is-success', 'is-error', 'is-warning');
+  }
+}
+
+function setEditFormDisabled(disabled) {
+  if (!detailState.editingAllowed || !orderEditFormElement) {
+    return;
+  }
+  orderEditFormElement.classList.toggle('is-disabled', disabled);
+  const controls = orderEditFormElement.querySelectorAll('input, select, textarea, button');
+  controls.forEach((control) => {
+    control.disabled = disabled;
+  });
+}
+
+function populateStatusOptions(selectedValue) {
+  if (!orderEditStatusSelect) {
+    return;
+  }
+  const normalizedSelected = selectedValue ? selectedValue.toString() : '';
+  orderEditStatusSelect.innerHTML = '';
+  let hasSelected = false;
+  const statuses = Array.isArray(detailState.statuses) ? detailState.statuses : [];
+  statuses.forEach((status) => {
+    const label = status ? status.toString().trim() : '';
+    if (!label) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = label;
+    option.textContent = label;
+    if (normalizedSelected && label === normalizedSelected) {
+      option.selected = true;
+      hasSelected = true;
+    }
+    orderEditStatusSelect.appendChild(option);
+  });
+  if (normalizedSelected && !hasSelected) {
+    const fallback = document.createElement('option');
+    fallback.value = normalizedSelected;
+    fallback.textContent = normalizedSelected;
+    fallback.selected = true;
+    orderEditStatusSelect.appendChild(fallback);
+  }
+}
+
+function populateTailorOptions(selectedId, selectedLabel = '') {
+  if (!orderEditTailorSelect) {
+    return;
+  }
+  const normalizedSelected = selectedId ? String(selectedId) : '';
+  orderEditTailorSelect.innerHTML = '';
+  const emptyOption = document.createElement('option');
+  emptyOption.value = '';
+  emptyOption.textContent = 'Sin asignar';
+  if (!normalizedSelected) {
+    emptyOption.selected = true;
+  }
+  orderEditTailorSelect.appendChild(emptyOption);
+  let hasSelected = false;
+  const tailors = Array.isArray(detailState.tailors) ? detailState.tailors : [];
+  tailors.forEach((tailor) => {
+    if (!tailor) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = String(tailor.id);
+    option.textContent = tailor.full_name || `Sastre #${tailor.id}`;
+    if (normalizedSelected && String(tailor.id) === normalizedSelected) {
+      option.selected = true;
+      hasSelected = true;
+    }
+    orderEditTailorSelect.appendChild(option);
+  });
+  if (normalizedSelected && !hasSelected) {
+    const fallback = document.createElement('option');
+    fallback.value = normalizedSelected;
+    fallback.textContent = selectedLabel || 'Sastre asignado';
+    fallback.selected = true;
+    orderEditTailorSelect.appendChild(fallback);
+  }
+}
+
+function populateVendorOptions(selectedId, selectedLabel = '') {
+  if (!orderEditVendorSelect) {
+    return;
+  }
+  const normalizedSelected = selectedId ? String(selectedId) : '';
+  orderEditVendorSelect.innerHTML = '';
+  const emptyOption = document.createElement('option');
+  emptyOption.value = '';
+  emptyOption.textContent = 'Sin asignar';
+  if (!normalizedSelected) {
+    emptyOption.selected = true;
+  }
+  orderEditVendorSelect.appendChild(emptyOption);
+  let hasSelected = false;
+  const vendors = Array.isArray(detailState.vendors) ? detailState.vendors : [];
+  vendors.forEach((vendor) => {
+    if (!vendor) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = String(vendor.id);
+    option.textContent = vendor.full_name || `Vendedor #${vendor.id}`;
+    if (normalizedSelected && String(vendor.id) === normalizedSelected) {
+      option.selected = true;
+      hasSelected = true;
+    }
+    orderEditVendorSelect.appendChild(option);
+  });
+  if (normalizedSelected && !hasSelected) {
+    const fallback = document.createElement('option');
+    fallback.value = normalizedSelected;
+    fallback.textContent = selectedLabel || 'Vendedor asignado';
+    fallback.selected = true;
+    orderEditVendorSelect.appendChild(fallback);
+  }
+}
+
+function populateOriginOptions(selectedValue) {
+  if (!orderEditOriginSelect) {
+    return;
+  }
+  const normalizedSelected = selectedValue ? selectedValue.toString() : '';
+  orderEditOriginSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Selecciona un establecimiento';
+  placeholder.disabled = true;
+  placeholder.hidden = true;
+  if (!normalizedSelected) {
+    placeholder.selected = true;
+  }
+  orderEditOriginSelect.appendChild(placeholder);
+  ESTABLISHMENTS.forEach((branch) => {
+    const option = document.createElement('option');
+    option.value = branch;
+    option.textContent = branch;
+    if (branch === normalizedSelected) {
+      option.selected = true;
+    }
+    orderEditOriginSelect.appendChild(option);
+  });
+  if (normalizedSelected && !ESTABLISHMENTS.includes(normalizedSelected)) {
+    const fallback = document.createElement('option');
+    fallback.value = normalizedSelected;
+    fallback.textContent = normalizedSelected;
+    fallback.selected = true;
+    orderEditOriginSelect.appendChild(fallback);
+  }
+}
+
+function setEditFeedback(message, type = 'info') {
+  if (!orderEditFeedbackElement) {
+    return;
+  }
+  orderEditFeedbackElement.classList.remove('is-success', 'is-error', 'is-warning');
+  const normalized = message ? message.toString().trim() : '';
+  if (!normalized) {
+    orderEditFeedbackElement.textContent = '';
+    orderEditFeedbackElement.classList.add('hidden');
+    return;
+  }
+  orderEditFeedbackElement.textContent = normalized;
+  orderEditFeedbackElement.classList.remove('hidden');
+  if (type === 'success') {
+    orderEditFeedbackElement.classList.add('is-success');
+  } else if (type === 'error') {
+    orderEditFeedbackElement.classList.add('is-error');
+  } else if (type === 'warning') {
+    orderEditFeedbackElement.classList.add('is-warning');
+  }
+}
+
+function showCatalogWarningsIfNeeded() {
+  if (!detailState.editingAllowed || !orderEditFeedbackElement) {
+    return;
+  }
+  if (!detailState.catalogWarnings.length) {
+    return;
+  }
+  if (!orderEditFeedbackElement.classList.contains('hidden')) {
+    return;
+  }
+  setEditFeedback(detailState.catalogWarnings.join(' '), 'warning');
+}
+
+function populateOrderEditForm(order) {
+  if (!detailState.editingAllowed || !orderEditFormElement || !order) {
+    return;
+  }
+  if (orderEditContactInput) {
+    orderEditContactInput.value = order.customer_contact || '';
+  }
+  if (orderEditInvoiceInput) {
+    orderEditInvoiceInput.value = order.invoice_number || '';
+  }
+  populateStatusOptions(order.status || '');
+  populateTailorOptions(order.assigned_tailor?.id ?? '', order.assigned_tailor?.full_name || '');
+  populateVendorOptions(order.assigned_vendor?.id ?? '', order.assigned_vendor?.full_name || '');
+  populateOriginOptions(order.origin_branch || '');
+  if (orderEditDeliveryInput) {
+    orderEditDeliveryInput.value = toInputDateTimeValue(order.delivery_date);
+  }
+  if (orderEditNotesTextarea) {
+    orderEditNotesTextarea.value = order.notes || '';
+  }
+  orderEditFormElement.classList.remove('hidden');
+  setEditFormDisabled(false);
+  showCatalogWarningsIfNeeded();
+}
+
+function getTimeValue(value) {
+  if (!value) return 0;
+  const date = new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function sortTasks(tasks) {
+  return [...tasks].sort((a, b) => {
+    const priority = (task) =>
+      typeof task?.status === 'string' && task.status.trim().toLowerCase() === ORDER_TASK_STATUS_COMPLETED
+        ? 1
+        : 0;
+    const priorityDiff = priority(a) - priority(b);
+    if (priorityDiff !== 0) {
+      return priorityDiff;
+    }
+    return getTimeValue(a?.created_at) - getTimeValue(b?.created_at);
+  });
+}
+
+function renderTasks(tasks, { loading = false, error = null } = {}) {
+  if (!tasksContainerElement) return;
+  tasksContainerElement.innerHTML = '';
+  tasksContainerElement.classList.remove('muted', 'order-detail-error');
+  if (loading) {
+    tasksContainerElement.textContent = 'Cargando checklist de producción...';
+    tasksContainerElement.classList.add('muted');
+    return;
+  }
+  if (error) {
+    tasksContainerElement.textContent = error;
+    tasksContainerElement.classList.add('order-detail-error');
+    return;
+  }
+  if (!Array.isArray(tasks) || !tasks.length) {
+    tasksContainerElement.textContent = 'No hay tareas registradas para esta orden.';
+    tasksContainerElement.classList.add('muted');
+    return;
+  }
+  const list = document.createElement('ul');
+  list.className = 'order-detail-task-list';
+  sortTasks(tasks).forEach((task) => {
+    const item = document.createElement('li');
+    item.className = 'order-detail-task';
+    const normalizedStatus = typeof task?.status === 'string' ? task.status.trim().toLowerCase() : '';
+    if (normalizedStatus === ORDER_TASK_STATUS_COMPLETED) {
+      item.classList.add('is-completed');
+    } else {
+      item.classList.add('is-pending');
+    }
+
+    const header = document.createElement('div');
+    header.className = 'order-detail-task-header';
+    header.appendChild(createTaskStatusBadge(task?.status));
+    if (task?.updated_at) {
+      const updated = document.createElement('span');
+      updated.className = 'order-detail-task-meta';
+      updated.textContent = `Actualizado: ${formatDate(task.updated_at)}`;
+      header.appendChild(updated);
+    }
+    item.appendChild(header);
+
+    const description = document.createElement('p');
+    description.className = 'order-detail-task-description';
+    description.textContent = task?.description?.trim()
+      ? task.description.trim()
+      : 'Sin descripción registrada.';
+    item.appendChild(description);
+
+    const metaParts = [];
+    if (task?.responsible?.full_name) {
+      metaParts.push(`Responsable: ${task.responsible.full_name}`);
+    }
+    if (task?.created_at) {
+      metaParts.push(`Creada: ${formatDate(task.created_at)}`);
+    }
+    if (metaParts.length) {
+      const meta = document.createElement('p');
+      meta.className = 'order-detail-task-meta';
+      meta.textContent = metaParts.join(' • ');
+      item.appendChild(meta);
+    }
+
+    list.appendChild(item);
+  });
+  tasksContainerElement.appendChild(list);
+}
+
+function updateDocumentTitle(order) {
+  if (!order) {
+    document.title = 'Detalle de la orden | Portal de Sastrería';
+    return;
+  }
+  const number = order.order_number || (order.id ? `#${order.id}` : '');
+  if (number) {
+    document.title = `Orden ${number} | Portal de Sastrería`;
+  } else {
+    document.title = 'Detalle de la orden | Portal de Sastrería';
+  }
+}
+
+function renderOrder(order) {
+  if (!order) {
+    return;
+  }
+  updateDocumentTitle(order);
+  const orderNumber = order.order_number || (order.id ? `#${order.id}` : '—');
+  if (headingNumberElement) {
+    headingNumberElement.textContent = orderNumber;
+  }
+  if (headingCreatedElement) {
+    setSummaryField(headingCreatedElement, order.created_at ? formatDate(order.created_at) : '', '—');
+  }
+  if (headingUpdatedElement) {
+    setSummaryField(headingUpdatedElement, order.updated_at ? formatDate(order.updated_at) : '', '—');
+  }
+  if (headingStatusElement) {
+    headingStatusElement.innerHTML = '';
+    headingStatusElement.appendChild(createStatusBadgeElement(order.status));
+  }
+
+  setSummaryField(summaryCustomerElement, order.customer_name || '', 'Sin registrar');
+  setSummaryField(summaryDocumentElement, order.customer_document || '', 'Sin registrar');
+  setSummaryField(summaryContactElement, order.customer_contact || '', 'Sin registrar');
+  setSummaryField(summaryInvoiceElement, order.invoice_number || '', 'Sin número registrado');
+  setSummaryField(summaryOriginElement, order.origin_branch || '', 'Sin definir');
+  const deliveryLabel = formatDeliveryDateLabel(order);
+  setSummaryField(summaryDeliveryElement, deliveryLabel || '', 'Sin fecha de entrega');
+  setSummaryField(
+    summaryTailorElement,
+    order.assigned_tailor?.full_name || '',
+    'Sin asignar'
+  );
+  setSummaryField(
+    summaryVendorElement,
+    order.assigned_vendor?.full_name || '',
+    'Sin asignar'
+  );
+
+  renderNotes(order.notes);
+  renderMeasurements(order.measurements);
+}
+
+function extractErrorMessage(data) {
+  if (!data) {
+    return '';
+  }
+  if (Array.isArray(data.detail)) {
+    return data.detail
+      .map((item) => {
+        if (item?.msg) return item.msg;
+        if (item?.detail) return item.detail;
+        if (item?.message) return item.message;
+        if (typeof item === 'string') return item;
+        try {
+          return JSON.stringify(item);
+        } catch (error) {
+          return '';
+        }
+      })
+      .filter(Boolean)
+      .join(' ');
+  }
+  if (typeof data.detail === 'string') {
+    return data.detail;
+  }
+  if (data.detail?.msg) {
+    return data.detail.msg;
+  }
+  if (data.detail?.message) {
+    return data.detail.message;
+  }
+  if (typeof data.message === 'string') {
+    return data.message;
+  }
+  if (typeof data === 'string') {
+    return data;
+  }
+  return '';
+}
+
+async function fetchWithAuth(path, token, { method = 'GET', body } = {}) {
+  const headers = { Accept: 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const fetchOptions = { method, headers };
+  if (body !== undefined) {
+    fetchOptions.body = JSON.stringify(body);
+    fetchOptions.headers['Content-Type'] = 'application/json';
+  }
+  let response;
+  try {
+    response = await fetch(`${API_BASE_URL}${path}`, fetchOptions);
+  } catch (networkError) {
+    throw new Error('No se pudo conectar con el servidor. Intenta nuevamente.');
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  const contentType = response.headers.get('content-type') || '';
+  let data = null;
+  if (contentType.includes('application/json')) {
+    try {
+      data = await response.json();
+    } catch (parseError) {
+      data = null;
+    }
+  } else {
+    data = await response.text();
+  }
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Tu sesión ha expirado. Inicia sesión nuevamente.');
+    }
+    if (response.status === 404) {
+      throw new Error('No encontramos la orden solicitada.');
+    }
+    const message = extractErrorMessage(data) || 'Error al cargar la información.';
+    throw new Error(message);
+  }
+  return data;
+}
+
+async function fetchOrder(orderId, token) {
+  return fetchWithAuth(`/orders/${orderId}`, token);
+}
+
+async function fetchOrderTasks(orderId, token) {
+  const data = await fetchWithAuth(`/orders/${orderId}/tasks`, token);
+  return Array.isArray(data) ? data : [];
+}
+
+async function loadCurrentUser(token) {
+  const user = await fetchWithAuth('/users/me', token);
+  if (!user) {
+    throw new Error('No se pudo cargar la información del usuario.');
+  }
+  detailState.user = user;
+  updateEditPermissions();
+}
+
+async function loadStatuses(token) {
+  try {
+    const data = await fetchWithAuth('/statuses', token);
+    detailState.statuses = Array.isArray(data)
+      ? data
+        .map((status) => (status ? status.toString().trim() : ''))
+        .filter(Boolean)
+      : [];
+    if (!detailState.statuses.length) {
+      addCatalogWarning('No se pudieron cargar los estados disponibles.');
+    }
+  } catch (error) {
+    detailState.statuses = [];
+    addCatalogWarning('No se pudieron cargar los estados disponibles.');
+  }
+}
+
+async function loadTailors(token) {
+  try {
+    const data = await fetchWithAuth('/users?role=sastre', token);
+    detailState.tailors = Array.isArray(data) ? data : [];
+  } catch (error) {
+    detailState.tailors = [];
+    addCatalogWarning('No se pudieron cargar los sastres disponibles.');
+  }
+}
+
+async function loadVendors(token) {
+  try {
+    const data = await fetchWithAuth('/users?role=vendedor', token);
+    detailState.vendors = Array.isArray(data) ? data : [];
+  } catch (error) {
+    detailState.vendors = [];
+    addCatalogWarning('No se pudieron cargar los vendedores disponibles.');
+  }
+}
+
+async function loadEditCatalogs(token) {
+  detailState.catalogWarnings = [];
+  await Promise.all([loadStatuses(token), loadTailors(token), loadVendors(token)]);
+}
+
+async function loadOrderDetails(orderId, token) {
+  if (detailState.editingAllowed) {
+    setEditFormDisabled(true);
+  }
+  setStatusMessage('Cargando información de la orden...', 'loading');
+  try {
+    const order = await fetchOrder(orderId, token);
+    if (!order) {
+      throw new Error('No se pudo cargar la información de la orden.');
+    }
+    detailState.order = order;
+    if (order?.id) {
+      detailState.orderId = order.id;
+    }
+    renderOrder(order);
+    if (detailState.editingAllowed) {
+      populateOrderEditForm(order);
+    }
+    showContent();
+    clearStatusMessage();
+    try {
+      renderTasks([], { loading: true });
+      const tasks = await fetchOrderTasks(orderId, token);
+      renderTasks(tasks);
+    } catch (taskError) {
+      renderTasks([], { error: taskError.message || 'No se pudo cargar el checklist.' });
+    }
+  } catch (error) {
+    if (detailState.editingAllowed) {
+      setEditFormDisabled(true);
+      if (orderEditFormElement) {
+        orderEditFormElement.classList.add('hidden');
+      }
+    }
+    hideContent();
+    setStatusMessage(error.message || 'No se pudo cargar la información de la orden.', 'error');
+  }
+}
+
+async function handleOrderEditSubmit(event) {
+  event.preventDefault();
+  if (!detailState.editingAllowed) {
+    setEditFeedback('No tienes permisos para actualizar la orden.', 'error');
+    return;
+  }
+  if (!detailState.orderId || !detailState.token) {
+    setEditFeedback('No se puede identificar la orden para actualizarla.', 'error');
+    return;
+  }
+  const originValue = orderEditOriginSelect?.value || '';
+  if (!originValue) {
+    setEditFeedback('Selecciona el establecimiento remitente.', 'error');
+    if (orderEditOriginSelect) {
+      orderEditOriginSelect.focus();
+    }
+    return;
+  }
+
+  const payload = {
+    status: orderEditStatusSelect?.value || null,
+    assigned_tailor_id: parseSelectNumber(orderEditTailorSelect?.value),
+    assigned_vendor_id: parseSelectNumber(orderEditVendorSelect?.value),
+    customer_contact: getTrimmedOrNull(orderEditContactInput?.value ?? ''),
+    notes: getTrimmedOrNull(orderEditNotesTextarea?.value ?? ''),
+    delivery_date: (() => {
+      const normalized = normalizeDateForApi(orderEditDeliveryInput?.value || '');
+      return normalized ? normalized : null;
+    })(),
+    invoice_number: getTrimmedOrNull(orderEditInvoiceInput?.value ?? ''),
+    origin_branch: originValue,
+  };
+
+  setEditFormDisabled(true);
+  setEditFeedback('Guardando cambios...', 'info');
+
+  try {
+    const updatedOrder = await fetchWithAuth(
+      `/orders/${detailState.orderId}`,
+      detailState.token,
+      {
+        method: 'PATCH',
+        body: payload,
+      },
+    );
+    if (!updatedOrder) {
+      throw new Error('No se pudo actualizar la orden.');
+    }
+    detailState.order = updatedOrder;
+    renderOrder(updatedOrder);
+    populateOrderEditForm(updatedOrder);
+    setEditFeedback('Orden actualizada correctamente.', 'success');
+  } catch (error) {
+    setEditFormDisabled(false);
+    setEditFeedback(error.message || 'No se pudo actualizar la orden.', 'error');
+  }
+}
+
+async function preparePage(orderId, token) {
+  detailState.orderId = orderId;
+  detailState.token = token;
+  setStatusMessage('Cargando información de la orden...', 'loading');
+  try {
+    await loadCurrentUser(token);
+  } catch (error) {
+    hideContent();
+    setStatusMessage(
+      error.message || 'No se pudo cargar la información del usuario.',
+      'error',
+    );
+    return;
+  }
+  if (detailState.editingAllowed) {
+    await loadEditCatalogs(token);
+  } else {
+    detailState.catalogWarnings = [];
+  }
+  await loadOrderDetails(orderId, token);
+}
+
+if (orderEditFormElement) {
+  orderEditFormElement.addEventListener('submit', handleOrderEditSubmit);
+}
+
+function initialise() {
+  setCurrentYear();
+  applyInitialOrderNumberFromQuery();
+  const orderId = parseOrderId();
+  if (!orderId) {
+    setStatusMessage(
+      'No se especificó una orden válida. Regresa al panel y selecciona una orden.',
+      'error'
+    );
+    return;
+  }
+  const token = readStoredToken();
+  if (!token) {
+    setStatusMessage('Inicia sesión en el panel para ver la información de la orden.', 'error');
+    return;
+  }
+  preparePage(orderId, token);
+}
+
+initialise();

--- a/frontend/order.html
+++ b/frontend/order.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Detalle de la orden | Portal de Sastrería</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="container order-detail-top">
+        <h1>Portal de Sastrería</h1>
+        <a class="link-button top-bar-link" href="index.html">Volver al panel</a>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="card order-detail-card">
+        <div class="order-detail-page-header">
+          <div class="order-detail-heading">
+            <h2>
+              Orden <span id="orderHeadingNumber" class="order-detail-number">—</span>
+            </h2>
+            <p class="muted small">
+              Registrada: <span id="orderHeadingCreated">—</span>
+              · Última actualización: <span id="orderHeadingUpdated">—</span>
+            </p>
+          </div>
+          <div id="orderHeadingStatus" class="order-detail-status"></div>
+        </div>
+
+        <div
+          id="orderDetailStatusMessage"
+          class="order-detail-status-message hidden"
+          role="status"
+          aria-live="polite"
+        ></div>
+
+        <div id="orderDetailContent" class="order-detail-content hidden">
+          <section class="order-detail-section">
+            <h3>Resumen de la orden</h3>
+            <dl class="order-detail-summary-grid">
+              <div class="order-detail-summary-item">
+                <dt>Cliente</dt>
+                <dd id="orderSummaryCustomer">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Documento</dt>
+                <dd id="orderSummaryDocument">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Contacto</dt>
+                <dd id="orderSummaryContact">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Factura</dt>
+                <dd id="orderSummaryInvoice">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Establecimiento</dt>
+                <dd id="orderSummaryOrigin">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Fecha de entrega</dt>
+                <dd id="orderSummaryDelivery">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Sastre asignado</dt>
+                <dd id="orderSummaryTailor">—</dd>
+              </div>
+              <div class="order-detail-summary-item">
+                <dt>Vendedor asignado</dt>
+                <dd id="orderSummaryVendor">—</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section class="order-detail-section">
+            <div class="order-detail-section-header">
+              <h3>Actualizar orden</h3>
+              <p id="orderEditPermissionsNotice" class="muted small hidden">
+                Tu rol no permite modificar la orden desde esta vista.
+              </p>
+            </div>
+            <form id="orderEditForm" class="order-edit-form hidden" novalidate>
+              <div class="order-edit-grid">
+                <div class="order-edit-field">
+                  <label for="orderEditContact">Contacto</label>
+                  <input type="text" id="orderEditContact" autocomplete="tel" />
+                </div>
+                <div class="order-edit-field">
+                  <label for="orderEditInvoice">Número de factura</label>
+                  <input type="text" id="orderEditInvoice" autocomplete="off" />
+                </div>
+                <div class="order-edit-field">
+                  <label for="orderEditStatus">Estado</label>
+                  <select id="orderEditStatus"></select>
+                </div>
+                <div class="order-edit-field">
+                  <label for="orderEditTailor">Sastre asignado</label>
+                  <select id="orderEditTailor"></select>
+                </div>
+                <div class="order-edit-field">
+                  <label for="orderEditVendor">Vendedor asignado</label>
+                  <select id="orderEditVendor"></select>
+                </div>
+                <div class="order-edit-field">
+                  <label for="orderEditOrigin">Establecimiento remitente</label>
+                  <select id="orderEditOrigin" required></select>
+                </div>
+                <div class="order-edit-field">
+                  <label for="orderEditDelivery">Fecha y hora de entrega</label>
+                  <input type="datetime-local" id="orderEditDelivery" />
+                </div>
+                <div class="order-edit-field order-edit-notes">
+                  <label for="orderEditNotes">Notas</label>
+                  <textarea id="orderEditNotes" rows="3"></textarea>
+                </div>
+              </div>
+              <div
+                id="orderEditFeedback"
+                class="order-edit-feedback hidden"
+                role="status"
+                aria-live="polite"
+              ></div>
+              <div class="order-edit-actions">
+                <button type="submit" class="primary">Guardar cambios</button>
+              </div>
+            </form>
+          </section>
+
+          <section class="order-detail-section">
+            <h3>Notas</h3>
+            <p id="orderDetailNotes" class="order-detail-notes muted">
+              Sin notas registradas.
+            </p>
+          </section>
+
+          <section class="order-detail-section">
+            <h3>Medidas registradas</h3>
+            <div id="orderDetailMeasurements" class="measurement-tags muted">
+              Sin medidas registradas.
+            </div>
+          </section>
+
+          <section class="order-detail-section">
+            <h3>Checklist de producción</h3>
+            <div id="orderDetailTasks" class="order-detail-task-container muted">
+              Cargando checklist de producción...
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="container footer">
+      <small>
+        © <span id="currentYear"></span> Portal de Sastrería. Todos los derechos reservados.
+      </small>
+    </footer>
+
+    <script src="order-detail.js"></script>
+  </body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -42,6 +42,38 @@ body {
   font-size: 1.8rem;
 }
 
+.top-bar .top-bar-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 25px rgba(15, 76, 92, 0.2);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.top-bar .top-bar-link:hover,
+.top-bar .top-bar-link:focus {
+  background: white;
+  color: var(--primary-dark);
+  border-color: rgba(255, 255, 255, 0.9);
+  transform: translateY(-1px);
+  text-decoration: none;
+  box-shadow: 0 16px 28px rgba(15, 76, 92, 0.28);
+}
+
+.top-bar .top-bar-link:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 3px;
+}
+
 .main-nav {
   display: flex;
   align-items: center;
@@ -250,6 +282,18 @@ button.link-button {
 }
 
 button.link-button:hover {
+  color: var(--primary);
+}
+
+a.link-button {
+  color: var(--primary-dark);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+}
+
+a.link-button:hover {
   color: var(--primary);
 }
 
@@ -730,6 +774,297 @@ button[disabled] {
   margin-top: 0;
 }
 
+.order-detail-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-top h1 {
+  font-size: 1.6rem;
+  margin: 0;
+}
+
+.order-detail-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-detail-heading h2 {
+  margin: 0;
+}
+
+.order-detail-heading .muted {
+  margin: 0;
+}
+
+.order-detail-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-status-message {
+  margin-top: 1.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: #f1f5f9;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.order-detail-status-message.loading {
+  background: rgba(31, 122, 140, 0.12);
+  color: var(--primary-dark);
+}
+
+.order-detail-status-message.error {
+  background: rgba(197, 48, 48, 0.12);
+  color: var(--danger);
+}
+
+.order-detail-status-message.success {
+  background: rgba(47, 133, 90, 0.14);
+  color: var(--success);
+}
+
+.order-detail-content {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.order-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-detail-section h3 {
+  margin: 0;
+}
+
+.order-detail-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-section-header h3 {
+  margin: 0;
+}
+
+.order-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(31, 122, 140, 0.15);
+  border-radius: 12px;
+  background: rgba(31, 122, 140, 0.04);
+}
+
+.order-edit-form.is-disabled {
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.order-edit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+.order-edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.order-edit-field label {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.order-edit-field input,
+.order-edit-field select,
+.order-edit-field textarea {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 76, 92, 0.2);
+  font: inherit;
+  background: white;
+  color: var(--text);
+}
+
+.order-edit-field textarea {
+  resize: vertical;
+  min-height: 130px;
+}
+
+.order-edit-notes {
+  grid-column: 1 / -1;
+}
+
+.order-edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.order-edit-feedback {
+  font-size: 0.95rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: rgba(15, 76, 92, 0.08);
+  color: var(--primary-dark);
+}
+
+.order-edit-feedback.is-success {
+  background: rgba(47, 133, 90, 0.12);
+  color: var(--success);
+  border-color: rgba(47, 133, 90, 0.25);
+}
+
+.order-edit-feedback.is-error {
+  background: rgba(197, 48, 48, 0.12);
+  color: var(--danger);
+  border-color: rgba(197, 48, 48, 0.2);
+}
+
+.order-edit-feedback.is-warning {
+  background: rgba(255, 127, 80, 0.12);
+  color: var(--accent);
+  border-color: rgba(255, 127, 80, 0.25);
+}
+
+.order-edit-feedback.hidden {
+  display: none !important;
+}
+
+.order-detail-summary-grid {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.order-detail-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-detail-summary-item dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+}
+
+.order-detail-summary-item dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.order-detail-notes {
+  margin: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.order-detail-task-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-detail-task-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-detail-task {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-detail-task.is-completed {
+  border-color: rgba(47, 133, 90, 0.35);
+  background: rgba(47, 133, 90, 0.08);
+}
+
+.order-detail-task.is-pending {
+  border-color: rgba(255, 127, 80, 0.35);
+  background: rgba(255, 127, 80, 0.08);
+}
+
+.order-detail-task-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-task-description {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.order-detail-task-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.order-detail-error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .order-detail-summary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .button-row {
   display: flex;
   flex-wrap: wrap;
@@ -748,6 +1083,223 @@ button[disabled] {
 .order-panel-controls p {
   margin: 0;
   max-width: 48ch;
+}
+
+.kanban-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.kanban-header h3 {
+  margin-bottom: 0.25rem;
+}
+
+.kanban-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.kanban-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.kanban-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.kanban-search label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.kanban-search input {
+  width: min(280px, 100%);
+}
+
+.kanban-status {
+  margin-bottom: 1rem;
+}
+
+.kanban-board {
+  display: flex;
+  gap: 1rem;
+  align-items: stretch;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.kanban-column {
+  background: #f9fbfc;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  min-width: clamp(220px, 24vw, 280px);
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+
+.kanban-column-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.kanban-column-title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.kanban-column-count {
+  font-size: 0.9rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.kanban-column-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.kanban-column-body.is-empty {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.kanban-card {
+  background: white;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  box-shadow: 0 20px 45px rgba(15, 76, 92, 0.08);
+  border: 1px solid rgba(31, 122, 140, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.kanban-card.is-clickable {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.kanban-card.is-clickable:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 48px rgba(15, 76, 92, 0.12);
+}
+
+.kanban-card.is-clickable:focus-visible {
+  outline: 3px solid rgba(31, 122, 140, 0.35);
+  outline-offset: 3px;
+  transform: translateY(-2px);
+  box-shadow: 0 20px 52px rgba(15, 76, 92, 0.16);
+}
+
+.kanban-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.kanban-card-order {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--primary-dark);
+  word-break: break-word;
+}
+
+.kanban-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.kanban-card-meta-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  line-height: 1.4;
+}
+
+.kanban-card-meta-label {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.kanban-card-meta-value {
+  color: var(--text);
+}
+
+.kanban-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.kanban-card-delivery {
+  font-weight: 600;
+}
+
+.kanban-card-updated {
+  margin-left: auto;
+  font-size: 0.8rem;
+}
+
+.kanban-card-updated time {
+  font-style: normal;
+}
+
+@media (max-width: 768px) {
+  .kanban-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .kanban-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .kanban-actions button {
+    width: 100%;
+  }
+
+  .kanban-controls {
+    align-items: stretch;
+  }
+
+  .kanban-board {
+    padding-bottom: 1rem;
+  }
 }
 
 .order-search {
@@ -1010,6 +1562,43 @@ th {
 
 .measurement-row button {
   border: none;
+}
+
+.measurement-row.is-highlighted {
+  animation: measurementRowFlash 1.5s ease-out;
+  border-radius: 12px;
+}
+
+@keyframes measurementRowFlash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(15, 76, 92, 0.45);
+  }
+  60% {
+    box-shadow: 0 0 0 9px rgba(15, 76, 92, 0);
+  }
+  100% {
+    box-shadow: none;
+  }
+}
+
+.measurement-tag-button {
+  border: none;
+  background: rgba(31, 122, 140, 0.12);
+  color: var(--primary-dark);
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.measurement-tag-button:hover {
+  background: rgba(31, 122, 140, 0.24);
+  transform: translateY(-1px);
+}
+
+.measurement-tag-button:focus-visible {
+  outline: 3px solid rgba(31, 122, 140, 0.35);
+  outline-offset: 2px;
+  background: rgba(31, 122, 140, 0.26);
 }
 
 .order-task-input-label {


### PR DESCRIPTION
## Summary
- filter the Kanban data so delivered orders drop off four days after delivery to keep the board manageable
- add a role-aware edit form to the external order detail page that loads catalog data, submits updates, and re-renders the summary
- refresh the detail page styling, including a high-contrast "Volver al panel" button, to support the new editing workflow

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31f837bb083328e9eb9e86a2b2d56