### PR TITLE
fix: align nav badges and hide duplicate menu

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -102,8 +102,8 @@ const navButtons = document.querySelectorAll('.nav-button');
 const panelNavButton = document.getElementById('panelNavButton');
 const loginNavButton = document.getElementById('loginNavButton');
 const categoryBar = document.getElementById('categoryBar');
-const categoryBarExtra = document.getElementById('categoryBarExtra');
 const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
+const dashboardSubnav = document.querySelector('.dashboard-subnav');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
 const orderCreateTabButton = document.getElementById('orderCreateTabButton');
 const orderCreatePanel = document.getElementById('orderCreatePanel');
@@ -278,10 +278,11 @@ function updateDashboardShortcutVisibility() {
   if (categoryBar) {
     categoryBar.classList.toggle('hidden', !isAuthenticated);
   }
-  if (categoryBarExtra) {
-    categoryBarExtra.classList.toggle('hidden', !isAuthenticated);
+  if (dashboardSubnav) {
+    const shouldHideSubnav = isAuthenticated && categoryBar && !categoryBar.classList.contains('hidden');
+    dashboardSubnav.classList.toggle('hidden', shouldHideSubnav);
+    dashboardSubnav.setAttribute('aria-hidden', shouldHideSubnav ? 'true' : 'false');
   }
-
   if (!dashboardShortcutButtons.length) {
     return;
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,7 +104,6 @@
               Bitácora
             </button>
           </nav>
-          <span class="category-extra hidden" id="categoryBarExtra">Acceso administrativo</span>
         </div>
       </div>
     </header>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -137,11 +137,12 @@ body {
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
 }
 
-.nav-button {
+.nav-button,
+.login-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: none;
+  border: 1px solid transparent;
   background: transparent;
   color: var(--text);
   padding: 0.5rem 1.35rem;
@@ -152,48 +153,32 @@ body {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-decoration: none;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.nav-button:hover,
-.nav-button:focus-visible {
-  outline: none;
-  background: rgba(17, 17, 17, 0.08);
-  color: var(--primary);
-}
-
-.nav-button.active {
-  background: var(--primary);
-  color: var(--primary-contrast);
-  box-shadow: 0 10px 20px rgba(var(--shadow-color), 0.14);
-  transform: translateY(-1px);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .login-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--primary);
-  background: var(--primary);
-  color: var(--primary-contrast);
-  padding: 0.55rem 1.6rem;
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-decoration: none;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  background: var(--surface-muted);
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.02);
+  font-size: 0.85rem;
 }
 
+.nav-button:hover,
+.nav-button:focus-visible,
 .login-button:hover,
-.login-button:focus-visible,
-.login-button.active {
+.login-button:focus-visible {
   outline: none;
-  background: var(--primary-dark);
-  border-color: var(--primary-dark);
+  background: rgba(17, 17, 17, 0.08);
+  color: var(--primary);
+  transform: translateY(-1px);
+}
+
+.nav-button.active,
+.login-button.active {
+  background: var(--primary);
+  border-color: var(--primary);
   color: var(--primary-contrast);
+  box-shadow: 0 10px 20px rgba(var(--shadow-color), 0.14);
   transform: translateY(-1px);
 }
 
@@ -216,16 +201,6 @@ body {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
-}
-
-.category-extra {
-  margin-left: auto;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.72);
-  white-space: nowrap;
 }
 
 .category-pill {
@@ -280,16 +255,6 @@ body {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
-}
-
-.category-extra {
-  margin-left: auto;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #f7d9a0;
-  white-space: nowrap;
 }
 
 .category-pill {
@@ -886,10 +851,6 @@ button[disabled] {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
-  }
-
-  .category-extra {
-    margin-left: 0;
   }
 
   .dashboard-header {
@@ -1777,8 +1738,9 @@ th {
   max-width: 100%;
 }
 
+
 .status-badge.status-neutral {
-  background: rgba(120, 120, 120, 0.18);
+  background: rgba(120, 120, 120, 0.26);
   color: var(--primary-contrast);
 }
 
@@ -1788,7 +1750,7 @@ th {
 }
 
 .status-badge.status-success {
-  background: rgba(0, 0, 0, 0.18);
+  background: rgba(17, 17, 17, 0.45);
   color: var(--primary-contrast);
 }
 
@@ -1798,7 +1760,7 @@ th {
 }
 
 .status-badge.status-danger {
-  background: rgba(0, 0, 0, 0.24);
+  background: rgba(17, 17, 17, 0.6);
   color: var(--primary-contrast);
 }
 


### PR DESCRIPTION
## Summary
- restyle the login pill to share the same neutral and active treatments as the Clientes/Panel badges
- hide the in-dashboard tab strip whenever the top shortcut bar is visible so the menu no longer renders twice

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d588e37b908332b22bdf1844509aa3