### PR TITLE
refactor: enforce monochrome branding and role shortcuts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,31 +4,113 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portal de Sastrería</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="top-bar">
-      <div class="container">
-        <h1>Portal de Sastrería</h1>
-        <nav class="main-nav">
-          <div class="main-nav-buttons">
-            <button class="nav-button active" data-view="client-view">Clientes</button>
-            <button
-              class="nav-button hidden"
-              data-view="staff-view"
-              id="panelNavButton"
+    <header class="site-header">
+      <div class="top-info">
+        <div class="container top-info-inner">
+          <a
+            class="top-info-highlight"
+            href="https://wa.me/+593968059560"
+            target="_blank"
+            rel="noopener"
+          >
+            <span aria-hidden="true">WA</span>
+            Escríbenos y te asesoramos gratis
+          </a>
+          <nav class="top-links" aria-label="Información de la tienda">
+            <a href="https://www.adams.com.ec/sobre-nosotros/" target="_blank" rel="noopener"
+              >Sobre nosotros</a
             >
-              Panel
+            <a href="https://www.adams.com.ec/blog/" target="_blank" rel="noopener">Viernes de blog</a>
+            <a href="https://www.adams.com.ec/contactanos/" target="_blank" rel="noopener">Contáctanos</a>
+            <a href="https://www.adams.com.ec/faq/" target="_blank" rel="noopener">FAQ</a>
+          </nav>
+        </div>
+      </div>
+      <div class="main-header">
+        <div class="container main-header-inner">
+          <a
+            class="brand"
+            href="https://www.adams.com.ec/"
+            target="_blank"
+            rel="noopener"
+            aria-label="Adams Fashion Store"
+          >
+            <img
+              src="https://www.adams.com.ec/wp-content/uploads/2020/11/adam-.png"
+              alt="Adams Fashion Store"
+              loading="lazy"
+            />
+          </a>
+          <nav class="main-nav" aria-label="Navegación principal">
+            <div class="main-nav-buttons" role="tablist">
+              <button class="nav-button active" data-view="client-view">Clientes</button>
+              <button
+                class="nav-button hidden"
+                data-view="staff-view"
+                id="panelNavButton"
+              >
+                Panel
+              </button>
+            </div>
+            <button type="button" class="login-button" id="loginNavButton">
+              Iniciar sesión
             </button>
-          </div>
-          <button type="button" class="login-button" id="loginNavButton">
-            Iniciar sesión
-          </button>
-        </nav>
+          </nav>
+        </div>
+      </div>
+      <div class="category-bar hidden" id="categoryBar">
+        <div class="container category-bar-inner">
+          <nav class="category-nav" aria-label="Atajos del panel administrativo">
+            <button type="button" class="category-pill" data-target-tab="orderListPanel">
+              Órdenes registradas
+            </button>
+            <button type="button" class="category-pill" data-target-tab="orderKanbanPanel">
+              Kanban de órdenes
+            </button>
+            <button
+              type="button"
+              class="category-pill"
+              data-target-tab="orderCreatePanel"
+              data-hide-roles="sastre"
+            >
+              Crear orden
+            </button>
+            <button type="button" class="category-pill" data-target-tab="customersPanel">
+              Clientes
+            </button>
+            <button
+              type="button"
+              class="category-pill"
+              data-target-tab="usersPanel"
+              data-required-role="administrador"
+            >
+              Usuarios
+            </button>
+            <button
+              type="button"
+              class="category-pill"
+              data-target-tab="auditLogPanel"
+              data-required-role="administrador"
+            >
+              Bitácora
+            </button>
+          </nav>
+          <span class="category-extra hidden" id="categoryBarExtra">Acceso administrativo</span>
+        </div>
       </div>
     </header>
 
     <main class="container">
+      <h1 class="sr-only">Portal de Sastrería</h1>
       <section id="client-view" class="view active">
         <div class="card">
           <h2>Consulta el estado de tu orden</h2>

--- a/frontend/order.html
+++ b/frontend/order.html
@@ -4,17 +4,75 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Detalle de la orden | Portal de Sastrería</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="top-bar">
-      <div class="container order-detail-top">
-        <h1>Portal de Sastrería</h1>
-        <a class="link-button" href="index.html">Volver al panel</a>
+    <header class="site-header">
+      <div class="top-info">
+        <div class="container top-info-inner">
+          <a
+            class="top-info-highlight"
+            href="https://wa.me/+593968059560"
+            target="_blank"
+            rel="noopener"
+          >
+            <span aria-hidden="true">WA</span>
+            Escríbenos y te asesoramos gratis
+          </a>
+          <nav class="top-links" aria-label="Información de la tienda">
+            <a href="https://www.adams.com.ec/sobre-nosotros/" target="_blank" rel="noopener"
+              >Sobre nosotros</a
+            >
+            <a href="https://www.adams.com.ec/blog/" target="_blank" rel="noopener">Viernes de blog</a>
+            <a href="https://www.adams.com.ec/contactanos/" target="_blank" rel="noopener">Contáctanos</a>
+            <a href="https://www.adams.com.ec/faq/" target="_blank" rel="noopener">FAQ</a>
+          </nav>
+        </div>
+      </div>
+      <div class="main-header">
+        <div class="container main-header-inner">
+          <a
+            class="brand"
+            href="https://www.adams.com.ec/"
+            target="_blank"
+            rel="noopener"
+            aria-label="Adams Fashion Store"
+          >
+            <img
+              src="https://www.adams.com.ec/wp-content/uploads/2020/11/adam-.png"
+              alt="Adams Fashion Store"
+              loading="lazy"
+            />
+          </a>
+          <nav class="main-nav" aria-label="Navegación principal">
+            <div class="main-nav-buttons">
+              <a class="nav-button" href="index.html">Portal</a>
+            </div>
+            <a class="login-button" href="index.html">Volver al panel</a>
+          </nav>
+        </div>
+      </div>
+      <div class="category-bar">
+        <div class="container category-bar-inner">
+          <nav class="category-nav" aria-label="Categorías destacadas">
+            <a class="category-pill is-highlight" href="#orderDetailContent">Seguimiento</a>
+            <a class="category-pill" href="#orderDetailMeasurements">Ajustes</a>
+            <a class="category-pill" href="#orderDetailTasks">Entrega</a>
+            <a class="category-pill" href="#orderDetailNotes">Historial</a>
+          </nav>
+          <span class="category-extra">Actualización en línea</span>
+        </div>
       </div>
     </header>
 
     <main class="container">
+      <h1 class="sr-only">Detalle de la orden</h1>
       <section class="card order-detail-card">
         <div class="order-detail-page-header">
           <div class="order-detail-heading">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,15 +1,20 @@
 :root {
   color-scheme: light;
-  --primary: #1f7a8c;
-  --primary-dark: #0f4c5c;
-  --secondary: #f4f1de;
-  --accent: #ff7f50;
-  --text: #1f2933;
-  --muted: #6b7280;
-  --border: #d9e2ec;
-  --success: #2f855a;
-  --danger: #c53030;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --primary: #111111;
+  --primary-dark: #000000;
+  --primary-contrast: #ffffff;
+  --accent: #f1f1f1;
+  --accent-dark: #dcdcdc;
+  --secondary: #f5f5f5;
+  --surface: #ffffff;
+  --surface-muted: #f2f2f2;
+  --text: #111111;
+  --muted: #555555;
+  --border: #d9d9d9;
+  --shadow-color: 0, 0, 0;
+  --success: #1f1f1f;
+  --danger: #2c2c2c;
+  font-family: "Lato", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 * {
@@ -18,7 +23,7 @@
 
 body {
   margin: 0;
-  background: #f7fafc;
+  background: var(--secondary);
   color: var(--text);
   overflow-x: hidden;
 }
@@ -30,71 +35,234 @@ body {
   padding: 0 clamp(1rem, 4vw, 2.5rem);
 }
 
-.top-bar {
-  background: linear-gradient(120deg, var(--primary-dark), var(--primary));
-  color: white;
-  padding: 1.2rem 0;
-  box-shadow: 0 10px 25px rgba(15, 76, 92, 0.15);
+.site-header {
+  position: relative;
+  z-index: 10;
+  box-shadow: 0 8px 22px rgba(var(--shadow-color), 0.08);
 }
 
-.top-bar h1 {
-  margin: 0;
-  font-size: 1.8rem;
+.top-info {
+  background: var(--primary);
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.top-info-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0;
+}
+
+.top-info-highlight {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--primary-contrast);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.top-info-highlight span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--primary-contrast);
+  font-size: 0.8rem;
+}
+
+.top-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.top-links a {
+  color: rgba(255, 255, 255, 0.76);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.top-links a:hover {
+  color: #ffffff;
+}
+
+
+.main-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.main-header-inner {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: clamp(1rem, 4vw, 2.5rem);
+  padding: 1.1rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+}
+
+.brand img {
+  display: block;
+  max-height: clamp(56px, 7vw, 72px);
+  width: auto;
 }
 
 .main-nav {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-top: 0.75rem;
+  gap: 1rem;
+  justify-content: flex-end;
   flex-wrap: wrap;
 }
 
 .main-nav-buttons {
+  display: inline-flex;
+  gap: 0.5rem;
+  background: var(--surface-muted);
+  padding: 0.35rem;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+}
+
+.nav-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  padding: 0.5rem 1.35rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-button:hover,
+.nav-button:focus-visible {
+  outline: none;
+  background: rgba(17, 17, 17, 0.08);
+  color: var(--primary);
+}
+
+.nav-button.active {
+  background: var(--primary);
+  color: var(--primary-contrast);
+  box-shadow: 0 10px 20px rgba(var(--shadow-color), 0.14);
+  transform: translateY(-1px);
+}
+
+.login-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--primary);
+  background: var(--primary);
+  color: var(--primary-contrast);
+  padding: 0.55rem 1.6rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.login-button:hover,
+.login-button:focus-visible,
+.login-button.active {
+  outline: none;
+  background: var(--primary-dark);
+  border-color: var(--primary-dark);
+  color: var(--primary-contrast);
+  transform: translateY(-1px);
+}
+
+.category-bar {
+  background: var(--primary);
+  color: var(--primary-contrast);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.category-bar-inner {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.65rem 0;
+  overflow-x: auto;
+}
+
+.category-nav {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
 }
 
-.nav-button {
-  border: none;
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  padding: 0.5rem 1.25rem;
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: 0.95rem;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.nav-button:hover,
-.nav-button.active {
-  background: white;
-  color: var(--primary-dark);
-  transform: translateY(-1px);
-}
-
-.login-button {
+.category-extra {
   margin-left: auto;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  background: transparent;
-  color: white;
-  padding: 0.5rem 1.35rem;
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: 0.95rem;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+  white-space: nowrap;
 }
 
-.login-button:hover,
-.login-button.active {
-  background: white;
-  color: var(--primary-dark);
+.category-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  text-decoration: none;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.category-pill.is-highlight {
+  background: var(--primary-contrast);
+  color: var(--primary);
+  border-color: transparent;
+}
+
+.category-pill:hover,
+.category-pill:focus-visible {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.45);
+  color: #ffffff;
   transform: translateY(-1px);
 }
 
 main {
-  padding: clamp(1.75rem, 4vw, 2.5rem) 0;
+  padding: clamp(2.5rem, 4vw, 3.5rem) 0;
 }
 
 .view {
@@ -105,22 +273,26 @@ main {
   display: block;
 }
 
+
 .card {
-  background: white;
-  border-radius: 18px;
-  padding: clamp(1.25rem, 4vw, 1.8rem);
-  margin-bottom: 2rem;
-  box-shadow: 0 25px 60px rgba(15, 76, 92, 0.08);
+  background: var(--surface);
+  border-radius: 24px;
+  padding: clamp(1.45rem, 4vw, 2rem);
+  margin-bottom: 2.4rem;
+  border: 1px solid rgba(7, 10, 12, 0.05);
+  box-shadow: 0 24px 55px rgba(var(--shadow-color), 0.09);
 }
 
 h2 {
   margin-top: 0;
-  font-size: 1.6rem;
+  font-size: clamp(1.65rem, 3vw, 1.9rem);
+  letter-spacing: 0.02em;
 }
 
 h3 {
   margin-top: 0;
-  font-size: 1.2rem;
+  font-size: clamp(1.2rem, 2.4vw, 1.35rem);
+  letter-spacing: 0.01em;
 }
 
 .form-grid {
@@ -136,6 +308,7 @@ h3 {
 
 label {
   font-weight: 600;
+  color: var(--muted);
 }
 
 .sr-only {
@@ -154,12 +327,13 @@ input[type="text"],
 input[type="password"],
 textarea,
 select {
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 0.65rem 0.75rem;
+  background: var(--surface);
+  border: 1px solid rgba(7, 10, 12, 0.12);
+  border-radius: 12px;
+  padding: 0.7rem 0.85rem;
   font-size: 1rem;
   font-family: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 input:focus,
@@ -167,7 +341,7 @@ textarea:focus,
 select:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(31, 122, 140, 0.2);
+  box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.18);
 }
 
 textarea {
@@ -176,43 +350,54 @@ textarea {
 
 button {
   font-family: inherit;
-  font-size: 1rem;
+  font-size: 0.95rem;
   cursor: pointer;
 }
 
 button.primary {
   background: var(--primary);
-  color: white;
+  color: var(--primary-contrast);
   border: none;
-  padding: 0.75rem 1.5rem;
-  border-radius: 10px;
-  transition: background 0.2s ease, transform 0.2s ease;
+  padding: 0.75rem 1.6rem;
+  border-radius: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 button.primary:hover {
   background: var(--primary-dark);
   transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(var(--shadow-color), 0.12);
 }
 
 button.secondary {
   background: transparent;
-  border: 1px dashed var(--primary);
-  color: var(--primary-dark);
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
+  border: 1px solid rgba(7, 10, 12, 0.16);
+  color: var(--primary);
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
   width: fit-content;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 button.secondary:hover {
-  border-style: solid;
+  border-color: var(--primary);
+  color: var(--primary);
+  transform: translateY(-1px);
 }
 
 button.danger {
   background: var(--danger);
-  color: white;
+  color: var(--primary-contrast);
   border: none;
   padding: 0.55rem 1rem;
   border-radius: 8px;
+  font-weight: 600;
 }
 
 button.danger:hover {
@@ -220,28 +405,31 @@ button.danger:hover {
 }
 
 button.danger.ghost {
-  background: rgba(197, 48, 48, 0.1);
+  background: rgba(17, 17, 17, 0.12);
   color: var(--danger);
 }
 
 button.danger.ghost:hover {
-  background: rgba(197, 48, 48, 0.2);
+  background: rgba(17, 17, 17, 0.2);
 }
 
 button.full-width {
   width: 100%;
   background: var(--primary);
   border: none;
-  color: white;
-  padding: 0.75rem;
-  border-radius: 10px;
+  color: var(--primary-contrast);
+  padding: 0.8rem;
+  border-radius: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 button.link-button {
   background: none;
   border: none;
-  color: var(--primary-dark);
-  font-weight: 600;
+  color: var(--primary);
+  font-weight: 700;
   padding: 0;
   margin-left: 0.5rem;
   text-decoration: underline;
@@ -250,19 +438,19 @@ button.link-button {
 }
 
 button.link-button:hover {
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 
 a.link-button {
-  color: var(--primary-dark);
-  font-weight: 600;
+  color: var(--primary);
+  font-weight: 700;
   text-decoration: underline;
   text-decoration-thickness: 1.5px;
   text-underline-offset: 3px;
 }
 
 a.link-button:hover {
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 
 button[disabled] {
@@ -280,12 +468,13 @@ button[disabled] {
 }
 
 .order-result {
-  margin-top: 1.5rem;
-  padding: 1.5rem;
-  border-radius: 14px;
-  border: 1px solid var(--border);
-  background: var(--secondary);
-  line-height: 1.5;
+  margin-top: 1.6rem;
+  padding: 1.6rem;
+  border-radius: 18px;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  background: var(--surface-muted);
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
 }
 
 .order-result.hidden {
@@ -314,24 +503,32 @@ button[disabled] {
 }
 
 .dashboard-tab {
-  border: 1px solid var(--border);
-  background: white;
-  color: var(--primary-dark);
-  padding: 0.5rem 1.1rem;
+  border: 1px solid rgba(7, 10, 12, 0.12);
+  background: var(--surface);
+  color: var(--muted);
+  padding: 0.55rem 1.2rem;
   border-radius: 999px;
-  font-size: 0.95rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.dashboard-tab:hover {
-  background: rgba(31, 122, 140, 0.12);
+.dashboard-tab:hover,
+.dashboard-tab:focus-visible {
+  outline: none;
+  background: rgba(17, 17, 17, 0.1);
+  border-color: rgba(17, 17, 17, 0.25);
+  color: var(--primary);
 }
 
 .dashboard-tab.active {
   background: var(--primary);
-  color: white;
-  box-shadow: 0 15px 30px rgba(15, 76, 92, 0.15);
+  border-color: var(--primary);
+  color: var(--primary-contrast);
+  box-shadow: 0 18px 32px rgba(var(--shadow-color), 0.12);
 }
 
 .customer-panel-header {
@@ -381,11 +578,12 @@ button[disabled] {
 }
 
 .customer-create {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.25rem;
-  background: #f9fbfc;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 16px;
+  padding: 1.35rem;
+  background: var(--surface-muted);
   margin-bottom: 1.5rem;
+  box-shadow: 0 16px 32px rgba(var(--shadow-color), 0.08);
 }
 
 .users-panel-header {
@@ -420,10 +618,10 @@ button[disabled] {
 
 .user-create,
 .user-edit {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.25rem;
-  background: #f9fbfc;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 16px;
+  padding: 1.35rem;
+  background: var(--surface-muted);
   margin-bottom: 1.5rem;
   display: flex;
   flex-direction: column;
@@ -485,10 +683,10 @@ button[disabled] {
 }
 
 .customer-detail {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.5rem;
-  background: #f9fbfc;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 18px;
+  padding: 1.6rem;
+  background: var(--surface-muted);
   margin-top: 1.5rem;
   display: flex;
   flex-direction: column;
@@ -531,10 +729,10 @@ button[disabled] {
 
 .customer-order-history-list {
   margin-top: 0.75rem;
-  border: 1px dashed var(--border);
-  border-radius: 10px;
-  padding: 0.75rem;
-  background: white;
+  border: 1px dashed rgba(7, 10, 12, 0.12);
+  border-radius: 14px;
+  padding: 0.85rem;
+  background: var(--surface);
 }
 
 .customer-order-history-items {
@@ -578,28 +776,43 @@ button[disabled] {
 
 
 .tag.muted-tag {
-  background: rgba(148, 163, 184, 0.18);
+  background: rgba(89, 90, 90, 0.18);
   color: var(--muted);
 }
 
 @media (max-width: 600px) {
-  .top-bar {
-    padding: 1rem 0;
+  .top-info-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    text-align: left;
   }
 
-  .top-bar h1 {
-    font-size: 1.5rem;
+  .top-links {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .main-header-inner {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+  }
+
+  .brand {
+    justify-content: center;
   }
 
   .main-nav {
+    width: 100%;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.5rem;
+    gap: 0.75rem;
   }
 
   .main-nav-buttons {
     width: 100%;
-    flex-direction: column;
+    flex-wrap: wrap;
+    justify-content: flex-start;
     gap: 0.5rem;
   }
 
@@ -608,7 +821,13 @@ button[disabled] {
     width: 100%;
   }
 
-  .login-button {
+  .category-bar-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .category-extra {
     margin-left: 0;
   }
 
@@ -701,10 +920,10 @@ button[disabled] {
 }
 
 .order-detail {
-  border: 1px solid var(--border);
-  border-radius: 0 0 12px 12px;
-  padding: 1.5rem;
-  background: #f9fbfc;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 0 0 16px 16px;
+  padding: 1.6rem;
+  background: var(--surface-muted);
   margin: 0;
   display: flex;
   flex-direction: column;
@@ -742,19 +961,6 @@ button[disabled] {
   margin-top: 0;
 }
 
-.order-detail-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.order-detail-top h1 {
-  font-size: 1.6rem;
-  margin: 0;
-}
-
 .order-detail-page-header {
   display: flex;
   align-items: flex-start;
@@ -786,25 +992,29 @@ button[disabled] {
 
 .order-detail-status-message {
   margin-top: 1.25rem;
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
-  background: #f1f5f9;
+  padding: 0.9rem 1.1rem;
+  border-radius: 16px;
+  background: var(--surface-muted);
   color: var(--muted);
   font-size: 0.95rem;
+  border: 1px solid rgba(7, 10, 12, 0.06);
 }
 
 .order-detail-status-message.loading {
-  background: rgba(31, 122, 140, 0.12);
-  color: var(--primary-dark);
+  background: rgba(17, 17, 17, 0.08);
+  border-color: rgba(17, 17, 17, 0.2);
+  color: var(--primary);
 }
 
 .order-detail-status-message.error {
-  background: rgba(197, 48, 48, 0.12);
+  background: rgba(44, 44, 44, 0.12);
+  border-color: rgba(44, 44, 44, 0.24);
   color: var(--danger);
 }
 
 .order-detail-status-message.success {
-  background: rgba(47, 133, 90, 0.14);
+  background: rgba(31, 31, 31, 0.12);
+  border-color: rgba(31, 31, 31, 0.24);
   color: var(--success);
 }
 
@@ -876,23 +1086,23 @@ button[disabled] {
 }
 
 .order-detail-task {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: #f8fafc;
-  padding: 0.85rem 1rem;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 14px;
+  background: var(--surface-muted);
+  padding: 0.95rem 1.1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
 .order-detail-task.is-completed {
-  border-color: rgba(47, 133, 90, 0.35);
-  background: rgba(47, 133, 90, 0.08);
+  border-color: rgba(31, 31, 31, 0.25);
+  background: rgba(31, 31, 31, 0.08);
 }
 
 .order-detail-task.is-pending {
-  border-color: rgba(255, 127, 80, 0.35);
-  background: rgba(255, 127, 80, 0.08);
+  border-color: rgba(17, 17, 17, 0.18);
+  background: rgba(17, 17, 17, 0.05);
 }
 
 .order-detail-task-header {
@@ -1006,13 +1216,14 @@ button[disabled] {
 }
 
 .kanban-column {
-  background: #f9fbfc;
-  border: 1px solid var(--border);
-  border-radius: 14px;
+  background: var(--surface-muted);
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 16px;
   min-width: clamp(220px, 24vw, 280px);
   display: flex;
   flex-direction: column;
   max-height: 70vh;
+  box-shadow: 0 16px 38px rgba(var(--shadow-color), 0.08);
 }
 
 .kanban-column-header {
@@ -1054,11 +1265,11 @@ button[disabled] {
 }
 
 .kanban-card {
-  background: white;
-  border-radius: 12px;
-  padding: 0.85rem 1rem;
-  box-shadow: 0 20px 45px rgba(15, 76, 92, 0.08);
-  border: 1px solid rgba(31, 122, 140, 0.08);
+  background: var(--surface);
+  border-radius: 14px;
+  padding: 0.95rem 1.05rem;
+  box-shadow: 0 18px 40px rgba(var(--shadow-color), 0.08);
+  border: 1px solid rgba(7, 10, 12, 0.08);
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
@@ -1073,14 +1284,14 @@ button[disabled] {
 
 .kanban-card.is-clickable:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 48px rgba(15, 76, 92, 0.12);
+  box-shadow: 0 20px 50px rgba(var(--shadow-color), 0.12);
 }
 
 .kanban-card.is-clickable:focus-visible {
-  outline: 3px solid rgba(31, 122, 140, 0.35);
+  outline: 3px solid rgba(17, 17, 17, 0.35);
   outline-offset: 3px;
   transform: translateY(-2px);
-  box-shadow: 0 20px 52px rgba(15, 76, 92, 0.16);
+  box-shadow: 0 22px 55px rgba(var(--shadow-color), 0.16);
 }
 
 
@@ -1094,7 +1305,7 @@ button[disabled] {
 .kanban-card-order {
   font-weight: 700;
   font-size: 1rem;
-  color: var(--primary-dark);
+  color: var(--primary);
   word-break: break-word;
 }
 
@@ -1216,19 +1427,23 @@ button[disabled] {
 }
 
 .pagination-button {
-  border: 1px solid var(--border);
-  background: white;
-  color: var(--primary-dark);
-  padding: 0.35rem 0.85rem;
-  border-radius: 8px;
-  font-size: 0.9rem;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  border: 1px solid rgba(7, 10, 12, 0.12);
+  background: var(--surface);
+  color: var(--primary);
+  padding: 0.4rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .pagination-button:hover:not(:disabled) {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: white;
+  background: rgba(17, 17, 17, 0.08);
+  border-color: rgba(17, 17, 17, 0.2);
+  color: var(--primary);
+  transform: translateY(-1px);
 }
 
 .pagination-button:disabled {
@@ -1258,11 +1473,11 @@ button[disabled] {
 }
 
 .measurement-set {
-  border: 1px solid var(--border);
-  border-radius: 12px;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 14px;
   padding: 1rem;
-  background: white;
-  box-shadow: 0 10px 25px rgba(15, 76, 92, 0.04);
+  background: var(--surface);
+  box-shadow: 0 16px 32px rgba(var(--shadow-color), 0.07);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -1277,10 +1492,10 @@ button[disabled] {
 }
 
 .measurement-option {
-  border: 1px solid var(--border);
-  border-radius: 12px;
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 14px;
   padding: 1rem;
-  background: #f8fafc;
+  background: var(--surface-muted);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -1316,7 +1531,7 @@ td {
 
 th {
   text-align: left;
-  background: rgba(31, 122, 140, 0.08);
+  background: rgba(17, 17, 17, 0.05);
 }
 
 .order-row {
@@ -1324,7 +1539,7 @@ th {
 }
 
 .order-row.is-selected {
-  background: rgba(31, 122, 140, 0.08);
+  background: rgba(17, 17, 17, 0.05);
 }
 
 .order-row.is-selected td {
@@ -1336,7 +1551,7 @@ th {
 }
 
 .customer-row.is-selected {
-  background: rgba(31, 122, 140, 0.08);
+  background: rgba(17, 17, 17, 0.05);
 }
 
 .customer-row.is-selected td {
@@ -1348,7 +1563,7 @@ th {
 }
 
 .user-row.is-editing {
-  background: rgba(31, 122, 140, 0.08);
+  background: rgba(17, 17, 17, 0.05);
 }
 
 .user-row.is-editing td {
@@ -1367,8 +1582,8 @@ th {
   min-width: 2.25rem;
   padding: 0.25rem 0.65rem;
   border-radius: 999px;
-  background: rgba(31, 122, 140, 0.18);
-  color: var(--primary-dark);
+  background: rgba(17, 17, 17, 0.12);
+  color: var(--primary);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -1436,10 +1651,10 @@ th {
 
 @keyframes measurementRowFlash {
   0% {
-    box-shadow: 0 0 0 0 rgba(15, 76, 92, 0.45);
+    box-shadow: 0 0 0 0 rgba(17, 17, 17, 0.35);
   }
   60% {
-    box-shadow: 0 0 0 9px rgba(15, 76, 92, 0);
+    box-shadow: 0 0 0 9px rgba(17, 17, 17, 0);
   }
   100% {
     box-shadow: none;
@@ -1448,22 +1663,22 @@ th {
 
 .measurement-tag-button {
   border: none;
-  background: rgba(31, 122, 140, 0.12);
-  color: var(--primary-dark);
+  background: rgba(17, 17, 17, 0.14);
+  color: var(--primary);
   cursor: pointer;
   font: inherit;
   transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .measurement-tag-button:hover {
-  background: rgba(31, 122, 140, 0.24);
+  background: rgba(17, 17, 17, 0.2);
   transform: translateY(-1px);
 }
 
 .measurement-tag-button:focus-visible {
-  outline: 3px solid rgba(31, 122, 140, 0.35);
+  outline: 3px solid rgba(17, 17, 17, 0.35);
   outline-offset: 2px;
-  background: rgba(31, 122, 140, 0.26);
+  background: rgba(17, 17, 17, 0.26);
 }
 
 .order-task-input-label {
@@ -1475,8 +1690,8 @@ th {
   align-items: center;
   padding: 0.25rem 0.55rem;
   border-radius: 999px;
-  background: rgba(31, 122, 140, 0.12);
-  color: var(--primary-dark);
+  background: rgba(17, 17, 17, 0.12);
+  color: var(--primary);
   margin: 0.15rem;
   font-size: 0.85rem;
 }
@@ -1491,8 +1706,8 @@ th {
   font-size: 0.85rem;
   font-weight: 600;
   line-height: 1.25;
-  background: rgba(31, 122, 140, 0.12);
-  color: var(--primary-dark);
+  background: rgba(17, 17, 17, 0.12);
+  color: var(--primary);
   text-align: center;
   white-space: normal;
   word-break: break-word;
@@ -1502,28 +1717,28 @@ th {
 }
 
 .status-badge.status-neutral {
-  background: rgba(148, 163, 184, 0.18);
-  color: var(--muted);
+  background: rgba(120, 120, 120, 0.18);
+  color: var(--primary-contrast);
 }
 
 .status-badge.status-info {
-  background: rgba(31, 122, 140, 0.12);
-  color: var(--primary-dark);
+  background: rgba(0, 0, 0, 0.12);
+  color: var(--primary);
 }
 
 .status-badge.status-success {
-  background: rgba(47, 133, 90, 0.15);
-  color: var(--success);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--primary-contrast);
 }
 
 .status-badge.status-warning {
-  background: rgba(255, 127, 80, 0.18);
-  color: var(--accent);
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--primary);
 }
 
 .status-badge.status-danger {
-  background: rgba(197, 48, 48, 0.15);
-  color: var(--danger);
+  background: rgba(0, 0, 0, 0.24);
+  color: var(--primary-contrast);
 }
 
 .table-wrapper pre {
@@ -1531,9 +1746,9 @@ th {
   word-break: break-word;
   font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 0.8rem;
-  background: #f1f5f9;
-  border-radius: 8px;
-  padding: 0.5rem;
+  background: var(--surface-muted);
+  border-radius: 10px;
+  padding: 0.6rem;
 }
 
 .public-order-list {
@@ -1544,11 +1759,11 @@ th {
 }
 
 .public-order-card {
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 1.25rem;
-  background: white;
-  box-shadow: 0 10px 30px rgba(15, 76, 92, 0.08);
+  border: 1px solid rgba(7, 10, 12, 0.08);
+  border-radius: 18px;
+  padding: 1.3rem;
+  background: var(--surface);
+  box-shadow: 0 18px 36px rgba(var(--shadow-color), 0.08);
 }
 
 .public-order-card header {
@@ -1575,11 +1790,11 @@ th {
   position: fixed;
   bottom: 1.5rem;
   right: 1.5rem;
-  background: var(--primary-dark);
-  color: white;
+  background: var(--primary);
+  color: var(--primary-contrast);
   padding: 0.9rem 1.2rem;
-  border-radius: 12px;
-  box-shadow: 0 20px 45px rgba(15, 76, 92, 0.25);
+  border-radius: 14px;
+  box-shadow: 0 20px 45px rgba(var(--shadow-color), 0.18);
   opacity: 0;
   transform: translateY(20px);
   transition: opacity 0.3s ease, transform 0.3s ease;
@@ -1643,11 +1858,11 @@ th {
 
   .table-wrapper tbody tr {
     display: block;
-    background: white;
-    border: 1px solid var(--border);
-    border-radius: 12px;
+    background: var(--surface);
+    border: 1px solid rgba(7, 10, 12, 0.08);
+    border-radius: 16px;
     margin-bottom: 1rem;
-    box-shadow: 0 18px 32px rgba(15, 76, 92, 0.08);
+    box-shadow: 0 18px 32px rgba(var(--shadow-color), 0.08);
     overflow: hidden;
   }
 
@@ -1689,7 +1904,7 @@ th {
   .order-row.is-selected,
   .customer-row.is-selected {
     border-color: var(--primary);
-    box-shadow: 0 20px 36px rgba(15, 76, 92, 0.12);
+    box-shadow: 0 20px 36px rgba(var(--shadow-color), 0.12);
     margin-bottom: 0;
   }
 
@@ -1706,9 +1921,9 @@ th {
     padding: 0;
     border: 1px solid var(--border);
     border-top: none;
-    border-radius: 0 0 12px 12px;
-    background: #f9fbfc;
-    box-shadow: 0 20px 36px rgba(15, 76, 92, 0.12);
+    border-radius: 0 0 16px 16px;
+    background: var(--surface-muted);
+    box-shadow: 0 20px 36px rgba(var(--shadow-color), 0.12);
   }
 
   .order-detail,


### PR DESCRIPTION
## Summary
- adopt a monochrome Adams-inspired palette across the portal headers, controls, tables, and status accents to remove red highlights
- gate the administrative shortcut bar behind authentication with per-role visibility so only permitted staff tabs surface
- keep the shortcut pills in sync with the active dashboard view and fall back to allowed tabs when roles change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d48cbd74c8833297ea4cff5c286de0