### PR TITLE
fix: restore dashboard toggles and header session state

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -98,9 +98,12 @@ function clearStoredToken() {
 }
 
 const views = document.querySelectorAll('.view');
-const navButtons = document.querySelectorAll('.nav-button');
+const navButtons = document.querySelectorAll('.nav-link');
 const panelNavButton = document.getElementById('panelNavButton');
 const loginNavButton = document.getElementById('loginNavButton');
+const headerSessionInfo = document.getElementById('headerSessionInfo');
+const headerUserNameElement = document.getElementById('headerUserName');
+const headerLogoutButton = document.getElementById('headerLogoutButton');
 const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
 const orderCreateTabButton = document.getElementById('orderCreateTabButton');
@@ -250,6 +253,7 @@ function setActiveView(viewId) {
     const shouldHighlightLogin = viewId === 'staff-view' && !state.token;
     loginNavButton.classList.toggle('active', shouldHighlightLogin);
   }
+  updateNavigationForAuth();
 }
 
 navButtons.forEach((btn) => {
@@ -314,16 +318,19 @@ function setActiveDashboardTab(tabId = 'orderListPanel') {
       }
       btn.disabled = shouldHideUsersTab;
     }
-    btn.classList.toggle('active', tab === targetTab);
+    const isActiveTab = tab === targetTab;
+    btn.classList.toggle('active', isActiveTab);
+    btn.setAttribute('aria-expanded', isActiveTab ? 'true' : 'false');
+    btn.setAttribute('aria-selected', isActiveTab ? 'true' : 'false');
   });
   dashboardPanels.forEach((panel) => {
-    if (panel.id === 'orderCreatePanel' && userRole === 'sastre') {
-      panel.classList.add('hidden');
-    } else if (panel.id === 'usersPanel' && userRole !== 'administrador') {
-      panel.classList.add('hidden');
-    } else {
-      panel.classList.toggle('hidden', panel.id !== targetTab);
-    }
+    const isTargetPanel = panel.id === targetTab;
+    const shouldHidePanel =
+      (panel.id === 'orderCreatePanel' && userRole === 'sastre') ||
+      (panel.id === 'usersPanel' && userRole !== 'administrador') ||
+      !isTargetPanel;
+    panel.classList.toggle('hidden', shouldHidePanel);
+    panel.setAttribute('aria-hidden', shouldHidePanel ? 'true' : 'false');
   });
   if (targetTab === 'usersPanel' && userRole === 'administrador') {
     loadUsers();
@@ -1531,14 +1538,19 @@ function renderCustomerMeasurementOptions(customer) {
 }
 function updateUserInfo() {
   if (!state.user) {
+    updateHeaderSession();
     updateUserCreationForm();
     return;
   }
+  const displayName = getUserDisplayName(state.user);
   if (currentUserNameElement) {
-    currentUserNameElement.textContent = state.user.full_name;
+    currentUserNameElement.textContent = displayName || state.user.full_name || '';
   }
   if (currentUserRoleElement) {
     currentUserRoleElement.textContent = ROLE_LABELS[state.user.role] || state.user.role;
+  }
+  if (headerUserNameElement) {
+    headerUserNameElement.textContent = displayName;
   }
   if (deleteCustomerButton) {
     if (state.user.role === 'administrador') {
@@ -1573,6 +1585,7 @@ function updateUserInfo() {
   } else {
     setActiveDashboardTab(activeDashboardTab);
   }
+  updateHeaderSession();
   updateUserCreationForm();
   renderOrderTasks();
 }
@@ -1596,6 +1609,32 @@ function hideDashboard() {
   }
 }
 
+function getUserDisplayName(user) {
+  if (!user || typeof user !== 'object') {
+    return '';
+  }
+  if (typeof user.full_name === 'string' && user.full_name.trim()) {
+    return user.full_name.trim();
+  }
+  if (typeof user.username === 'string' && user.username.trim()) {
+    return user.username.trim();
+  }
+  return '';
+}
+
+function updateHeaderSession() {
+  const isAuthenticated = Boolean(state.token && state.user);
+  if (headerSessionInfo) {
+    headerSessionInfo.classList.toggle('hidden', !isAuthenticated);
+  }
+  if (headerUserNameElement) {
+    headerUserNameElement.textContent = isAuthenticated ? getUserDisplayName(state.user) : '';
+  }
+  if (headerLogoutButton) {
+    headerLogoutButton.disabled = !isAuthenticated;
+  }
+}
+
 function updateNavigationForAuth() {
   const isAuthenticated = Boolean(state.token);
   if (panelNavButton) {
@@ -1607,6 +1646,7 @@ function updateNavigationForAuth() {
       loginNavButton.classList.remove('active');
     }
   }
+  updateHeaderSession();
 }
 
 async function bootstrapAuthenticatedSession({ showWelcomeToast = false } = {}) {
@@ -2106,6 +2146,12 @@ function handleLogout(auto = false) {
   if (currentUserRoleElement) {
     currentUserRoleElement.textContent = '';
   }
+  if (headerUserNameElement) {
+    headerUserNameElement.textContent = '';
+  }
+  if (headerSessionInfo) {
+    headerSessionInfo.classList.add('hidden');
+  }
   if (assignTailorSelect) {
     populateTailorSelect(assignTailorSelect);
   }
@@ -2213,6 +2259,13 @@ if (staffLoginForm) {
 
 if (logoutButton) {
   logoutButton.addEventListener('click', () => {
+    handleLogout(false);
+    showToast('Sesión cerrada correctamente.', 'success');
+  });
+}
+
+if (headerLogoutButton) {
+  headerLogoutButton.addEventListener('click', () => {
     handleLogout(false);
     showToast('Sesión cerrada correctamente.', 'success');
   });

--- a/frontend/assets/adams-logo.svg
+++ b/frontend/assets/adams-logo.svg
@@ -1,0 +1,27 @@
+<svg width="220" height="80" viewBox="0 0 220 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Adams Fashion Store</title>
+  <text
+    x="110"
+    y="42"
+    text-anchor="middle"
+    font-family="'Montserrat', 'Lato', 'Helvetica Neue', Arial, sans-serif"
+    font-size="38"
+    font-weight="600"
+    letter-spacing="0.32em"
+    fill="#0d0f10"
+  >
+    ADAMS
+  </text>
+  <text
+    x="110"
+    y="60"
+    text-anchor="middle"
+    font-family="'Montserrat', 'Lato', 'Helvetica Neue', Arial, sans-serif"
+    font-size="12"
+    font-weight="500"
+    letter-spacing="0.35em"
+    fill="#5f6368"
+  >
+    MEN • WOMEN • KID
+  </text>
+</svg>

--- a/frontend/assets/favicon.svg
+++ b/frontend/assets/favicon.svg
@@ -1,0 +1,16 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Adams Favicon</title>
+  <rect width="64" height="64" rx="12" fill="#0d0f10" />
+  <text
+    x="32"
+    y="40"
+    text-anchor="middle"
+    font-family="'Montserrat', 'Lato', 'Helvetica Neue', Arial, sans-serif"
+    font-size="28"
+    font-weight="600"
+    letter-spacing="0.2em"
+    fill="#ffffff"
+  >
+    A
+  </text>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,36 +3,50 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Portal de Sastrería</title>
+    <title>Portal Adams | Seguimiento de órdenes</title>
+    <meta
+      name="description"
+      content="Extensión digital de Adams para consultar órdenes a medida y que el personal gestione confecciones con estilo."
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;500;600;700&family=Montserrat:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="top-bar">
-      <div class="container">
-        <h1>Portal de Sastrería</h1>
-        <nav class="main-nav">
-          <div class="main-nav-buttons">
-            <button class="nav-button active" data-view="client-view">Clientes</button>
-            <button
-              class="nav-button hidden"
-              data-view="staff-view"
-              id="panelNavButton"
-            >
-              Panel
-            </button>
-          </div>
-          <button type="button" class="login-button" id="loginNavButton">
-            Iniciar sesión
+    <header class="site-header">
+      <div class="top-strip">
+        <div class="container top-strip-content" aria-hidden="true"></div>
+      </div>
+      <div class="container header-main">
+        <a class="brand" href="index.html" aria-label="Inicio Adams">
+          <img src="assets/adams-logo.svg" alt="Adams Fashion Store" class="brand-logo" />
+        </a>
+        <nav class="header-nav" aria-label="Navegación principal">
+          <button class="nav-link active" data-view="client-view">Seguimiento</button>
+          <button class="nav-link hidden" data-view="staff-view" id="panelNavButton">
+            Equipo Adams
           </button>
         </nav>
+        <div class="header-actions">
+          <button type="button" class="header-cta" id="loginNavButton">Acceder</button>
+          <div id="headerSessionInfo" class="header-session hidden" aria-live="polite">
+            <span id="headerUserName" class="header-user">&nbsp;</span>
+            <button type="button" class="header-session-exit" id="headerLogoutButton">Cerrar sesión</button>
+          </div>
+        </div>
       </div>
     </header>
 
     <main class="container">
       <section id="client-view" class="view active">
         <div class="card">
-          <h2>Consulta el estado de tu orden</h2>
-          <p>Ingresa el número de orden o la cédula con la que registraste tu pedido.</p>
+          <h2>Consulta el estado de tu orden Adams</h2>
+          <p>Ingresa el número de orden o la cédula con la que registraste tu confección.</p>
           <form id="orderLookupForm" class="form-grid">
             <div class="form-row">
               <label for="orderNumber">Número de orden</label>
@@ -690,7 +704,7 @@
     ></div>
 
     <footer class="container footer">
-      <small>© <span id="currentYear"></span> Portal de Sastrería. Todos los derechos reservados.</small>
+      <small>© <span id="currentYear"></span> Adams Sastrería. Inspirado en www.adams.com.ec · Todos los derechos reservados.</small>
     </footer>
 
     <script src="app.js"></script>

--- a/frontend/order.html
+++ b/frontend/order.html
@@ -3,14 +3,32 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Detalle de la orden | Portal de Sastrería</title>
+    <title>Detalle de la orden | Portal Adams</title>
+    <meta
+      name="description"
+      content="Visualiza el avance de tus confecciones personalizadas con el estilo Adams."
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;500;600;700&family=Montserrat:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="top-bar">
-      <div class="container order-detail-top">
-        <h1>Portal de Sastrería</h1>
-        <a class="link-button" href="index.html">Volver al panel</a>
+    <header class="site-header order-header">
+      <div class="top-strip">
+        <div class="container top-strip-content" aria-hidden="true"></div>
+      </div>
+      <div class="container header-main">
+        <a class="brand" href="index.html" aria-label="Volver al portal Adams">
+          <img src="assets/adams-logo.svg" alt="Adams Fashion Store" class="brand-logo" />
+        </a>
+        <div class="header-actions">
+          <a class="header-link" href="index.html">&larr; Volver al portal</a>
+        </div>
       </div>
     </header>
 
@@ -100,9 +118,7 @@
     </main>
 
     <footer class="container footer">
-      <small>
-        © <span id="currentYear"></span> Portal de Sastrería. Todos los derechos reservados.
-      </small>
+      <small>© <span id="currentYear"></span> Adams Sastrería. Inspirado en www.adams.com.ec · Todos los derechos reservados.</small>
     </footer>
 
     <script src="order-detail.js"></script>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,15 +1,21 @@
 :root {
   color-scheme: light;
-  --primary: #1f7a8c;
-  --primary-dark: #0f4c5c;
-  --secondary: #f4f1de;
-  --accent: #ff7f50;
-  --text: #1f2933;
-  --muted: #6b7280;
-  --border: #d9e2ec;
+  --primary: #111213;
+  --primary-dark: #0b0d0f;
+  --primary-light: #2f3237;
+  --secondary: #f4f4f5;
+  --accent: #9f793e;
+  --accent-soft: #c7a167;
+  --text: #111213;
+  --muted: #6a6e73;
+  --border: #dcdde0;
+  --surface: #ffffff;
+  --surface-muted: #f7f7f8;
   --success: #2f855a;
-  --danger: #c53030;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --danger: #bb4c3c;
+  --shadow-soft: rgba(17, 17, 19, 0.06);
+  --shadow-strong: rgba(17, 17, 19, 0.12);
+  font-family: "Lato", "Helvetica Neue", Arial, sans-serif;
 }
 
 * {
@@ -18,83 +24,224 @@
 
 body {
   margin: 0;
-  background: #f7fafc;
+  font-family: inherit;
+  line-height: 1.6;
+  background: var(--secondary);
   color: var(--text);
   overflow-x: hidden;
 }
 
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--primary);
+}
+
 .container {
   width: 100%;
-  max-width: 1100px;
+  max-width: 1180px;
   margin: 0 auto;
   padding: 0 clamp(1rem, 4vw, 2.5rem);
 }
 
-.top-bar {
-  background: linear-gradient(120deg, var(--primary-dark), var(--primary));
-  color: white;
-  padding: 1.2rem 0;
-  box-shadow: 0 10px 25px rgba(15, 76, 92, 0.15);
+.site-header {
+  background: var(--surface);
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 8px 22px var(--shadow-soft);
 }
 
-.top-bar h1 {
-  margin: 0;
-  font-size: 1.8rem;
+.top-strip {
+  background: var(--primary);
+  color: rgba(244, 244, 245, 0.85);
 }
 
-.main-nav {
+.top-strip-content {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.75rem;
-  margin-top: 0.75rem;
+  padding: 0.55rem 0;
+  font-family: "Montserrat", "Lato", sans-serif;
+  font-size: 0.68rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
   flex-wrap: wrap;
+  text-align: center;
 }
 
-.main-nav-buttons {
+.top-strip-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.top-strip-item + .top-strip-item::before {
+  content: "";
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(244, 244, 245, 0.45);
+  margin: 0 0.55rem;
+}
+
+.header-main {
   display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 2rem);
+  padding: clamp(1rem, 2.5vw, 1.4rem) 0;
 }
 
-.nav-button {
-  border: none;
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  padding: 0.5rem 1.25rem;
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: 0.95rem;
-  transition: background 0.2s ease, transform 0.2s ease;
+.brand {
+  display: inline-flex;
+  align-items: center;
 }
 
-.nav-button:hover,
-.nav-button.active {
-  background: white;
-  color: var(--primary-dark);
-  transform: translateY(-1px);
+.brand-logo {
+  width: clamp(150px, 20vw, 210px);
+  height: auto;
 }
 
-.login-button {
+.header-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
   margin-left: auto;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  background: transparent;
-  color: white;
-  padding: 0.5rem 1.35rem;
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: 0.95rem;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
-.login-button:hover,
-.login-button.active {
-  background: white;
-  color: var(--primary-dark);
-  transform: translateY(-1px);
+.header-session {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--primary);
 }
+
+.header-user {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.header-session-exit {
+  border: none;
+  background: none;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--primary-light);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.header-session-exit:hover,
+.header-session-exit:focus-visible {
+  color: var(--primary);
+}
+
+.nav-link {
+  position: relative;
+  border: none;
+  background: none;
+  padding: 0.25rem 0;
+  font-family: "Montserrat", "Lato", sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--primary-light);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.45rem;
+  height: 2px;
+  background: transparent;
+  transition: background 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  color: var(--primary);
+}
+
+.nav-link:hover::after,
+.nav-link:focus-visible::after {
+  background: var(--accent);
+}
+
+.nav-link.active {
+  color: var(--primary);
+}
+
+.nav-link.active::after {
+  background: var(--accent);
+}
+
+.header-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--primary);
+  background: transparent;
+  color: var(--primary);
+  font-family: "Montserrat", "Lato", sans-serif;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.header-cta:hover,
+.header-cta:focus-visible,
+.header-cta.active {
+  background: var(--primary);
+  color: var(--surface);
+  box-shadow: 0 16px 30px var(--shadow-soft);
+}
+
+.header-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: "Montserrat", "Lato", sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--primary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.header-link:hover,
+.header-link:focus-visible {
+  color: var(--accent);
+}
+
 
 main {
-  padding: clamp(1.75rem, 4vw, 2.5rem) 0;
+  padding: clamp(1.5rem, 4vw, 2.5rem) 0 clamp(2.4rem, 6vw, 3.2rem);
 }
 
 .view {
@@ -106,21 +253,32 @@ main {
 }
 
 .card {
-  background: white;
-  border-radius: 18px;
-  padding: clamp(1.25rem, 4vw, 1.8rem);
-  margin-bottom: 2rem;
-  box-shadow: 0 25px 60px rgba(15, 76, 92, 0.08);
+  background: var(--surface);
+  border-radius: 16px;
+  padding: clamp(1.4rem, 3vw, 2.1rem);
+  margin-bottom: clamp(1.6rem, 3.2vw, 2.4rem);
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 36px var(--shadow-soft);
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Montserrat", "Lato", sans-serif;
+  letter-spacing: 0.05em;
+  margin-top: 0;
+  color: var(--primary);
 }
 
 h2 {
-  margin-top: 0;
-  font-size: 1.6rem;
+  font-size: clamp(1.6rem, 3vw, 1.9rem);
+  font-weight: 600;
 }
 
 h3 {
-  margin-top: 0;
   font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--primary);
 }
 
 .form-grid {
@@ -136,6 +294,8 @@ h3 {
 
 label {
   font-weight: 600;
+  color: var(--primary-light);
+  letter-spacing: 0.02em;
 }
 
 .sr-only {
@@ -155,19 +315,21 @@ input[type="password"],
 textarea,
 select {
   border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
   font-size: 1rem;
   font-family: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: var(--surface-muted);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 input:focus,
 textarea:focus,
 select:focus {
   outline: none;
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(31, 122, 140, 0.2);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(159, 121, 62, 0.2);
+  background: #ffffff;
 }
 
 textarea {
@@ -175,36 +337,45 @@ textarea {
 }
 
 button {
-  font-family: inherit;
+  font-family: "Montserrat", "Lato", sans-serif;
   font-size: 1rem;
   cursor: pointer;
 }
 
 button.primary {
   background: var(--primary);
-  color: white;
+  color: var(--surface);
   border: none;
-  padding: 0.75rem 1.5rem;
-  border-radius: 10px;
-  transition: background 0.2s ease, transform 0.2s ease;
+  padding: 0.8rem 1.7rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
 button.primary:hover {
   background: var(--primary-dark);
-  transform: translateY(-1px);
+  box-shadow: 0 18px 32px var(--shadow-soft);
 }
 
 button.secondary {
-  background: transparent;
-  border: 1px dashed var(--primary);
-  color: var(--primary-dark);
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--primary);
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
   width: fit-content;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 button.secondary:hover {
-  border-style: solid;
+  background: var(--primary);
+  color: var(--surface);
+  box-shadow: 0 16px 28px var(--shadow-soft);
 }
 
 button.danger {
@@ -212,49 +383,56 @@ button.danger {
   color: white;
   border: none;
   padding: 0.55rem 1rem;
-  border-radius: 8px;
+  border-radius: 10px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 button.danger:hover {
-  filter: brightness(0.9);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(197, 48, 48, 0.28);
+  filter: brightness(0.95);
 }
 
 button.danger.ghost {
-  background: rgba(197, 48, 48, 0.1);
+  background: rgba(197, 48, 48, 0.12);
   color: var(--danger);
 }
 
 button.danger.ghost:hover {
-  background: rgba(197, 48, 48, 0.2);
+  background: rgba(197, 48, 48, 0.18);
 }
 
 button.full-width {
   width: 100%;
   background: var(--primary);
   border: none;
-  color: white;
-  padding: 0.75rem;
-  border-radius: 10px;
+  color: var(--surface);
+  padding: 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
 }
 
 button.link-button {
   background: none;
   border: none;
-  color: var(--primary-dark);
+  color: var(--primary);
   font-weight: 600;
   padding: 0;
   margin-left: 0.5rem;
   text-decoration: underline;
   text-decoration-thickness: 1.5px;
   text-underline-offset: 3px;
+  cursor: pointer;
 }
 
 button.link-button:hover {
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 
 a.link-button {
-  color: var(--primary-dark);
+  color: var(--primary);
   font-weight: 600;
   text-decoration: underline;
   text-decoration-thickness: 1.5px;
@@ -262,13 +440,16 @@ a.link-button {
 }
 
 a.link-button:hover {
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 
 button[disabled] {
-  opacity: 0.6;
+  opacity: 0.65;
   cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
+
 
 .input-group {
   display: flex;
@@ -279,13 +460,25 @@ button[disabled] {
   flex: 1;
 }
 
+
 .order-result {
-  margin-top: 1.5rem;
-  padding: 1.5rem;
-  border-radius: 14px;
+  position: relative;
+  margin-top: 1.75rem;
+  padding: 1.6rem 1.6rem 1.6rem 2.1rem;
+  border-radius: 18px;
   border: 1px solid var(--border);
-  background: var(--secondary);
-  line-height: 1.5;
+  background: var(--surface);
+  line-height: 1.6;
+  box-shadow: 0 22px 48px var(--shadow-soft);
+  overflow: hidden;
+}
+
+.order-result::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 6px;
+  background: linear-gradient(180deg, var(--accent), var(--accent-soft));
 }
 
 .order-result.hidden {
@@ -295,6 +488,7 @@ button[disabled] {
 .order-result strong {
   display: inline-block;
   min-width: 140px;
+  color: var(--primary-dark);
 }
 
 .dashboard-header {
@@ -315,23 +509,25 @@ button[disabled] {
 
 .dashboard-tab {
   border: 1px solid var(--border);
-  background: white;
-  color: var(--primary-dark);
+  background: var(--surface);
+  color: var(--primary);
   padding: 0.5rem 1.1rem;
   border-radius: 999px;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   cursor: pointer;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .dashboard-tab:hover {
-  background: rgba(31, 122, 140, 0.12);
+  background: var(--surface-muted);
 }
 
 .dashboard-tab.active {
   background: var(--primary);
-  color: white;
-  box-shadow: 0 15px 30px rgba(15, 76, 92, 0.15);
+  color: var(--surface);
+  box-shadow: 0 15px 30px var(--shadow-soft);
 }
 
 .customer-panel-header {
@@ -583,33 +779,31 @@ button[disabled] {
 }
 
 @media (max-width: 600px) {
-  .top-bar {
-    padding: 1rem 0;
-  }
-
-  .top-bar h1 {
-    font-size: 1.5rem;
-  }
-
-  .main-nav {
+  .header-main {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.5rem;
+    gap: 1rem;
   }
 
-  .main-nav-buttons {
+  .header-nav {
     width: 100%;
     flex-direction: column;
-    gap: 0.5rem;
+    align-items: flex-start;
+    gap: 0.6rem;
   }
 
-  .nav-button,
-  .login-button {
+  .nav-link {
     width: 100%;
+    text-align: left;
   }
 
-  .login-button {
-    margin-left: 0;
+  .header-actions {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .header-cta {
+    width: 100%;
   }
 
   .dashboard-header {
@@ -1507,8 +1701,8 @@ th {
 }
 
 .status-badge.status-info {
-  background: rgba(31, 122, 140, 0.12);
-  color: var(--primary-dark);
+  background: rgba(47, 61, 79, 0.12);
+  color: var(--primary);
 }
 
 .status-badge.status-success {
@@ -1517,12 +1711,12 @@ th {
 }
 
 .status-badge.status-warning {
-  background: rgba(255, 127, 80, 0.18);
+  background: rgba(159, 121, 62, 0.18);
   color: var(--accent);
 }
 
 .status-badge.status-danger {
-  background: rgba(197, 48, 48, 0.15);
+  background: rgba(187, 76, 60, 0.18);
   color: var(--danger);
 }
 
@@ -1604,12 +1798,55 @@ th {
 }
 
 .footer {
-  padding-bottom: 2rem;
+  padding: clamp(1.6rem, 4vw, 2.6rem) 0 clamp(1.8rem, 4vw, 2.4rem);
   color: var(--muted);
   text-align: center;
 }
 
+.footer small {
+  display: block;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 @media (max-width: 768px) {
+  .top-strip-content {
+    gap: 0.5rem 1rem;
+  }
+
+  .header-main {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .header-nav {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+
+  .header-session {
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .header-session-exit {
+    font-size: 0.68rem;
+  }
+
+  .header-cta {
+    width: 100%;
+  }
+
   .input-group {
     flex-direction: column;
   }
@@ -1625,6 +1862,10 @@ th {
 }
 
 @media (max-width: 640px) {
+  .brand-text {
+    display: none;
+  }
+
   .table-wrapper {
     overflow-x: visible;
   }


### PR DESCRIPTION
## Summary
- ensure the header swaps the login call to action for the active staff session with a logout shortcut once authenticated
- tighten the dashboard tab controller so only the selected panel is shown and accessibility attributes stay in sync
- reset header/session UI on logout and expose the same action from the main navigation

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68d3838cd274833292294ea8c9562b78