### PR TITLE
style: refine status badges and navigation hint

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -102,7 +102,6 @@ const navButtons = document.querySelectorAll('.nav-button');
 const panelNavButton = document.getElementById('panelNavButton');
 const loginNavButton = document.getElementById('loginNavButton');
 const categoryBar = document.getElementById('categoryBar');
-const categoryBarExtra = document.getElementById('categoryBarExtra');
 const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
 const orderCreateTabButton = document.getElementById('orderCreateTabButton');
@@ -278,10 +277,6 @@ function updateDashboardShortcutVisibility() {
   if (categoryBar) {
     categoryBar.classList.toggle('hidden', !isAuthenticated);
   }
-  if (categoryBarExtra) {
-    categoryBarExtra.classList.toggle('hidden', !isAuthenticated);
-  }
-
   if (!dashboardShortcutButtons.length) {
     return;
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,7 +104,6 @@
               Bitácora
             </button>
           </nav>
-          <span class="category-extra hidden" id="categoryBarExtra">Acceso administrativo</span>
         </div>
       </div>
     </header>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -218,16 +218,6 @@ body {
   flex-wrap: wrap;
 }
 
-.category-extra {
-  margin-left: auto;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.72);
-  white-space: nowrap;
-}
-
 .category-pill {
   display: inline-flex;
   align-items: center;
@@ -280,16 +270,6 @@ body {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
-}
-
-.category-extra {
-  margin-left: auto;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #f7d9a0;
-  white-space: nowrap;
 }
 
 .category-pill {
@@ -886,10 +866,6 @@ button[disabled] {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
-  }
-
-  .category-extra {
-    margin-left: 0;
   }
 
   .dashboard-header {
@@ -1777,8 +1753,9 @@ th {
   max-width: 100%;
 }
 
+
 .status-badge.status-neutral {
-  background: rgba(120, 120, 120, 0.18);
+  background: rgba(120, 120, 120, 0.26);
   color: var(--primary-contrast);
 }
 
@@ -1788,7 +1765,7 @@ th {
 }
 
 .status-badge.status-success {
-  background: rgba(0, 0, 0, 0.18);
+  background: rgba(17, 17, 17, 0.45);
   color: var(--primary-contrast);
 }
 
@@ -1798,7 +1775,7 @@ th {
 }
 
 .status-badge.status-danger {
-  background: rgba(0, 0, 0, 0.24);
+  background: rgba(17, 17, 17, 0.6);
   color: var(--primary-contrast);
 }
 


### PR DESCRIPTION
## Summary
- darken status badge backgrounds and restore light text for neutral, success, and danger variants so the chip looks consistent whether the dashboard is open or not
- remove the "Acceso administrativo" helper label and associated styles so the shortcut bar no longer displays that wording when staff signs in

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d588e37b908332b22bdf1844509aa3