### PR TITLE
Fix checklist task creation in order detail form

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -180,6 +180,7 @@ const orderDetailNotesTextarea = document.getElementById('orderDetailNotes');
 const orderDetailMeasurementsContainer = document.getElementById('orderDetailMeasurements');
 const orderTasksList = document.getElementById('orderTasksList');
 const orderTaskForm = document.getElementById('orderTaskForm');
+const orderTaskAddButton = document.getElementById('orderTaskAddButton');
 const orderTaskDescriptionInput = document.getElementById('orderTaskDescription');
 const orderTaskResponsibleSelect = document.getElementById('orderTaskResponsibleSelect');
 const orderTasksPermissionsNotice = document.getElementById('orderTasksPermissionsNotice');
@@ -823,7 +824,9 @@ async function handleOrderTaskToggle(taskId, checkbox) {
 }
 
 async function handleOrderTaskCreate(event) {
-  event.preventDefault();
+  if (event) {
+    event.preventDefault();
+  }
   if (state.selectedOrderId === null) {
     showToast('Selecciona una orden antes de agregar tareas.', 'error');
     return;
@@ -845,9 +848,10 @@ async function handleOrderTaskCreate(event) {
     return;
   }
 
-  const submitButton = orderTaskForm?.querySelector('button[type="submit"]');
+  const submitButton = orderTaskAddButton;
   if (submitButton) {
     submitButton.disabled = true;
+    submitButton.setAttribute('aria-busy', 'true');
   }
   try {
     const body = { description: descriptionValue };
@@ -866,6 +870,7 @@ async function handleOrderTaskCreate(event) {
   } finally {
     if (submitButton) {
       submitButton.disabled = false;
+      submitButton.removeAttribute('aria-busy');
     }
   }
 }
@@ -3092,8 +3097,17 @@ if (updateOrderForm) {
   updateOrderForm.addEventListener('submit', handleOrderUpdate);
 }
 
-if (orderTaskForm) {
-  orderTaskForm.addEventListener('submit', handleOrderTaskCreate);
+if (orderTaskAddButton) {
+  orderTaskAddButton.addEventListener('click', handleOrderTaskCreate);
+}
+
+if (orderTaskDescriptionInput) {
+  orderTaskDescriptionInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      void handleOrderTaskCreate();
+    }
+  });
 }
 
 if (createUserForm) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -556,7 +556,7 @@
                     <div id="orderTasksList" class="order-tasks-list muted">
                       Selecciona una orden para ver el checklist.
                     </div>
-                    <form id="orderTaskForm" class="order-task-form hidden">
+                    <div id="orderTaskForm" class="order-task-form hidden" role="group" aria-label="Agregar trabajo al checklist">
                       <div class="order-task-fields">
                         <label class="sr-only" for="orderTaskDescription">Descripción del trabajo</label>
                         <input
@@ -565,13 +565,13 @@
                           maxlength="255"
                           placeholder="Describe el trabajo a registrar"
                         />
-                        <button type="submit" class="secondary">Agregar</button>
+                        <button type="button" class="secondary" id="orderTaskAddButton">Agregar</button>
                       </div>
                       <p class="muted small">
                         Añade los trabajos pendientes manualmente y marca cada casilla cuando el sastre los
                         complete.
                       </p>
-                    </form>
+                    </div>
                     <p id="orderTasksPermissionsNotice" class="muted small hidden">
                       Solo los sastres o administradores pueden modificar el checklist.
                     </p>


### PR DESCRIPTION
## Summary
- replace the nested checklist form with a non-submitting container and dedicated add button
- adjust the dashboard script to handle the new button, show busy state, and process Enter key presses without submitting the order form

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d590037a948332985b39ef8351af37