### PR TITLE
Fix login case sensitivity handling

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -7,6 +7,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from .config import get_settings
@@ -32,7 +33,17 @@ def get_password_hash(password: str) -> str:
 
 
 def authenticate_user(db: Session, username: str, password: str) -> Optional[models.User]:
-    user = db.query(models.User).filter(models.User.username == username).first()
+    if not isinstance(username, str):
+        return None
+    normalized_username = username.strip()
+    if not normalized_username:
+        return None
+    normalized_username = normalized_username.casefold()
+    user = (
+        db.query(models.User)
+        .filter(func.lower(models.User.username) == normalized_username)
+        .first()
+    )
     if not user or not verify_password(password, user.password_hash):
         return None
     return user

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -440,7 +440,7 @@ button.danger.ghost:hover {
 
 button.full-width {
   width: 100%;
-  background: var(--accent);
+  background: var(--primary);
   border: none;
   color: var(--primary-contrast);
   padding: 0.8rem;
@@ -448,6 +448,24 @@ button.full-width {
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  box-shadow: 0 10px 24px rgba(var(--shadow-color), 0.18);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.full-width:hover,
+button.full-width:focus-visible {
+  background: var(--primary-dark);
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgba(var(--shadow-color), 0.22);
+}
+
+button.full-width:disabled {
+  background: rgba(17, 17, 17, 0.3);
+  color: rgba(255, 255, 255, 0.75);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 button.link-button {


### PR DESCRIPTION
## Summary
- restore sending the username as entered from the login form
- authenticate users case-insensitively in the backend so mixed-case usernames still match

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68daaf9da434833280cf5787682d8d99