### PR TITLE
Refactor orders dashboard into unified panel

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -33,6 +33,7 @@ const state = {
   kanbanSearchTerm: '',
   kanbanNeedsRefresh: true,
   kanbanLastUpdated: null,
+  activeOrdersView: 'list',
   isCreateCustomerVisible: false,
   isCreateUserVisible: false,
   auditLogs: [],
@@ -102,12 +103,19 @@ const navButtons = document.querySelectorAll('.nav-button');
 const panelNavButton = document.getElementById('panelNavButton');
 const loginNavButton = document.getElementById('loginNavButton');
 const categoryBar = document.getElementById('categoryBar');
-const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
+const DASHBOARD_TAB_IDS = ['ordersPanel', 'customersPanel', 'usersPanel', 'auditLogPanel'];
+const ADMIN_ONLY_TABS = new Set(['usersPanel', 'auditLogPanel']);
+const dashboardTabButtons = Array.from(document.querySelectorAll('[data-tab]')).filter((btn) =>
+  DASHBOARD_TAB_IDS.includes(btn.dataset.tab)
+);
 const dashboardSubnav = document.querySelector('.dashboard-subnav');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
-const orderCreateTabButton = document.getElementById('orderCreateTabButton');
-const orderCreatePanel = document.getElementById('orderCreatePanel');
-const orderKanbanPanel = document.getElementById('orderKanbanPanel');
+const ordersTableSection = document.getElementById('ordersTableSection');
+const ordersKanbanSection = document.getElementById('ordersKanbanSection');
+const ordersCreateSection = document.getElementById('ordersCreateSection');
+const ordersCreateToggleButton = document.getElementById('ordersCreateToggleButton');
+const ordersViewToggleButtons = document.querySelectorAll('[data-orders-view]');
+const roleRestrictedElements = document.querySelectorAll('[data-hide-roles]');
 const orderKanbanColumns = document.getElementById('orderKanbanColumns');
 const orderKanbanStatus = document.getElementById('orderKanbanStatus');
 const orderKanbanSearchInput = document.getElementById('orderKanbanSearchInput');
@@ -231,7 +239,7 @@ const CUSTOMER_DETAIL_DEFAULT_SUMMARY = 'Selecciona un cliente para ver su infor
 const CUSTOMER_ORDER_HISTORY_PROMPT = 'Selecciona un cliente para ver sus órdenes anteriores.';
 const CUSTOMER_ORDER_HISTORY_EMPTY_MESSAGE = 'No tiene órdenes registradas.';
 
-let activeDashboardTab = 'orderListPanel';
+let activeDashboardTab = 'ordersPanel';
 const ORDER_TABLE_COLUMN_COUNT = 6;
 const CUSTOMER_TABLE_COLUMN_COUNT = 5;
 let activeOrderDetailRow = null;
@@ -280,17 +288,18 @@ function updateDashboardShortcutVisibility() {
     categoryBar.classList.toggle('hidden', !isAuthenticated);
   }
   if (dashboardSubnav) {
-    const shouldHideSubnav = isAuthenticated && categoryBar && !categoryBar.classList.contains('hidden');
-    dashboardSubnav.classList.toggle('hidden', shouldHideSubnav);
-    dashboardSubnav.setAttribute('aria-hidden', shouldHideSubnav ? 'true' : 'false');
+    dashboardSubnav.classList.toggle('hidden', !isAuthenticated);
+    dashboardSubnav.setAttribute('aria-hidden', isAuthenticated ? 'false' : 'true');
   }
   if (!dashboardShortcutButtons.length) {
+    applyRoleVisibility();
     return;
   }
 
   let hasVisibleActiveShortcut = false;
 
   dashboardShortcutButtons.forEach((btn) => {
+    const targetTab = btn.dataset.targetTab;
     const requiredRole = btn.dataset.requiredRole || null;
     const hideRoles = (btn.dataset.hideRoles || '')
       .split(',')
@@ -298,16 +307,24 @@ function updateDashboardShortcutVisibility() {
       .filter(Boolean);
     const lacksRequiredRole = Boolean(requiredRole) && userRole !== requiredRole;
     const hiddenForRole = hideRoles.length > 0 && (!userRole || hideRoles.includes(userRole));
-    const shouldHide = !isAuthenticated || lacksRequiredRole || hiddenForRole;
+    const isAdminTab = ADMIN_ONLY_TABS.has(targetTab);
+    const isRecognizedTab = DASHBOARD_TAB_IDS.includes(targetTab);
+    const shouldHide =
+      !isAuthenticated ||
+      !isRecognizedTab ||
+      lacksRequiredRole ||
+      hiddenForRole ||
+      (isAdminTab && userRole !== 'administrador');
     btn.classList.toggle('hidden', shouldHide);
-    if (!shouldHide && btn.dataset.targetTab === activeDashboardTab) {
+    if (!shouldHide && targetTab === activeDashboardTab) {
       hasVisibleActiveShortcut = true;
     }
   });
 
   if (isAuthenticated && !hasVisibleActiveShortcut) {
     const fallback = Array.from(dashboardShortcutButtons).find(
-      (btn) => !btn.classList.contains('hidden')
+      (btn) =>
+        !btn.classList.contains('hidden') && DASHBOARD_TAB_IDS.includes(btn.dataset.targetTab)
     );
     if (fallback) {
       setActiveDashboardTab(fallback.dataset.targetTab);
@@ -316,6 +333,7 @@ function updateDashboardShortcutVisibility() {
   }
 
   updateDashboardShortcutHighlight();
+  applyRoleVisibility();
 }
 
 dashboardShortcutButtons.forEach((btn) => {
@@ -350,13 +368,9 @@ if (loginNavButton) {
   });
 }
 
-function isOrderCreatePanelHidden() {
-  return !orderCreatePanel || orderCreatePanel.classList.contains('hidden');
-}
-
 function syncCreateOrderFormDisabled() {
   if (!createOrderForm) return;
-  const shouldDisable = isOrderCreatePanelHidden();
+  const shouldDisable = !ordersCreateSection || ordersCreateSection.classList.contains('hidden');
   createOrderForm.dataset.disabled = shouldDisable ? 'true' : 'false';
   const submitButton = createOrderForm.querySelector('button[type="submit"]');
   if (submitButton) {
@@ -364,60 +378,116 @@ function syncCreateOrderFormDisabled() {
   }
 }
 
-function setActiveDashboardTab(tabId = 'orderListPanel') {
-  if (!dashboardPanels.length) return;
+function setOrdersCreateSectionVisible(shouldShow) {
+  if (!ordersCreateSection) return;
+  const isVisible = Boolean(shouldShow);
+  ordersCreateSection.classList.toggle('hidden', !isVisible);
+  ordersCreateSection.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
+  if (ordersCreateToggleButton) {
+    ordersCreateToggleButton.setAttribute('aria-expanded', isVisible ? 'true' : 'false');
+  }
+  syncCreateOrderFormDisabled();
+  if (isVisible) {
+    const focusable = ordersCreateSection.querySelector(
+      'input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled])'
+    );
+    if (focusable) {
+      focusable.focus();
+    }
+  }
+}
+
+function applyRoleVisibility() {
   const userRole = state.user?.role || null;
-  let targetTab = tabId || 'orderListPanel';
-  if (targetTab === 'auditLogPanel' && userRole !== 'administrador') {
-    targetTab = 'orderListPanel';
-  }
-  if (targetTab === 'orderCreatePanel' && userRole === 'sastre') {
-    targetTab = 'orderListPanel';
-  }
-  if (targetTab === 'usersPanel' && userRole !== 'administrador') {
-    targetTab = 'orderListPanel';
-  }
-  activeDashboardTab = targetTab;
-  dashboardTabButtons.forEach((btn) => {
-    const tab = btn.dataset.tab;
-    if (tab === 'orderCreatePanel') {
-      const shouldHideTab = userRole === 'sastre';
-      if (shouldHideTab) {
-        btn.classList.add('hidden');
-      } else {
-        btn.classList.remove('hidden');
-      }
-      btn.disabled = shouldHideTab;
+  roleRestrictedElements.forEach((element) => {
+    const roles = (element.dataset.hideRoles || '')
+      .split(',')
+      .map((role) => role.trim())
+      .filter(Boolean);
+    const shouldHide = roles.length > 0 && (!userRole || roles.includes(userRole));
+    element.classList.toggle('hidden', shouldHide);
+    if ('disabled' in element) {
+      element.disabled = shouldHide;
     }
-    if (tab === 'usersPanel') {
-      const shouldHideUsersTab = userRole !== 'administrador';
-      if (shouldHideUsersTab) {
-        btn.classList.add('hidden');
-      } else {
-        btn.classList.remove('hidden');
-      }
-      btn.disabled = shouldHideUsersTab;
+    if (element === ordersCreateToggleButton && shouldHide) {
+      setOrdersCreateSectionVisible(false);
     }
-    btn.classList.toggle('active', tab === targetTab);
-  });
-  dashboardPanels.forEach((panel) => {
-    if (panel.id === 'orderCreatePanel' && userRole === 'sastre') {
-      panel.classList.add('hidden');
-    } else if (panel.id === 'usersPanel' && userRole !== 'administrador') {
-      panel.classList.add('hidden');
-    } else {
-      panel.classList.toggle('hidden', panel.id !== targetTab);
+    if (element === ordersCreateToggleButton) {
+      ordersCreateToggleButton.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
     }
   });
-  if (targetTab === 'usersPanel' && userRole === 'administrador') {
-    loadUsers();
+}
+
+function setActiveOrdersView(view) {
+  const nextView = view === 'kanban' ? 'kanban' : 'list';
+  state.activeOrdersView = nextView;
+  ordersViewToggleButtons.forEach((btn) => {
+    const isActive = btn.dataset.ordersView === nextView;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+  if (ordersTableSection) {
+    ordersTableSection.classList.toggle('hidden', nextView !== 'list');
+    ordersTableSection.setAttribute('aria-hidden', nextView === 'list' ? 'false' : 'true');
   }
-  if (targetTab === 'orderKanbanPanel') {
+  if (ordersKanbanSection) {
+    const isKanban = nextView === 'kanban';
+    ordersKanbanSection.classList.toggle('hidden', !isKanban);
+    ordersKanbanSection.setAttribute('aria-hidden', isKanban ? 'false' : 'true');
+  }
+  if (nextView === 'kanban') {
     ensureKanbanDataLoaded();
   } else {
     renderOrderKanban();
   }
-  syncCreateOrderFormDisabled();
+}
+
+function setActiveDashboardTab(tabId = 'ordersPanel') {
+  if (!dashboardPanels.length) return;
+  const userRole = state.user?.role || null;
+  let targetTab = tabId && DASHBOARD_TAB_IDS.includes(tabId) ? tabId : 'ordersPanel';
+  if (ADMIN_ONLY_TABS.has(targetTab) && userRole !== 'administrador') {
+    targetTab = 'ordersPanel';
+  }
+  activeDashboardTab = targetTab;
+
+  dashboardTabButtons.forEach((btn) => {
+    const tab = btn.dataset.tab;
+    if (!tab) return;
+    const isAdminTab = ADMIN_ONLY_TABS.has(tab);
+    const shouldHide = !state.token || (isAdminTab && userRole !== 'administrador');
+    btn.classList.toggle('hidden', shouldHide);
+    btn.disabled = shouldHide;
+    btn.classList.toggle('active', tab === targetTab);
+  });
+
+  dashboardPanels.forEach((panel) => {
+    const { id } = panel;
+    if (!id) return;
+    const isAdminPanel = ADMIN_ONLY_TABS.has(id);
+    const shouldHide = !state.token || (isAdminPanel && userRole !== 'administrador');
+    if (shouldHide) {
+      panel.classList.add('hidden');
+    } else {
+      panel.classList.toggle('hidden', id !== targetTab);
+    }
+  });
+
+  if (targetTab === 'usersPanel' && userRole === 'administrador') {
+    loadUsers();
+  }
+
+  if (targetTab === 'ordersPanel') {
+    if (state.activeOrdersView === 'kanban') {
+      ensureKanbanDataLoaded();
+    } else {
+      renderOrderKanban();
+    }
+    syncCreateOrderFormDisabled();
+  } else {
+    renderOrderKanban();
+  }
+
   updateDashboardShortcutHighlight();
 }
 
@@ -430,9 +500,31 @@ dashboardTabButtons.forEach((btn) => {
   });
 });
 
+ordersViewToggleButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    if (btn.disabled) {
+      return;
+    }
+    setActiveOrdersView(btn.dataset.ordersView);
+  });
+});
+
+if (ordersCreateToggleButton) {
+  ordersCreateToggleButton.addEventListener('click', () => {
+    if (ordersCreateToggleButton.disabled) {
+      return;
+    }
+    const shouldShow = ordersCreateSection?.classList.contains('hidden');
+    setOrdersCreateSectionVisible(Boolean(shouldShow));
+  });
+}
+
 setActiveDashboardTab(activeDashboardTab);
 updateDashboardShortcutHighlight();
 updateDashboardShortcutVisibility();
+setActiveOrdersView(state.activeOrdersView || 'list');
+setOrdersCreateSectionVisible(false);
+applyRoleVisibility();
 
 if (dashboardShortcutButtons.length) {
   dashboardShortcutButtons.forEach((shortcut) => {
@@ -1646,31 +1738,12 @@ function updateUserInfo() {
     }
   }
   const isAdmin = state.user.role === 'administrador';
-  if (auditLogTabButton) {
-    auditLogTabButton.classList.toggle('hidden', !isAdmin);
-  }
-  if (usersTabButton) {
-    usersTabButton.classList.toggle('hidden', !isAdmin);
-  }
-  const isTailor = state.user.role === 'sastre';
-  if (orderCreateTabButton) {
-    if (isTailor) {
-      orderCreateTabButton.classList.add('hidden');
-    } else {
-      orderCreateTabButton.classList.remove('hidden');
-    }
-    orderCreateTabButton.disabled = isTailor;
-  }
-  if (orderCreatePanel && isTailor) {
-    orderCreatePanel.classList.add('hidden');
-  }
-  if (!isAdmin && activeDashboardTab === 'auditLogPanel') {
-    setActiveDashboardTab('orderListPanel');
-  } else if (isTailor && activeDashboardTab === 'orderCreatePanel') {
-    setActiveDashboardTab('orderListPanel');
+  if (!isAdmin && ADMIN_ONLY_TABS.has(activeDashboardTab)) {
+    setActiveDashboardTab('ordersPanel');
   } else {
     setActiveDashboardTab(activeDashboardTab);
   }
+  applyRoleVisibility();
   updateUserCreationForm();
   renderOrderTasks();
   updateDashboardShortcutVisibility();
@@ -1683,7 +1756,7 @@ function showDashboard() {
   if (staffLoginCard) {
     staffLoginCard.classList.add('hidden');
   }
-  setActiveDashboardTab('orderListPanel');
+  setActiveDashboardTab('ordersPanel');
 }
 
 function hideDashboard() {
@@ -1967,7 +2040,7 @@ async function loadKanbanOrders({ force = false } = {}) {
 }
 
 function ensureKanbanDataLoaded() {
-  if (!state.token) {
+  if (!state.token || state.activeOrdersView !== 'kanban') {
     renderOrderKanban();
     return;
   }
@@ -1985,7 +2058,12 @@ function ensureKanbanDataLoaded() {
 function markKanbanDataStale() {
   state.kanbanNeedsRefresh = true;
   renderOrderKanban();
-  if (activeDashboardTab === 'orderKanbanPanel' && state.token && !state.kanbanLoading) {
+  const shouldReload =
+    activeDashboardTab === 'ordersPanel' &&
+    state.activeOrdersView === 'kanban' &&
+    state.token &&
+    !state.kanbanLoading;
+  if (shouldReload) {
     loadKanbanOrders({ force: true });
   }
 }
@@ -2226,7 +2304,7 @@ function handleLogout(auto = false) {
   if (usersTabButton) {
     usersTabButton.classList.add('hidden');
   }
-  setActiveDashboardTab('orderListPanel');
+  setActiveDashboardTab('ordersPanel');
   hideDashboard();
   if (customerSearchInput) {
     customerSearchInput.value = '';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -70,19 +70,8 @@
       <div class="category-bar hidden" id="categoryBar">
         <div class="container category-bar-inner">
           <nav class="category-nav" aria-label="Atajos del panel administrativo">
-            <button type="button" class="category-pill" data-target-tab="orderListPanel">
-              Órdenes registradas
-            </button>
-            <button type="button" class="category-pill" data-target-tab="orderKanbanPanel">
-              Kanban de órdenes
-            </button>
-            <button
-              type="button"
-              class="category-pill"
-              data-target-tab="orderCreatePanel"
-              data-hide-roles="sastre"
-            >
-              Crear orden
+            <button type="button" class="category-pill" data-target-tab="ordersPanel">
+              Órdenes
             </button>
             <button type="button" class="category-pill" data-target-tab="customersPanel">
               Clientes
@@ -154,23 +143,7 @@
           </div>
 
           <nav class="dashboard-subnav">
-            <button type="button" class="dashboard-tab active" data-tab="orderListPanel">Órdenes registradas</button>
-            <button
-              type="button"
-              class="dashboard-tab"
-              data-tab="orderKanbanPanel"
-              id="orderKanbanTabButton"
-            >
-              Kanban de órdenes
-            </button>
-            <button
-              type="button"
-              class="dashboard-tab"
-              data-tab="orderCreatePanel"
-              id="orderCreateTabButton"
-            >
-              Crear orden
-            </button>
+            <button type="button" class="dashboard-tab active" data-tab="ordersPanel">Órdenes</button>
             <button type="button" class="dashboard-tab" data-tab="customersPanel">Clientes</button>
             <button
               type="button"
@@ -419,202 +392,318 @@
             </form>
           </section>
 
-          <section class="card dashboard-panel" id="orderListPanel">
-            <h3>Órdenes registradas</h3>
-            <div class="order-panel-controls">
-              <p class="muted small">
-                Las órdenes pendientes se muestran primero, ordenadas por la fecha de entrega más
-                cercana. Las fechas vencidas se resaltan en rojo mientras la orden no haya sido
-                entregada.
-              </p>
-              <div class="order-search">
-                <label for="orderSearchInput">Buscar</label>
-                <input
-                  type="search"
-                  id="orderSearchInput"
-                  placeholder="Número de orden o cédula"
-                  autocomplete="off"
-                />
-              </div>
-              <div class="table-pagination">
-                <label for="orderPageSize">Filas por página</label>
-                <div class="pagination-controls">
-                  <select id="orderPageSize">
-                    <option value="10" selected>10</option>
-                    <option value="15">15</option>
-                    <option value="20">20</option>
-                    <option value="25">25</option>
-                    <option value="30">30</option>
-                    <option value="35">35</option>
-                    <option value="40">40</option>
-                    <option value="45">45</option>
-                    <option value="50">50</option>
-                  </select>
-                  <div class="pagination-buttons">
-                    <button
-                      type="button"
-                      class="pagination-button"
-                      id="orderPrevPage"
-                      aria-label="Página anterior de órdenes"
-                    >
-                      Anterior
-                    </button>
-                    <span
-                      id="orderPaginationInfo"
-                      class="pagination-info"
-                      aria-live="polite"
-                    >
-                      Mostrando 0-0 de 0
-                    </span>
-                    <button
-                      type="button"
-                      class="pagination-button"
-                      id="orderNextPage"
-                      aria-label="Página siguiente de órdenes"
-                    >
-                      Siguiente
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="table-wrapper">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Orden</th>
-                    <th>Cliente</th>
-                    <th>Estado</th>
-                    <th>Fecha de ingreso</th>
-                    <th>Fecha de entrega</th>
-                    <th>Acciones</th>
-                  </tr>
-                </thead>
-                <tbody id="ordersTableBody"></tbody>
-              </table>
-            </div>
-            <div id="orderDetail" class="order-detail hidden">
-              <div class="order-detail-header">
-                <div>
-                  <h4>Detalle de la orden</h4>
-                  <p class="muted small">Orden <span id="orderDetailNumber"></span></p>
-                </div>
-                <button type="button" id="closeOrderDetailButton" class="link-button">Cerrar</button>
-              </div>
-              <div class="order-detail-meta">
-                <p><strong>Registrada:</strong> <span id="orderDetailCreatedAt"></span></p>
-                <p><strong>Última actualización:</strong> <span id="orderDetailUpdatedAt"></span></p>
-              </div>
-              <form id="updateOrderForm" class="form-grid">
-                <div class="form-row">
-                  <label for="orderDetailCustomer">Cliente</label>
-                  <input type="text" id="orderDetailCustomer" readonly />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailDocument">Documento</label>
-                  <input type="text" id="orderDetailDocument" readonly />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailContact">Contacto</label>
-                  <input type="text" id="orderDetailContact" />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailInvoice">Número de factura</label>
-                  <input type="text" id="orderDetailInvoice" />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailStatus">Estado</label>
-                  <select id="orderDetailStatus"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailTailor">Sastre asignado</label>
-                  <select id="orderDetailTailor"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailVendor">Vendedor asignado</label>
-                  <select id="orderDetailVendor"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailOrigin">Establecimiento remitente</label>
-                  <select id="orderDetailOrigin"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailDeliveryDate">Fecha y hora de entrega</label>
-                  <input type="datetime-local" id="orderDetailDeliveryDate" />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailNotes">Notas</label>
-                  <textarea id="orderDetailNotes" rows="3"></textarea>
-                </div>
-                <div class="form-row">
-                  <label>Medidas</label>
-                  <div id="orderDetailMeasurements" class="measurement-tags muted"></div>
-                </div>
-                <div class="form-row">
-                  <label>Checklist de producción</label>
-                  <div id="orderTasksContainer" class="order-tasks-container">
-                    <div id="orderTasksList" class="order-tasks-list muted">
-                      Selecciona una orden para ver el checklist.
-                    </div>
-                    <div id="orderTaskForm" class="order-task-form hidden" role="group" aria-label="Agregar trabajo al checklist">
-                      <div class="order-task-fields">
-                        <label class="sr-only" for="orderTaskDescription">Descripción del trabajo</label>
-                        <input
-                          type="text"
-                          id="orderTaskDescription"
-                          maxlength="255"
-                          placeholder="Describe el trabajo a registrar"
-                        />
-                        <button type="button" class="secondary" id="orderTaskAddButton">Agregar</button>
-                      </div>
-                      <p class="muted small">
-                        Añade los trabajos pendientes manualmente y marca cada casilla cuando el sastre los
-                        complete.
-                      </p>
-                    </div>
-                    <p id="orderTasksPermissionsNotice" class="muted small hidden">
-                      Solo los sastres o administradores pueden modificar el checklist.
-                    </p>
-                  </div>
-                </div>
-                <div class="button-row">
-                  <button type="submit" class="primary">Guardar cambios</button>
-                </div>
-              </form>
-            </div>
-          </section>
-
-          <section class="card dashboard-panel hidden" id="orderKanbanPanel">
-            <div class="kanban-header">
-              <div>
-                <h3>Kanban de órdenes</h3>
+          <section class="card dashboard-panel hidden" id="ordersPanel">
+            <div class="orders-controls">
+              <div class="orders-controls-info">
+                <h3>Gestión de órdenes</h3>
                 <p class="muted small">
-                  Visualiza las órdenes agrupadas por estado y refresca el tablero para obtener los
-                  datos más recientes.
+                  Administra las órdenes registradas, visualiza el tablero Kanban y registra nuevos
+                  pedidos desde un mismo espacio.
                 </p>
               </div>
-              <div class="kanban-actions">
-                <button type="button" class="secondary" id="orderKanbanRefreshButton">
-                  Actualizar tablero
+              <div class="orders-controls-actions">
+                <div class="orders-view-toggle" role="group" aria-label="Cambiar vista de órdenes">
+                  <button type="button" data-orders-view="list">Lista</button>
+                  <button type="button" data-orders-view="kanban">Kanban</button>
+                </div>
+                <button
+                  type="button"
+                  class="primary"
+                  id="ordersCreateToggleButton"
+                  data-hide-roles="sastre"
+                  aria-expanded="false"
+                  aria-controls="ordersCreateSection"
+                >
+                  Crear orden
                 </button>
               </div>
             </div>
-            <div class="kanban-controls">
-              <div class="kanban-search">
-                <label for="orderKanbanSearchInput">Buscar</label>
-                <input
-                  type="search"
-                  id="orderKanbanSearchInput"
-                  placeholder="Número de orden, cliente o cédula"
-                  autocomplete="off"
-                />
+
+            <div id="ordersTableSection" class="orders-view-panel">
+              <div class="order-panel-controls">
+                <p class="muted small">
+                  Las órdenes pendientes se muestran primero, ordenadas por la fecha de entrega más
+                  cercana. Las fechas vencidas se resaltan en rojo mientras la orden no haya sido
+                  entregada.
+                </p>
+                <div class="order-search">
+                  <label for="orderSearchInput">Buscar</label>
+                  <input
+                    type="search"
+                    id="orderSearchInput"
+                    placeholder="Número de orden o cédula"
+                    autocomplete="off"
+                  />
+                </div>
+                <div class="table-pagination">
+                  <label for="orderPageSize">Filas por página</label>
+                  <div class="pagination-controls">
+                    <select id="orderPageSize">
+                      <option value="10" selected>10</option>
+                      <option value="15">15</option>
+                      <option value="20">20</option>
+                      <option value="25">25</option>
+                      <option value="30">30</option>
+                      <option value="35">35</option>
+                      <option value="40">40</option>
+                      <option value="45">45</option>
+                      <option value="50">50</option>
+                    </select>
+                    <div class="pagination-buttons">
+                      <button
+                        type="button"
+                        class="pagination-button"
+                        id="orderPrevPage"
+                        aria-label="Página anterior de órdenes"
+                      >
+                        Anterior
+                      </button>
+                      <span
+                        id="orderPaginationInfo"
+                        class="pagination-info"
+                        aria-live="polite"
+                      >
+                        Mostrando 0-0 de 0
+                      </span>
+                      <button
+                        type="button"
+                        class="pagination-button"
+                        id="orderNextPage"
+                        aria-label="Página siguiente de órdenes"
+                      >
+                        Siguiente
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <p class="muted small">
-                La búsqueda se aplica localmente sobre los resultados cargados en el tablero.
-              </p>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Orden</th>
+                      <th>Cliente</th>
+                      <th>Estado</th>
+                      <th>Fecha de ingreso</th>
+                      <th>Fecha de entrega</th>
+                      <th>Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ordersTableBody"></tbody>
+                </table>
+              </div>
+              <div id="orderDetail" class="order-detail hidden">
+                <div class="order-detail-header">
+                  <div>
+                    <h4>Detalle de la orden</h4>
+                    <p class="muted small">Orden <span id="orderDetailNumber"></span></p>
+                  </div>
+                  <button type="button" id="closeOrderDetailButton" class="link-button">Cerrar</button>
+                </div>
+                <div class="order-detail-meta">
+                  <p><strong>Registrada:</strong> <span id="orderDetailCreatedAt"></span></p>
+                  <p><strong>Última actualización:</strong> <span id="orderDetailUpdatedAt"></span></p>
+                </div>
+                <form id="updateOrderForm" class="form-grid">
+                  <div class="form-row">
+                    <label for="orderDetailCustomer">Cliente</label>
+                    <input type="text" id="orderDetailCustomer" readonly />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailDocument">Documento</label>
+                    <input type="text" id="orderDetailDocument" readonly />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailContact">Contacto</label>
+                    <input type="text" id="orderDetailContact" />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailInvoice">Número de factura</label>
+                    <input type="text" id="orderDetailInvoice" />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailStatus">Estado</label>
+                    <select id="orderDetailStatus"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailTailor">Sastre asignado</label>
+                    <select id="orderDetailTailor"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailVendor">Vendedor asignado</label>
+                    <select id="orderDetailVendor"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailOrigin">Establecimiento remitente</label>
+                    <select id="orderDetailOrigin"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailDeliveryDate">Fecha y hora de entrega</label>
+                    <input type="datetime-local" id="orderDetailDeliveryDate" />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailNotes">Notas</label>
+                    <textarea id="orderDetailNotes" rows="3"></textarea>
+                  </div>
+                  <div class="form-row">
+                    <label>Medidas</label>
+                    <div id="orderDetailMeasurements" class="measurement-tags muted"></div>
+                  </div>
+                  <div class="form-row">
+                    <label>Checklist de producción</label>
+                    <div id="orderTasksContainer" class="order-tasks-container">
+                      <div id="orderTasksList" class="order-tasks-list muted">
+                        Selecciona una orden para ver el checklist.
+                      </div>
+                      <div id="orderTaskForm" class="order-task-form hidden" role="group" aria-label="Agregar trabajo al checklist">
+                        <div class="order-task-fields">
+                          <label class="sr-only" for="orderTaskDescription">Descripción del trabajo</label>
+                          <input
+                            type="text"
+                            id="orderTaskDescription"
+                            maxlength="255"
+                            placeholder="Describe el trabajo a registrar"
+                          />
+                          <button type="button" class="secondary" id="orderTaskAddButton">Agregar</button>
+                        </div>
+                        <p class="muted small">
+                          Añade los trabajos pendientes manualmente y marca cada casilla cuando el sastre los
+                          complete.
+                        </p>
+                      </div>
+                      <p id="orderTasksPermissionsNotice" class="muted small hidden">
+                        Solo los sastres o administradores pueden modificar el checklist.
+                      </p>
+                    </div>
+                  </div>
+                  <div class="button-row">
+                    <button type="submit" class="primary">Guardar cambios</button>
+                  </div>
+                </form>
+              </div>
             </div>
-            <div id="orderKanbanStatus" class="kanban-status muted hidden" aria-live="polite"></div>
-            <div id="orderKanbanColumns" class="kanban-board" aria-live="polite"></div>
+
+            <div id="ordersKanbanSection" class="orders-view-panel hidden" aria-hidden="true">
+              <div class="kanban-header">
+                <div>
+                  <h3>Kanban de órdenes</h3>
+                  <p class="muted small">
+                    Visualiza las órdenes agrupadas por estado y refresca el tablero para obtener los
+                    datos más recientes.
+                  </p>
+                </div>
+                <div class="kanban-actions">
+                  <button type="button" class="secondary" id="orderKanbanRefreshButton">
+                    Actualizar tablero
+                  </button>
+                </div>
+              </div>
+              <div class="kanban-controls">
+                <div class="kanban-search">
+                  <label for="orderKanbanSearchInput">Buscar</label>
+                  <input
+                    type="search"
+                    id="orderKanbanSearchInput"
+                    placeholder="Número de orden, cliente o cédula"
+                    autocomplete="off"
+                  />
+                </div>
+                <p class="muted small">
+                  La búsqueda se aplica localmente sobre los resultados cargados en el tablero.
+                </p>
+              </div>
+              <div id="orderKanbanStatus" class="kanban-status muted hidden" aria-live="polite"></div>
+              <div id="orderKanbanColumns" class="kanban-board" aria-live="polite"></div>
+            </div>
+
+            <div id="ordersCreateSection" class="orders-create-inline hidden" aria-hidden="true">
+              <div class="orders-create-header">
+                <h4>Registrar nueva orden</h4>
+                <p class="muted small">
+                  Completa el formulario y guarda la orden para que el equipo pueda comenzar a
+                  trabajarla.
+                </p>
+              </div>
+              <form id="createOrderForm" class="form-grid">
+                <div class="form-row">
+                  <label for="newOrderNumber">Número de orden</label>
+                  <input type="text" id="newOrderNumber" required />
+                </div>
+                <div class="form-row">
+                  <label for="newOrderInvoice">Número de factura</label>
+                  <input type="text" id="newOrderInvoice" placeholder="Ej. FAC-2024-00001" />
+                </div>
+                <div class="form-row">
+                  <label for="orderCustomerSelect">Cliente</label>
+                  <select id="orderCustomerSelect" required>
+                    <option value="">Selecciona un cliente</option>
+                  </select>
+                </div>
+                <div class="form-row">
+                  <label for="newCustomerDocument">Documento</label>
+                  <input type="text" id="newCustomerDocument" readonly />
+                </div>
+                <div class="form-row">
+                  <label for="newCustomerName">Nombre del cliente</label>
+                  <input type="text" id="newCustomerName" required />
+                </div>
+                <div class="form-row">
+                  <label for="newCustomerContact">Contacto del cliente</label>
+                  <input type="text" id="newCustomerContact" placeholder="Teléfono o correo" />
+                </div>
+                <div class="form-row">
+                  <label for="newOrderStatus">Estado inicial</label>
+                  <select id="newOrderStatus"></select>
+                </div>
+                <div class="form-row">
+                  <label for="newOrderOrigin">Establecimiento remitente</label>
+                  <select id="newOrderOrigin" required>
+                    <option value="">Selecciona un establecimiento</option>
+                  </select>
+                </div>
+                <div class="form-row">
+                  <label for="newOrderDeliveryDate">Fecha y hora de entrega</label>
+                  <input type="datetime-local" id="newOrderDeliveryDate" />
+                </div>
+                <div class="form-row">
+                  <label>Medidas guardadas del cliente</label>
+                  <div id="customerMeasurementOptions" class="measurement-option-list muted">
+                    Selecciona un cliente para ver sus medidas guardadas.
+                  </div>
+                </div>
+                <div class="form-row">
+                  <label>Medidas de la orden</label>
+                  <div id="measurementsList" class="measurement-list"></div>
+                  <button type="button" id="addMeasurementButton" class="secondary">Agregar medida</button>
+                </div>
+                <div class="form-row">
+                  <label for="newOrderNotes">Notas</label>
+                  <textarea id="newOrderNotes" rows="2" placeholder="Detalles adicionales"></textarea>
+                </div>
+                <div class="form-row">
+                  <label>Trabajos a realizar</label>
+                  <p class="muted small">
+                    Ingresa cada trabajo que debe realizarse para completar la orden. El sastre podrá marcar
+                    aquí los avances.
+                  </p>
+                  <div id="newOrderTasksList" class="measurement-list"></div>
+                  <button type="button" id="addOrderTaskButton" class="secondary">Agregar trabajo</button>
+                </div>
+                <div class="form-row">
+                  <label for="assignTailor">Asignar a sastre</label>
+                  <select id="assignTailor">
+                    <option value="">Sin asignar</option>
+                  </select>
+                </div>
+                <div class="form-row">
+                  <label for="assignVendor">Asignar a vendedor</label>
+                  <select id="assignVendor">
+                    <option value="">Sin asignar</option>
+                  </select>
+                </div>
+                <button type="submit" class="primary">Guardar orden</button>
+              </form>
+            </div>
           </section>
 
           <section class="card dashboard-panel hidden" id="usersPanel">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -236,55 +236,6 @@ body {
   transform: translateY(-1px);
 }
 
-.category-bar {
-  background: var(--primary);
-  color: var(--primary-contrast);
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.category-bar-inner {
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-  padding: 0.65rem 0;
-  overflow-x: auto;
-}
-
-.category-nav {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.category-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 1rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  text-decoration: none;
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.78);
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.category-pill.is-highlight {
-  background: var(--accent);
-  color: var(--primary);
-}
-
-.category-pill:hover,
-.category-pill:focus-visible {
-  outline: none;
-  border-color: rgba(255, 255, 255, 0.45);
-  color: #ffffff;
-}
-
 main {
   padding: clamp(2.5rem, 4vw, 3.5rem) 0;
 }
@@ -541,37 +492,33 @@ button[disabled] {
 .dashboard-subnav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 1rem;
   margin-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(7, 10, 12, 0.08);
+  padding-bottom: 0.5rem;
 }
 
 .dashboard-tab {
-  border: 1px solid rgba(7, 10, 12, 0.12);
-  background: var(--surface);
+  background: transparent;
+  border: none;
   color: var(--muted);
-  padding: 0.55rem 1.2rem;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.5rem 0.25rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  border-bottom: 3px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
 }
 
 .dashboard-tab:hover,
 .dashboard-tab:focus-visible {
   outline: none;
-  background: rgba(17, 17, 17, 0.1);
-  border-color: rgba(17, 17, 17, 0.25);
   color: var(--primary);
 }
 
 .dashboard-tab.active {
-  background: var(--primary);
+  color: var(--primary);
   border-color: var(--primary);
-  color: var(--primary-contrast);
-  box-shadow: 0 18px 32px rgba(var(--shadow-color), 0.12);
 }
 
 .customer-panel-header {
@@ -879,11 +826,15 @@ button[disabled] {
 
   .dashboard-subnav {
     width: 100%;
+    overflow-x: auto;
+    border-bottom: none;
+    padding-bottom: 0;
+    gap: 0.75rem;
   }
 
   .dashboard-tab {
-    flex: 1 1 120px;
-    text-align: center;
+    flex: 0 0 auto;
+    padding: 0.5rem 0.75rem;
   }
 
   .customer-panel-header > :first-child {
@@ -1197,6 +1148,106 @@ button[disabled] {
 .order-panel-controls p {
   margin: 0;
   max-width: 48ch;
+}
+
+.orders-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.orders-controls-info h3 {
+  margin-bottom: 0.35rem;
+}
+
+.orders-controls-info p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.orders-controls-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.orders-controls-actions > * {
+  flex: 0 0 auto;
+}
+
+.orders-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(7, 10, 12, 0.12);
+  background: rgba(7, 10, 12, 0.04);
+}
+
+.orders-view-toggle button {
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.orders-view-toggle button:hover,
+.orders-view-toggle button:focus-visible {
+  outline: none;
+  color: var(--primary);
+}
+
+.orders-view-toggle button.active {
+  background: var(--primary);
+  color: var(--primary-contrast);
+  box-shadow: 0 18px 32px rgba(var(--shadow-color), 0.12);
+}
+
+#ordersCreateToggleButton {
+  box-shadow: 0 20px 44px rgba(var(--shadow-color), 0.16);
+}
+
+.orders-view-panel {
+  margin-bottom: 2rem;
+}
+
+.orders-view-panel:last-of-type {
+  margin-bottom: 0;
+}
+
+.orders-create-inline {
+  border: 1px solid rgba(7, 10, 12, 0.1);
+  border-radius: 18px;
+  background: rgba(7, 10, 12, 0.02);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: 0 24px 55px rgba(var(--shadow-color), 0.08);
+  margin-top: 1.5rem;
+}
+
+.orders-create-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1.25rem;
+}
+
+.orders-create-header h4 {
+  margin: 0;
+}
+
+.orders-create-header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 60ch;
 }
 
 .kanban-header {
@@ -1877,6 +1928,52 @@ th {
   th,
   td {
     padding: 0.6rem;
+  }
+
+  .orders-controls {
+    gap: 1rem;
+  }
+
+  .orders-controls-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+
+  .orders-view-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .orders-view-toggle button {
+    flex: 1 1 0;
+  }
+
+  .orders-controls-actions > * {
+    width: 100%;
+  }
+
+  #ordersCreateToggleButton {
+    width: 100%;
+  }
+}
+
+@media (min-width: 960px) {
+  .orders-controls {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .orders-controls-info {
+    flex: 1 1 auto;
+    max-width: 60ch;
+  }
+
+  .orders-controls-actions {
+    justify-content: flex-end;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the separate order list, kanban, and creation tabs with a unified orders panel that includes view toggles and an inline creation form
- update the dashboard scripts to track the active orders view, lazy-load kanban data only when needed, and apply role-based visibility to the new controls
- refresh the dashboard styles to support the consolidated layout and responsive control bar while restyling the navigation buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68defc884b9c8332850646d864d38142