### PR TITLE
Refine Kanban detail presentation

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -33,6 +33,7 @@ const state = {
   kanbanSearchTerm: '',
   kanbanNeedsRefresh: true,
   kanbanLastUpdated: null,
+  activeOrdersView: 'list',
   isCreateCustomerVisible: false,
   isCreateUserVisible: false,
   auditLogs: [],
@@ -102,16 +103,35 @@ const navButtons = document.querySelectorAll('.nav-button');
 const panelNavButton = document.getElementById('panelNavButton');
 const loginNavButton = document.getElementById('loginNavButton');
 const categoryBar = document.getElementById('categoryBar');
-const dashboardTabButtons = document.querySelectorAll('.dashboard-tab');
+const DASHBOARD_TAB_IDS = [
+  'ordersPanel',
+  'orderCreatePanel',
+  'customersPanel',
+  'usersPanel',
+  'auditLogPanel',
+];
+const ADMIN_ONLY_TABS = new Set(['usersPanel', 'auditLogPanel']);
+const dashboardTabButtons = Array.from(document.querySelectorAll('[data-tab]')).filter((btn) =>
+  DASHBOARD_TAB_IDS.includes(btn.dataset.tab)
+);
 const dashboardSubnav = document.querySelector('.dashboard-subnav');
 const dashboardPanels = document.querySelectorAll('.dashboard-panel');
-const orderCreateTabButton = document.getElementById('orderCreateTabButton');
+const ordersTableSection = document.getElementById('ordersTableSection');
+const ordersKanbanSection = document.getElementById('ordersKanbanSection');
 const orderCreatePanel = document.getElementById('orderCreatePanel');
-const orderKanbanPanel = document.getElementById('orderKanbanPanel');
+const orderCreateBackButton = document.getElementById('orderCreateBackButton');
+const ordersCreateButton = document.getElementById('ordersCreateButton');
+const ordersViewToggleButtons = document.querySelectorAll('[data-orders-view]');
+const roleRestrictedElements = document.querySelectorAll('[data-hide-roles]');
 const orderKanbanColumns = document.getElementById('orderKanbanColumns');
 const orderKanbanStatus = document.getElementById('orderKanbanStatus');
 const orderKanbanSearchInput = document.getElementById('orderKanbanSearchInput');
 const orderKanbanRefreshButton = document.getElementById('orderKanbanRefreshButton');
+const orderKanbanDetailContainer = document.getElementById('orderKanbanDetail');
+const orderKanbanDetailOverlay = document.getElementById('orderKanbanDetailOverlay');
+const orderKanbanDetailDialog = document.getElementById('orderKanbanDetailDialog');
+const orderKanbanDetailMessage = document.getElementById('orderKanbanDetailMessage');
+const kanbanDetailCloseElements = document.querySelectorAll('[data-kanban-detail-close]');
 const orderLookupForm = document.getElementById('orderLookupForm');
 const orderNumberInput = document.getElementById('orderNumber');
 const orderDocumentInput = document.getElementById('customerDocument');
@@ -231,11 +251,15 @@ const CUSTOMER_DETAIL_DEFAULT_SUMMARY = 'Selecciona un cliente para ver su infor
 const CUSTOMER_ORDER_HISTORY_PROMPT = 'Selecciona un cliente para ver sus órdenes anteriores.';
 const CUSTOMER_ORDER_HISTORY_EMPTY_MESSAGE = 'No tiene órdenes registradas.';
 
-let activeDashboardTab = 'orderListPanel';
+let activeDashboardTab = 'ordersPanel';
+let lastOrdersViewBeforeCreate = 'list';
 const ORDER_TABLE_COLUMN_COUNT = 6;
 const CUSTOMER_TABLE_COLUMN_COUNT = 5;
 let activeOrderDetailRow = null;
+let currentOrderDetailHost = null;
 let activeCustomerDetailRow = null;
+let lastKanbanFocusedElement = null;
+let lastKanbanFocusedOrderId = null;
 
 
 function setActiveView(viewId) {
@@ -280,17 +304,18 @@ function updateDashboardShortcutVisibility() {
     categoryBar.classList.toggle('hidden', !isAuthenticated);
   }
   if (dashboardSubnav) {
-    const shouldHideSubnav = isAuthenticated && categoryBar && !categoryBar.classList.contains('hidden');
-    dashboardSubnav.classList.toggle('hidden', shouldHideSubnav);
-    dashboardSubnav.setAttribute('aria-hidden', shouldHideSubnav ? 'true' : 'false');
+    dashboardSubnav.classList.toggle('hidden', !isAuthenticated);
+    dashboardSubnav.setAttribute('aria-hidden', isAuthenticated ? 'false' : 'true');
   }
   if (!dashboardShortcutButtons.length) {
+    applyRoleVisibility();
     return;
   }
 
   let hasVisibleActiveShortcut = false;
 
   dashboardShortcutButtons.forEach((btn) => {
+    const targetTab = btn.dataset.targetTab;
     const requiredRole = btn.dataset.requiredRole || null;
     const hideRoles = (btn.dataset.hideRoles || '')
       .split(',')
@@ -298,16 +323,24 @@ function updateDashboardShortcutVisibility() {
       .filter(Boolean);
     const lacksRequiredRole = Boolean(requiredRole) && userRole !== requiredRole;
     const hiddenForRole = hideRoles.length > 0 && (!userRole || hideRoles.includes(userRole));
-    const shouldHide = !isAuthenticated || lacksRequiredRole || hiddenForRole;
+    const isAdminTab = ADMIN_ONLY_TABS.has(targetTab);
+    const isRecognizedTab = DASHBOARD_TAB_IDS.includes(targetTab);
+    const shouldHide =
+      !isAuthenticated ||
+      !isRecognizedTab ||
+      lacksRequiredRole ||
+      hiddenForRole ||
+      (isAdminTab && userRole !== 'administrador');
     btn.classList.toggle('hidden', shouldHide);
-    if (!shouldHide && btn.dataset.targetTab === activeDashboardTab) {
+    if (!shouldHide && targetTab === activeDashboardTab) {
       hasVisibleActiveShortcut = true;
     }
   });
 
   if (isAuthenticated && !hasVisibleActiveShortcut) {
     const fallback = Array.from(dashboardShortcutButtons).find(
-      (btn) => !btn.classList.contains('hidden')
+      (btn) =>
+        !btn.classList.contains('hidden') && DASHBOARD_TAB_IDS.includes(btn.dataset.targetTab)
     );
     if (fallback) {
       setActiveDashboardTab(fallback.dataset.targetTab);
@@ -316,6 +349,7 @@ function updateDashboardShortcutVisibility() {
   }
 
   updateDashboardShortcutHighlight();
+  applyRoleVisibility();
 }
 
 dashboardShortcutButtons.forEach((btn) => {
@@ -350,13 +384,19 @@ if (loginNavButton) {
   });
 }
 
-function isOrderCreatePanelHidden() {
-  return !orderCreatePanel || orderCreatePanel.classList.contains('hidden');
+function focusFirstCreateOrderField() {
+  if (!createOrderForm) return;
+  const focusable = createOrderForm.querySelector(
+    'input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled])'
+  );
+  if (focusable) {
+    focusable.focus();
+  }
 }
 
 function syncCreateOrderFormDisabled() {
   if (!createOrderForm) return;
-  const shouldDisable = isOrderCreatePanelHidden();
+  const shouldDisable = !orderCreatePanel || orderCreatePanel.classList.contains('hidden');
   createOrderForm.dataset.disabled = shouldDisable ? 'true' : 'false';
   const submitButton = createOrderForm.querySelector('button[type="submit"]');
   if (submitButton) {
@@ -364,59 +404,107 @@ function syncCreateOrderFormDisabled() {
   }
 }
 
-function setActiveDashboardTab(tabId = 'orderListPanel') {
+function applyRoleVisibility() {
+  const userRole = state.user?.role || null;
+  roleRestrictedElements.forEach((element) => {
+    const roles = (element.dataset.hideRoles || '')
+      .split(',')
+      .map((role) => role.trim())
+      .filter(Boolean);
+    const shouldHide = roles.length > 0 && (!userRole || roles.includes(userRole));
+    element.classList.toggle('hidden', shouldHide);
+    if ('disabled' in element) {
+      element.disabled = shouldHide;
+    }
+    if (element === ordersCreateButton) {
+      element.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
+      if (shouldHide && activeDashboardTab === 'orderCreatePanel') {
+        setActiveDashboardTab('ordersPanel');
+      }
+    }
+  });
+}
+
+function setActiveOrdersView(view) {
+  const nextView = view === 'kanban' ? 'kanban' : 'list';
+  state.activeOrdersView = nextView;
+  ordersViewToggleButtons.forEach((btn) => {
+    const isActive = btn.dataset.ordersView === nextView;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+  if (ordersTableSection) {
+    ordersTableSection.classList.toggle('hidden', nextView !== 'list');
+    ordersTableSection.setAttribute('aria-hidden', nextView === 'list' ? 'false' : 'true');
+  }
+  if (ordersKanbanSection) {
+    const isKanban = nextView === 'kanban';
+    ordersKanbanSection.classList.toggle('hidden', !isKanban);
+    ordersKanbanSection.setAttribute('aria-hidden', isKanban ? 'false' : 'true');
+  }
+  if (nextView === 'kanban') {
+    ensureKanbanDataLoaded();
+    updateKanbanDetailVisibility();
+  } else {
+    if (currentOrderDetailHost === 'kanban') {
+      currentOrderDetailHost = null;
+    }
+    updateKanbanDetailVisibility();
+    renderOrders();
+    renderOrderKanban();
+  }
+}
+
+function setActiveDashboardTab(tabId = 'ordersPanel') {
   if (!dashboardPanels.length) return;
   const userRole = state.user?.role || null;
-  let targetTab = tabId || 'orderListPanel';
-  if (targetTab === 'auditLogPanel' && userRole !== 'administrador') {
-    targetTab = 'orderListPanel';
-  }
-  if (targetTab === 'orderCreatePanel' && userRole === 'sastre') {
-    targetTab = 'orderListPanel';
-  }
-  if (targetTab === 'usersPanel' && userRole !== 'administrador') {
-    targetTab = 'orderListPanel';
+  let targetTab = tabId && DASHBOARD_TAB_IDS.includes(tabId) ? tabId : 'ordersPanel';
+  if (ADMIN_ONLY_TABS.has(targetTab) && userRole !== 'administrador') {
+    targetTab = 'ordersPanel';
   }
   activeDashboardTab = targetTab;
+
+  const highlightTabId = targetTab === 'orderCreatePanel' ? 'ordersPanel' : targetTab;
+
   dashboardTabButtons.forEach((btn) => {
     const tab = btn.dataset.tab;
-    if (tab === 'orderCreatePanel') {
-      const shouldHideTab = userRole === 'sastre';
-      if (shouldHideTab) {
-        btn.classList.add('hidden');
-      } else {
-        btn.classList.remove('hidden');
-      }
-      btn.disabled = shouldHideTab;
-    }
-    if (tab === 'usersPanel') {
-      const shouldHideUsersTab = userRole !== 'administrador';
-      if (shouldHideUsersTab) {
-        btn.classList.add('hidden');
-      } else {
-        btn.classList.remove('hidden');
-      }
-      btn.disabled = shouldHideUsersTab;
-    }
-    btn.classList.toggle('active', tab === targetTab);
+    if (!tab) return;
+    const isAdminTab = ADMIN_ONLY_TABS.has(tab);
+    const shouldHide = !state.token || (isAdminTab && userRole !== 'administrador');
+    btn.classList.toggle('hidden', shouldHide);
+    btn.disabled = shouldHide;
+    btn.classList.toggle('active', tab === highlightTabId);
   });
+
   dashboardPanels.forEach((panel) => {
-    if (panel.id === 'orderCreatePanel' && userRole === 'sastre') {
-      panel.classList.add('hidden');
-    } else if (panel.id === 'usersPanel' && userRole !== 'administrador') {
+    const { id } = panel;
+    if (!id) return;
+    const isAdminPanel = ADMIN_ONLY_TABS.has(id);
+    const shouldHide = !state.token || (isAdminPanel && userRole !== 'administrador');
+    if (shouldHide) {
       panel.classList.add('hidden');
     } else {
-      panel.classList.toggle('hidden', panel.id !== targetTab);
+      panel.classList.toggle('hidden', id !== targetTab);
     }
   });
+
   if (targetTab === 'usersPanel' && userRole === 'administrador') {
     loadUsers();
   }
-  if (targetTab === 'orderKanbanPanel') {
-    ensureKanbanDataLoaded();
+
+  if (targetTab === 'ordersPanel') {
+    if (state.activeOrdersView === 'kanban') {
+      ensureKanbanDataLoaded();
+    } else {
+      renderOrderKanban();
+    }
   } else {
     renderOrderKanban();
+    if (targetTab === 'orderCreatePanel') {
+      focusFirstCreateOrderField();
+    }
   }
+
   syncCreateOrderFormDisabled();
   updateDashboardShortcutHighlight();
 }
@@ -430,9 +518,48 @@ dashboardTabButtons.forEach((btn) => {
   });
 });
 
+ordersViewToggleButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    if (btn.disabled) {
+      return;
+    }
+    setActiveOrdersView(btn.dataset.ordersView);
+  });
+});
+
+if (ordersCreateButton) {
+  ordersCreateButton.addEventListener('click', () => {
+    if (ordersCreateButton.disabled) {
+      return;
+    }
+    lastOrdersViewBeforeCreate = state.activeOrdersView || 'list';
+    setActiveView('staff-view');
+    setActiveDashboardTab('orderCreatePanel');
+    if (orderCreatePanel && orderCreatePanel.scrollIntoView) {
+      orderCreatePanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  });
+}
+
+if (orderCreateBackButton) {
+  orderCreateBackButton.addEventListener('click', () => {
+    setActiveDashboardTab('ordersPanel');
+    setActiveOrdersView(lastOrdersViewBeforeCreate || 'list');
+    if (
+      ordersCreateButton &&
+      !ordersCreateButton.classList.contains('hidden') &&
+      !ordersCreateButton.disabled
+    ) {
+      ordersCreateButton.focus();
+    }
+  });
+}
+
 setActiveDashboardTab(activeDashboardTab);
 updateDashboardShortcutHighlight();
 updateDashboardShortcutVisibility();
+setActiveOrdersView(state.activeOrdersView || 'list');
+applyRoleVisibility();
 
 if (dashboardShortcutButtons.length) {
   dashboardShortcutButtons.forEach((shortcut) => {
@@ -1646,31 +1773,12 @@ function updateUserInfo() {
     }
   }
   const isAdmin = state.user.role === 'administrador';
-  if (auditLogTabButton) {
-    auditLogTabButton.classList.toggle('hidden', !isAdmin);
-  }
-  if (usersTabButton) {
-    usersTabButton.classList.toggle('hidden', !isAdmin);
-  }
-  const isTailor = state.user.role === 'sastre';
-  if (orderCreateTabButton) {
-    if (isTailor) {
-      orderCreateTabButton.classList.add('hidden');
-    } else {
-      orderCreateTabButton.classList.remove('hidden');
-    }
-    orderCreateTabButton.disabled = isTailor;
-  }
-  if (orderCreatePanel && isTailor) {
-    orderCreatePanel.classList.add('hidden');
-  }
-  if (!isAdmin && activeDashboardTab === 'auditLogPanel') {
-    setActiveDashboardTab('orderListPanel');
-  } else if (isTailor && activeDashboardTab === 'orderCreatePanel') {
-    setActiveDashboardTab('orderListPanel');
+  if (!isAdmin && ADMIN_ONLY_TABS.has(activeDashboardTab)) {
+    setActiveDashboardTab('ordersPanel');
   } else {
     setActiveDashboardTab(activeDashboardTab);
   }
+  applyRoleVisibility();
   updateUserCreationForm();
   renderOrderTasks();
   updateDashboardShortcutVisibility();
@@ -1683,7 +1791,7 @@ function showDashboard() {
   if (staffLoginCard) {
     staffLoginCard.classList.add('hidden');
   }
-  setActiveDashboardTab('orderListPanel');
+  setActiveDashboardTab('ordersPanel');
 }
 
 function hideDashboard() {
@@ -1967,7 +2075,7 @@ async function loadKanbanOrders({ force = false } = {}) {
 }
 
 function ensureKanbanDataLoaded() {
-  if (!state.token) {
+  if (!state.token || state.activeOrdersView !== 'kanban') {
     renderOrderKanban();
     return;
   }
@@ -1985,7 +2093,12 @@ function ensureKanbanDataLoaded() {
 function markKanbanDataStale() {
   state.kanbanNeedsRefresh = true;
   renderOrderKanban();
-  if (activeDashboardTab === 'orderKanbanPanel' && state.token && !state.kanbanLoading) {
+  const shouldReload =
+    activeDashboardTab === 'ordersPanel' &&
+    state.activeOrdersView === 'kanban' &&
+    state.token &&
+    !state.kanbanLoading;
+  if (shouldReload) {
     loadKanbanOrders({ force: true });
   }
 }
@@ -2226,7 +2339,7 @@ function handleLogout(auto = false) {
   if (usersTabButton) {
     usersTabButton.classList.add('hidden');
   }
-  setActiveDashboardTab('orderListPanel');
+  setActiveDashboardTab('ordersPanel');
   hideDashboard();
   if (customerSearchInput) {
     customerSearchInput.value = '';
@@ -2854,11 +2967,16 @@ function populateOrderDetail(order, options = {}) {
   }
 
   refreshOrderTasks(order.id);
+  updateKanbanDetailVisibility();
 }
 
 function clearOrderDetail(options = {}) {
   if (!orderDetail) return;
-  const { skipRender = false } = options;
+  const wasKanbanHost = currentOrderDetailHost === 'kanban';
+  const skipRenderOption =
+    typeof options.skipRender === 'boolean' ? options.skipRender : wasKanbanHost;
+  const focusOrderId = lastKanbanFocusedOrderId;
+  const focusElement = lastKanbanFocusedElement;
 
   state.selectedOrderId = null;
   updateOrderForm?.reset();
@@ -2885,9 +3003,38 @@ function clearOrderDetail(options = {}) {
   removeOrderDetailRow();
   orderDetail.classList.add('hidden');
 
-  if (!skipRender) {
+  if (wasKanbanHost) {
+    currentOrderDetailHost = null;
+  }
+  updateKanbanDetailVisibility();
+
+  if (!skipRenderOption) {
     renderOrders();
   }
+  renderOrderKanban();
+
+  if (wasKanbanHost) {
+    requestAnimationFrame(() => {
+      let focusTarget = null;
+      if (focusOrderId && orderKanbanColumns) {
+        focusTarget = orderKanbanColumns.querySelector(`[data-order-id="${focusOrderId}"]`);
+      }
+      if (!(focusTarget instanceof HTMLElement) && focusElement instanceof HTMLElement) {
+        focusTarget = focusElement.isConnected ? focusElement : null;
+      }
+      if (!(focusTarget instanceof HTMLElement)) {
+        focusTarget = Array.from(ordersViewToggleButtons).find(
+          (btn) => btn instanceof HTMLElement && btn.dataset.ordersView === 'kanban',
+        );
+      }
+      if (focusTarget instanceof HTMLElement) {
+        focusTarget.focus();
+      }
+    });
+  }
+
+  lastKanbanFocusedElement = null;
+  lastKanbanFocusedOrderId = null;
 }
 
 async function handleOrderUpdate(event) {
@@ -3131,6 +3278,40 @@ if (closeOrderDetailButton) {
   });
 }
 
+kanbanDetailCloseElements.forEach((element) => {
+  element.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (
+      orderKanbanDetailOverlay &&
+      !orderKanbanDetailOverlay.classList.contains('hidden') &&
+      currentOrderDetailHost === 'kanban'
+    ) {
+      clearOrderDetail();
+    }
+  });
+});
+
+if (orderKanbanDetailOverlay) {
+  orderKanbanDetailOverlay.addEventListener('click', (event) => {
+    if (event.target === orderKanbanDetailOverlay && currentOrderDetailHost === 'kanban') {
+      clearOrderDetail();
+    }
+  });
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('keydown', (event) => {
+    if (
+      event.key === 'Escape' &&
+      currentOrderDetailHost === 'kanban' &&
+      orderKanbanDetailOverlay &&
+      !orderKanbanDetailOverlay.classList.contains('hidden')
+    ) {
+      clearOrderDetail();
+    }
+  });
+}
+
 if (createCustomerForm) {
   createCustomerForm.addEventListener('submit', async (event) => {
     event.preventDefault();
@@ -3235,7 +3416,8 @@ if (deleteCustomerButton) {
 async function createOrder(event) {
   event.preventDefault();
   if (!createOrderForm) return;
-  if (createOrderForm.dataset.disabled === 'true' || isOrderCreatePanelHidden()) {
+  const isCreatePanelHidden = !orderCreatePanel || orderCreatePanel.classList.contains('hidden');
+  if (createOrderForm.dataset.disabled === 'true' || isCreatePanelHidden) {
     return;
   }
   const newOrderNumber = document.getElementById('newOrderNumber').value.trim();
@@ -3455,10 +3637,64 @@ function compareOrdersForDisplay(a, b) {
 }
 
 function removeOrderDetailRow() {
+  if (currentOrderDetailHost !== 'table') {
+    activeOrderDetailRow = null;
+    return;
+  }
   if (activeOrderDetailRow && activeOrderDetailRow.parentNode) {
     activeOrderDetailRow.parentNode.removeChild(activeOrderDetailRow);
   }
   activeOrderDetailRow = null;
+}
+
+function attachOrderDetailToKanban() {
+  if (!orderDetail || !orderKanbanDetailContainer) {
+    return;
+  }
+  if (activeOrderDetailRow && activeOrderDetailRow.parentNode) {
+    activeOrderDetailRow.parentNode.removeChild(activeOrderDetailRow);
+    activeOrderDetailRow = null;
+  }
+  orderKanbanDetailContainer.appendChild(orderDetail);
+  currentOrderDetailHost = 'kanban';
+  orderDetail.classList.remove('hidden');
+  updateKanbanDetailVisibility();
+  requestAnimationFrame(() => {
+    if (orderKanbanDetailDialog?.isConnected) {
+      orderKanbanDetailDialog.focus();
+    }
+  });
+}
+
+function updateKanbanDetailVisibility() {
+  if (!orderKanbanDetailContainer) {
+    return;
+  }
+  const isKanbanHost =
+    currentOrderDetailHost === 'kanban' && orderKanbanDetailContainer.contains(orderDetail);
+  const shouldShowDetail = isKanbanHost && state.selectedOrderId !== null;
+  orderKanbanDetailContainer.classList.toggle('hidden', !shouldShowDetail);
+  if (orderKanbanDetailOverlay) {
+    orderKanbanDetailOverlay.classList.toggle('hidden', !shouldShowDetail);
+    orderKanbanDetailOverlay.setAttribute('aria-hidden', shouldShowDetail ? 'false' : 'true');
+  }
+  if (orderKanbanDetailMessage) {
+    orderKanbanDetailMessage.classList.toggle('hidden', shouldShowDetail);
+  }
+  if (orderDetail) {
+    orderDetail.classList.toggle('kanban-mode', isKanbanHost);
+    const hideDetailElement = currentOrderDetailHost === 'kanban' && !shouldShowDetail;
+    orderDetail.classList.toggle('hidden', hideDetailElement);
+    if (currentOrderDetailHost === 'kanban') {
+      orderDetail.setAttribute('aria-hidden', shouldShowDetail ? 'false' : 'true');
+    } else {
+      orderDetail.removeAttribute('aria-hidden');
+      orderDetail.classList.remove('kanban-mode');
+    }
+  }
+  if (document.body) {
+    document.body.classList.toggle('kanban-detail-open', shouldShowDetail);
+  }
 }
 
 function removeCustomerDetailRow() {
@@ -3589,51 +3825,103 @@ function createKanbanMetaItem(label, value) {
   return item;
 }
 
-function getOrderDetailUrl(order) {
+async function openOrderDetailFromKanban(order) {
   if (!order || order.id === undefined || order.id === null) {
-    return null;
+    showToast('No se pudo abrir el detalle de la orden seleccionada.', 'error');
+    return;
   }
-  if (typeof window === 'undefined' || typeof window.location === 'undefined') {
-    return `order.html?id=${encodeURIComponent(order.id)}`;
+
+  if (!lastKanbanFocusedOrderId) {
+    lastKanbanFocusedOrderId = String(order.id);
   }
-  try {
-    const detailUrl = new URL('order.html', window.location.href);
-    detailUrl.searchParams.set('id', order.id);
-    if (order?.order_number) {
-      detailUrl.searchParams.set('number', order.order_number);
+  if (!(lastKanbanFocusedElement instanceof HTMLElement)) {
+    lastKanbanFocusedElement =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  }
+
+  const orderIdKey = String(order.id);
+  setActiveDashboardTab('ordersPanel');
+  if (state.activeOrdersView !== 'kanban') {
+    setActiveOrdersView('kanban');
+  }
+
+  let detail = state.orders.find((item) => String(item.id) === orderIdKey);
+  if (!detail) {
+    try {
+      detail = await apiFetch(`/orders/${encodeURIComponent(orderIdKey)}`);
+    } catch (error) {
+      /* ignore fetch failure and fall back to cached data */
     }
-    return detailUrl.toString();
-  } catch (error) {
-    let fallback = `order.html?id=${encodeURIComponent(order.id)}`;
-    if (order?.order_number) {
-      fallback += `&number=${encodeURIComponent(order.order_number)}`;
-    }
-    return fallback;
   }
+
+  if (!detail) {
+    detail = order;
+  }
+
+  if (!detail || detail.id === undefined || detail.id === null) {
+    showToast('No se pudo abrir el detalle de la orden seleccionada.', 'error');
+    return;
+  }
+
+  const remainingOrders = state.orders.filter((item) => String(item.id) !== orderIdKey);
+  state.orders = [...remainingOrders, detail];
+  if (typeof state.orderTotal !== 'number' || state.orderTotal < state.orders.length) {
+    state.orderTotal = state.orders.length;
+  }
+
+  populateOrderDetail(detail, { skipRender: true, focusOnDetail: false });
+  attachOrderDetailToKanban();
+  renderOrderKanban();
 }
 
 function createKanbanCard(order) {
-  const detailUrl = getOrderDetailUrl(order);
-  const card = detailUrl ? document.createElement('a') : document.createElement('article');
+  const card = document.createElement('article');
   card.className = 'kanban-card';
+  card.classList.add('is-clickable');
+  card.setAttribute('role', 'button');
+  card.tabIndex = 0;
   if (order?.id !== undefined && order?.id !== null) {
     card.dataset.orderId = String(order.id);
   }
-  if (detailUrl) {
-    card.href = detailUrl;
-    card.target = '_blank';
-    card.rel = 'noopener noreferrer';
-    card.classList.add('is-clickable');
-    const labelParts = [];
-    if (order?.order_number) {
-      labelParts.push(`Orden ${order.order_number}`);
-    }
-    if (order?.customer_name) {
-      labelParts.push(order.customer_name);
-    }
-    card.setAttribute('aria-label', `Abrir detalle de ${labelParts.join(' · ') || 'la orden'}`);
-    card.title = 'Abrir información de la orden en una nueva pestaña';
+
+  const isActive =
+    state.selectedOrderId !== null &&
+    order?.id !== undefined &&
+    order?.id !== null &&
+    String(state.selectedOrderId) === String(order.id);
+  card.classList.toggle('is-active', Boolean(isActive));
+  card.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+
+  const labelParts = [];
+  if (order?.order_number) {
+    labelParts.push(`Orden ${order.order_number}`);
   }
+  if (order?.customer_name) {
+    labelParts.push(order.customer_name);
+  }
+  if (labelParts.length) {
+    card.setAttribute('aria-label', `Ver detalle de ${labelParts.join(' · ')}`);
+  } else {
+    card.setAttribute('aria-label', 'Ver detalle de la orden seleccionada');
+  }
+  card.title = 'Ver detalle de la orden';
+
+  const handleCardActivation = (event) => {
+    event.preventDefault();
+    if (order?.id !== undefined && order?.id !== null) {
+      lastKanbanFocusedOrderId = String(order.id);
+    }
+    lastKanbanFocusedElement = card;
+    openOrderDetailFromKanban(order);
+  };
+
+  card.addEventListener('click', handleCardActivation);
+  card.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleCardActivation(event);
+    }
+  });
 
 
   const header = document.createElement('div');
@@ -3698,6 +3986,8 @@ function renderOrderKanban() {
     return;
   }
 
+  updateKanbanDetailVisibility();
+
   if (orderKanbanSearchInput && orderKanbanSearchInput.value !== state.kanbanSearchTerm) {
     orderKanbanSearchInput.value = state.kanbanSearchTerm;
   }
@@ -3713,6 +4003,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = 'Inicia sesión para ver el tablero de órdenes.';
       orderKanbanStatus.classList.remove('hidden');
     }
+    updateKanbanDetailVisibility();
     return;
   }
 
@@ -3721,6 +4012,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = 'Cargando tablero Kanban...';
       orderKanbanStatus.classList.remove('hidden');
     }
+    updateKanbanDetailVisibility();
     return;
   }
 
@@ -3729,6 +4021,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = state.kanbanError;
       orderKanbanStatus.classList.remove('hidden');
     }
+    updateKanbanDetailVisibility();
     return;
   }
 
@@ -3740,6 +4033,7 @@ function renderOrderKanban() {
         : 'No hay órdenes registradas.';
       orderKanbanStatus.classList.remove('hidden');
     }
+    updateKanbanDetailVisibility();
     return;
   }
 
@@ -3753,6 +4047,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = 'No se encontraron órdenes que coincidan con la búsqueda actual.';
       orderKanbanStatus.classList.remove('hidden');
     }
+    updateKanbanDetailVisibility();
     return;
   }
 
@@ -3845,6 +4140,8 @@ function renderOrderKanban() {
       orderKanbanStatus.classList.add('hidden');
     }
   }
+
+  updateKanbanDetailVisibility();
 }
 
 function renderOrders() {
@@ -3977,28 +4274,36 @@ function renderOrders() {
 
     ordersTableBody.appendChild(row);
 
-    if (isSelected && orderDetail) {
-      const detailRow = document.createElement('tr');
-      detailRow.className = 'order-detail-row';
-      detailRow.dataset.orderId = String(order.id);
-
-      const detailCell = document.createElement('td');
-      detailCell.colSpan = ORDER_TABLE_COLUMN_COUNT;
-      detailCell.className = 'order-detail-cell';
-      detailCell.appendChild(orderDetail);
-
-      detailRow.appendChild(detailCell);
-      ordersTableBody.appendChild(detailRow);
-      activeOrderDetailRow = detailRow;
-      orderDetail.classList.remove('hidden');
-      detailButton.textContent = 'Ocultar detalle';
-      detailButton.setAttribute('aria-expanded', 'true');
+    if (isSelected) {
       hasActiveDetail = true;
+      if (orderDetail && currentOrderDetailHost !== 'kanban') {
+        const detailRow = document.createElement('tr');
+        detailRow.className = 'order-detail-row';
+        detailRow.dataset.orderId = String(order.id);
+
+        const detailCell = document.createElement('td');
+        detailCell.colSpan = ORDER_TABLE_COLUMN_COUNT;
+        detailCell.className = 'order-detail-cell';
+        detailCell.appendChild(orderDetail);
+
+        detailRow.appendChild(detailCell);
+        ordersTableBody.appendChild(detailRow);
+        activeOrderDetailRow = detailRow;
+        orderDetail.classList.remove('hidden');
+        detailButton.textContent = 'Ocultar detalle';
+        detailButton.setAttribute('aria-expanded', 'true');
+        currentOrderDetailHost = 'table';
+        updateKanbanDetailVisibility();
+      }
     }
   });
 
   if (!hasActiveDetail && orderDetail) {
     orderDetail.classList.add('hidden');
+    if (currentOrderDetailHost !== 'kanban') {
+      currentOrderDetailHost = null;
+    }
+    updateKanbanDetailVisibility();
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,45 +67,6 @@
           </nav>
         </div>
       </div>
-      <div class="category-bar hidden" id="categoryBar">
-        <div class="container category-bar-inner">
-          <nav class="category-nav" aria-label="Atajos del panel administrativo">
-            <button type="button" class="category-pill" data-target-tab="orderListPanel">
-              Órdenes registradas
-            </button>
-            <button type="button" class="category-pill" data-target-tab="orderKanbanPanel">
-              Kanban de órdenes
-            </button>
-            <button
-              type="button"
-              class="category-pill"
-              data-target-tab="orderCreatePanel"
-              data-hide-roles="sastre"
-            >
-              Crear orden
-            </button>
-            <button type="button" class="category-pill" data-target-tab="customersPanel">
-              Clientes
-            </button>
-            <button
-              type="button"
-              class="category-pill"
-              data-target-tab="usersPanel"
-              data-required-role="administrador"
-            >
-              Usuarios
-            </button>
-            <button
-              type="button"
-              class="category-pill"
-              data-target-tab="auditLogPanel"
-              data-required-role="administrador"
-            >
-              Bitácora
-            </button>
-          </nav>
-        </div>
-      </div>
     </header>
 
     <main class="container">
@@ -154,23 +115,7 @@
           </div>
 
           <nav class="dashboard-subnav">
-            <button type="button" class="dashboard-tab active" data-tab="orderListPanel">Órdenes registradas</button>
-            <button
-              type="button"
-              class="dashboard-tab"
-              data-tab="orderKanbanPanel"
-              id="orderKanbanTabButton"
-            >
-              Kanban de órdenes
-            </button>
-            <button
-              type="button"
-              class="dashboard-tab"
-              data-tab="orderCreatePanel"
-              id="orderCreateTabButton"
-            >
-              Crear orden
-            </button>
+            <button type="button" class="dashboard-tab active" data-tab="ordersPanel">Órdenes</button>
             <button type="button" class="dashboard-tab" data-tab="customersPanel">Clientes</button>
             <button
               type="button"
@@ -337,6 +282,11 @@
           </section>
 
           <section class="card dashboard-panel hidden" id="orderCreatePanel">
+            <div class="order-create-toolbar">
+              <button type="button" class="secondary" id="orderCreateBackButton">
+                ← Volver a órdenes
+              </button>
+            </div>
             <h3>Crear nueva orden</h3>
             <form id="createOrderForm" class="form-grid">
               <div class="form-row">
@@ -419,202 +369,250 @@
             </form>
           </section>
 
-          <section class="card dashboard-panel" id="orderListPanel">
-            <h3>Órdenes registradas</h3>
-            <div class="order-panel-controls">
-              <p class="muted small">
-                Las órdenes pendientes se muestran primero, ordenadas por la fecha de entrega más
-                cercana. Las fechas vencidas se resaltan en rojo mientras la orden no haya sido
-                entregada.
-              </p>
-              <div class="order-search">
-                <label for="orderSearchInput">Buscar</label>
-                <input
-                  type="search"
-                  id="orderSearchInput"
-                  placeholder="Número de orden o cédula"
-                  autocomplete="off"
-                />
-              </div>
-              <div class="table-pagination">
-                <label for="orderPageSize">Filas por página</label>
-                <div class="pagination-controls">
-                  <select id="orderPageSize">
-                    <option value="10" selected>10</option>
-                    <option value="15">15</option>
-                    <option value="20">20</option>
-                    <option value="25">25</option>
-                    <option value="30">30</option>
-                    <option value="35">35</option>
-                    <option value="40">40</option>
-                    <option value="45">45</option>
-                    <option value="50">50</option>
-                  </select>
-                  <div class="pagination-buttons">
-                    <button
-                      type="button"
-                      class="pagination-button"
-                      id="orderPrevPage"
-                      aria-label="Página anterior de órdenes"
-                    >
-                      Anterior
-                    </button>
-                    <span
-                      id="orderPaginationInfo"
-                      class="pagination-info"
-                      aria-live="polite"
-                    >
-                      Mostrando 0-0 de 0
-                    </span>
-                    <button
-                      type="button"
-                      class="pagination-button"
-                      id="orderNextPage"
-                      aria-label="Página siguiente de órdenes"
-                    >
-                      Siguiente
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="table-wrapper">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Orden</th>
-                    <th>Cliente</th>
-                    <th>Estado</th>
-                    <th>Fecha de ingreso</th>
-                    <th>Fecha de entrega</th>
-                    <th>Acciones</th>
-                  </tr>
-                </thead>
-                <tbody id="ordersTableBody"></tbody>
-              </table>
-            </div>
-            <div id="orderDetail" class="order-detail hidden">
-              <div class="order-detail-header">
-                <div>
-                  <h4>Detalle de la orden</h4>
-                  <p class="muted small">Orden <span id="orderDetailNumber"></span></p>
-                </div>
-                <button type="button" id="closeOrderDetailButton" class="link-button">Cerrar</button>
-              </div>
-              <div class="order-detail-meta">
-                <p><strong>Registrada:</strong> <span id="orderDetailCreatedAt"></span></p>
-                <p><strong>Última actualización:</strong> <span id="orderDetailUpdatedAt"></span></p>
-              </div>
-              <form id="updateOrderForm" class="form-grid">
-                <div class="form-row">
-                  <label for="orderDetailCustomer">Cliente</label>
-                  <input type="text" id="orderDetailCustomer" readonly />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailDocument">Documento</label>
-                  <input type="text" id="orderDetailDocument" readonly />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailContact">Contacto</label>
-                  <input type="text" id="orderDetailContact" />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailInvoice">Número de factura</label>
-                  <input type="text" id="orderDetailInvoice" />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailStatus">Estado</label>
-                  <select id="orderDetailStatus"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailTailor">Sastre asignado</label>
-                  <select id="orderDetailTailor"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailVendor">Vendedor asignado</label>
-                  <select id="orderDetailVendor"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailOrigin">Establecimiento remitente</label>
-                  <select id="orderDetailOrigin"></select>
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailDeliveryDate">Fecha y hora de entrega</label>
-                  <input type="datetime-local" id="orderDetailDeliveryDate" />
-                </div>
-                <div class="form-row">
-                  <label for="orderDetailNotes">Notas</label>
-                  <textarea id="orderDetailNotes" rows="3"></textarea>
-                </div>
-                <div class="form-row">
-                  <label>Medidas</label>
-                  <div id="orderDetailMeasurements" class="measurement-tags muted"></div>
-                </div>
-                <div class="form-row">
-                  <label>Checklist de producción</label>
-                  <div id="orderTasksContainer" class="order-tasks-container">
-                    <div id="orderTasksList" class="order-tasks-list muted">
-                      Selecciona una orden para ver el checklist.
-                    </div>
-                    <div id="orderTaskForm" class="order-task-form hidden" role="group" aria-label="Agregar trabajo al checklist">
-                      <div class="order-task-fields">
-                        <label class="sr-only" for="orderTaskDescription">Descripción del trabajo</label>
-                        <input
-                          type="text"
-                          id="orderTaskDescription"
-                          maxlength="255"
-                          placeholder="Describe el trabajo a registrar"
-                        />
-                        <button type="button" class="secondary" id="orderTaskAddButton">Agregar</button>
-                      </div>
-                      <p class="muted small">
-                        Añade los trabajos pendientes manualmente y marca cada casilla cuando el sastre los
-                        complete.
-                      </p>
-                    </div>
-                    <p id="orderTasksPermissionsNotice" class="muted small hidden">
-                      Solo los sastres o administradores pueden modificar el checklist.
-                    </p>
-                  </div>
-                </div>
-                <div class="button-row">
-                  <button type="submit" class="primary">Guardar cambios</button>
-                </div>
-              </form>
-            </div>
-          </section>
-
-          <section class="card dashboard-panel hidden" id="orderKanbanPanel">
-            <div class="kanban-header">
-              <div>
-                <h3>Kanban de órdenes</h3>
+          <section class="card dashboard-panel hidden" id="ordersPanel">
+            <div class="orders-controls">
+              <div class="orders-controls-info">
+                <h3>Gestión de órdenes</h3>
                 <p class="muted small">
-                  Visualiza las órdenes agrupadas por estado y refresca el tablero para obtener los
-                  datos más recientes.
+                  Administra las órdenes registradas, visualiza el tablero Kanban y abre el formulario
+                  de nuevas órdenes cuando lo necesites.
                 </p>
               </div>
-              <div class="kanban-actions">
-                <button type="button" class="secondary" id="orderKanbanRefreshButton">
-                  Actualizar tablero
+              <div class="orders-controls-actions">
+                <div class="orders-view-toggle" role="group" aria-label="Cambiar vista de órdenes">
+                  <button type="button" data-orders-view="list">Lista</button>
+                  <button type="button" data-orders-view="kanban">Kanban</button>
+                </div>
+                <button
+                  type="button"
+                  class="primary"
+                  id="ordersCreateButton"
+                  data-hide-roles="sastre"
+                >
+                  Crear orden
                 </button>
               </div>
             </div>
-            <div class="kanban-controls">
-              <div class="kanban-search">
-                <label for="orderKanbanSearchInput">Buscar</label>
-                <input
-                  type="search"
-                  id="orderKanbanSearchInput"
-                  placeholder="Número de orden, cliente o cédula"
-                  autocomplete="off"
-                />
+
+            <div id="ordersTableSection" class="orders-view-panel">
+              <div class="order-panel-controls">
+                <p class="muted small">
+                  Las órdenes pendientes se muestran primero, ordenadas por la fecha de entrega más
+                  cercana. Las fechas vencidas se resaltan en rojo mientras la orden no haya sido
+                  entregada.
+                </p>
+                <div class="order-search">
+                  <label for="orderSearchInput">Buscar</label>
+                  <input
+                    type="search"
+                    id="orderSearchInput"
+                    placeholder="Número de orden o cédula"
+                    autocomplete="off"
+                  />
+                </div>
+                <div class="table-pagination">
+                  <label for="orderPageSize">Filas por página</label>
+                  <div class="pagination-controls">
+                    <select id="orderPageSize">
+                      <option value="10" selected>10</option>
+                      <option value="15">15</option>
+                      <option value="20">20</option>
+                      <option value="25">25</option>
+                      <option value="30">30</option>
+                      <option value="35">35</option>
+                      <option value="40">40</option>
+                      <option value="45">45</option>
+                      <option value="50">50</option>
+                    </select>
+                    <div class="pagination-buttons">
+                      <button
+                        type="button"
+                        class="pagination-button"
+                        id="orderPrevPage"
+                        aria-label="Página anterior de órdenes"
+                      >
+                        Anterior
+                      </button>
+                      <span
+                        id="orderPaginationInfo"
+                        class="pagination-info"
+                        aria-live="polite"
+                      >
+                        Mostrando 0-0 de 0
+                      </span>
+                      <button
+                        type="button"
+                        class="pagination-button"
+                        id="orderNextPage"
+                        aria-label="Página siguiente de órdenes"
+                      >
+                        Siguiente
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <p class="muted small">
-                La búsqueda se aplica localmente sobre los resultados cargados en el tablero.
-              </p>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Orden</th>
+                      <th>Cliente</th>
+                      <th>Estado</th>
+                      <th>Fecha de ingreso</th>
+                      <th>Fecha de entrega</th>
+                      <th>Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ordersTableBody"></tbody>
+                </table>
+              </div>
+              <div id="orderDetail" class="order-detail hidden">
+                <div class="order-detail-header">
+                  <div>
+                    <h4 id="orderDetailDialogHeading">Detalle de la orden</h4>
+                    <p class="muted small">Orden <span id="orderDetailNumber"></span></p>
+                  </div>
+                  <button type="button" id="closeOrderDetailButton" class="link-button">Cerrar</button>
+                </div>
+                <div class="order-detail-meta">
+                  <p><strong>Registrada:</strong> <span id="orderDetailCreatedAt"></span></p>
+                  <p><strong>Última actualización:</strong> <span id="orderDetailUpdatedAt"></span></p>
+                </div>
+                <form id="updateOrderForm" class="form-grid">
+                  <div class="form-row">
+                    <label for="orderDetailCustomer">Cliente</label>
+                    <input type="text" id="orderDetailCustomer" readonly />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailDocument">Documento</label>
+                    <input type="text" id="orderDetailDocument" readonly />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailContact">Contacto</label>
+                    <input type="text" id="orderDetailContact" />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailInvoice">Número de factura</label>
+                    <input type="text" id="orderDetailInvoice" />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailStatus">Estado</label>
+                    <select id="orderDetailStatus"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailTailor">Sastre asignado</label>
+                    <select id="orderDetailTailor"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailVendor">Vendedor asignado</label>
+                    <select id="orderDetailVendor"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailOrigin">Establecimiento remitente</label>
+                    <select id="orderDetailOrigin"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailDeliveryDate">Fecha y hora de entrega</label>
+                    <input type="datetime-local" id="orderDetailDeliveryDate" />
+                  </div>
+                  <div class="form-row">
+                    <label for="orderDetailNotes">Notas</label>
+                    <textarea id="orderDetailNotes" rows="3"></textarea>
+                  </div>
+                  <div class="form-row">
+                    <label>Medidas</label>
+                    <div id="orderDetailMeasurements" class="measurement-tags muted"></div>
+                  </div>
+                  <div class="form-row">
+                    <label>Checklist de producción</label>
+                    <div id="orderTasksContainer" class="order-tasks-container">
+                      <div id="orderTasksList" class="order-tasks-list muted">
+                        Selecciona una orden para ver el checklist.
+                      </div>
+                      <div id="orderTaskForm" class="order-task-form hidden" role="group" aria-label="Agregar trabajo al checklist">
+                        <div class="order-task-fields">
+                          <label class="sr-only" for="orderTaskDescription">Descripción del trabajo</label>
+                          <input
+                            type="text"
+                            id="orderTaskDescription"
+                            maxlength="255"
+                            placeholder="Describe el trabajo a registrar"
+                          />
+                          <button type="button" class="secondary" id="orderTaskAddButton">Agregar</button>
+                        </div>
+                        <p class="muted small">
+                          Añade los trabajos pendientes manualmente y marca cada casilla cuando el sastre los
+                          complete.
+                        </p>
+                      </div>
+                      <p id="orderTasksPermissionsNotice" class="muted small hidden">
+                        Solo los sastres o administradores pueden modificar el checklist.
+                      </p>
+                    </div>
+                  </div>
+                  <div class="button-row">
+                    <button type="submit" class="primary">Guardar cambios</button>
+                  </div>
+                </form>
+              </div>
             </div>
-            <div id="orderKanbanStatus" class="kanban-status muted hidden" aria-live="polite"></div>
-            <div id="orderKanbanColumns" class="kanban-board" aria-live="polite"></div>
+
+            <div id="ordersKanbanSection" class="orders-view-panel hidden" aria-hidden="true">
+              <div class="kanban-header">
+                <div>
+                  <h3>Kanban de órdenes</h3>
+                  <p class="muted small">
+                    Visualiza las órdenes agrupadas por estado y refresca el tablero para obtener los
+                    datos más recientes.
+                  </p>
+                </div>
+                <div class="kanban-actions">
+                  <button type="button" class="secondary" id="orderKanbanRefreshButton">
+                    Actualizar tablero
+                  </button>
+                </div>
+              </div>
+              <div class="kanban-controls">
+                <div class="kanban-search">
+                  <label for="orderKanbanSearchInput">Buscar</label>
+                  <input
+                    type="search"
+                    id="orderKanbanSearchInput"
+                    placeholder="Número de orden, cliente o cédula"
+                    autocomplete="off"
+                  />
+                </div>
+                <p class="muted small">
+                  La búsqueda se aplica localmente sobre los resultados cargados en el tablero.
+                </p>
+              </div>
+              <div id="orderKanbanStatus" class="kanban-status muted hidden" aria-live="polite"></div>
+              <div id="orderKanbanColumns" class="kanban-board" aria-live="polite"></div>
+            </div>
+
+            <div
+              id="orderKanbanDetailOverlay"
+              class="kanban-detail-overlay hidden"
+              aria-hidden="true"
+            >
+              <div class="kanban-detail-backdrop" data-kanban-detail-close></div>
+              <div
+                id="orderKanbanDetailDialog"
+                class="kanban-detail-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="orderDetailDialogHeading"
+                tabindex="-1"
+              >
+                <div id="orderKanbanDetail" class="kanban-detail-content">
+                  <p id="orderKanbanDetailMessage" class="muted small">
+                    Selecciona una orden del tablero para ver el detalle.
+                  </p>
+                </div>
+              </div>
+            </div>
+
           </section>
 
           <section class="card dashboard-panel hidden" id="usersPanel">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -236,55 +236,6 @@ body {
   transform: translateY(-1px);
 }
 
-.category-bar {
-  background: var(--primary);
-  color: var(--primary-contrast);
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.category-bar-inner {
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-  padding: 0.65rem 0;
-  overflow-x: auto;
-}
-
-.category-nav {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.category-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 1rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  text-decoration: none;
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.78);
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.category-pill.is-highlight {
-  background: var(--accent);
-  color: var(--primary);
-}
-
-.category-pill:hover,
-.category-pill:focus-visible {
-  outline: none;
-  border-color: rgba(255, 255, 255, 0.45);
-  color: #ffffff;
-}
-
 main {
   padding: clamp(2.5rem, 4vw, 3.5rem) 0;
 }
@@ -541,37 +492,33 @@ button[disabled] {
 .dashboard-subnav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 1rem;
   margin-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(7, 10, 12, 0.08);
+  padding-bottom: 0.5rem;
 }
 
 .dashboard-tab {
-  border: 1px solid rgba(7, 10, 12, 0.12);
-  background: var(--surface);
+  background: transparent;
+  border: none;
   color: var(--muted);
-  padding: 0.55rem 1.2rem;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.5rem 0.25rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  border-bottom: 3px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
 }
 
 .dashboard-tab:hover,
 .dashboard-tab:focus-visible {
   outline: none;
-  background: rgba(17, 17, 17, 0.1);
-  border-color: rgba(17, 17, 17, 0.25);
   color: var(--primary);
 }
 
 .dashboard-tab.active {
-  background: var(--primary);
+  color: var(--primary);
   border-color: var(--primary);
-  color: var(--primary-contrast);
-  box-shadow: 0 18px 32px rgba(var(--shadow-color), 0.12);
 }
 
 .customer-panel-header {
@@ -879,11 +826,15 @@ button[disabled] {
 
   .dashboard-subnav {
     width: 100%;
+    overflow-x: auto;
+    border-bottom: none;
+    padding-bottom: 0;
+    gap: 0.75rem;
   }
 
   .dashboard-tab {
-    flex: 1 1 120px;
-    text-align: center;
+    flex: 0 0 auto;
+    padding: 0.5rem 0.75rem;
   }
 
   .customer-panel-header > :first-child {
@@ -968,6 +919,14 @@ button[disabled] {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.order-detail.kanban-mode {
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .order-detail-header {
@@ -1199,6 +1158,90 @@ button[disabled] {
   max-width: 48ch;
 }
 
+.orders-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.order-create-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.order-create-toolbar button {
+  align-self: flex-start;
+}
+
+.orders-controls-info h3 {
+  margin-bottom: 0.35rem;
+}
+
+.orders-controls-info p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.orders-controls-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.orders-controls-actions > * {
+  flex: 0 0 auto;
+}
+
+.orders-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(7, 10, 12, 0.12);
+  background: rgba(7, 10, 12, 0.04);
+}
+
+.orders-view-toggle button {
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.orders-view-toggle button:hover,
+.orders-view-toggle button:focus-visible {
+  outline: none;
+  color: var(--primary);
+}
+
+.orders-view-toggle button.active {
+  background: var(--primary);
+  color: var(--primary-contrast);
+  box-shadow: 0 18px 32px rgba(var(--shadow-color), 0.12);
+}
+
+#ordersCreateButton {
+  box-shadow: 0 20px 44px rgba(var(--shadow-color), 0.16);
+}
+
+.orders-view-panel {
+  margin-bottom: 2rem;
+}
+
+.orders-view-panel:last-of-type {
+  margin-bottom: 0;
+}
+
 .kanban-header {
   display: flex;
   flex-wrap: wrap;
@@ -1253,6 +1296,54 @@ button[disabled] {
   align-items: stretch;
   overflow-x: auto;
   padding-bottom: 0.5rem;
+}
+
+.kanban-detail-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(1rem, 4vw, 2.5rem);
+  z-index: 1200;
+}
+
+.kanban-detail-overlay.hidden {
+  display: none !important;
+}
+
+.kanban-detail-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 10, 12, 0.45);
+}
+
+.kanban-detail-dialog {
+  position: relative;
+  background: var(--surface);
+  border-radius: 20px;
+  box-shadow: 0 28px 68px rgba(var(--shadow-color), 0.2);
+  width: min(960px, 100%);
+  max-height: calc(100vh - clamp(2rem, 10vh, 5rem));
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  z-index: 1;
+  outline: none;
+}
+
+.kanban-detail-content {
+  padding: clamp(1.25rem, 3vw, 2rem);
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.kanban-detail-content .muted {
+  margin: 0;
+}
+
+body.kanban-detail-open {
+  overflow: hidden;
 }
 
 .kanban-column {
@@ -1313,6 +1404,10 @@ button[disabled] {
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
+  width: 100%;
+  text-align: left;
+  color: inherit;
+  font: inherit;
 }
 
 .kanban-card.is-clickable {
@@ -1332,6 +1427,11 @@ button[disabled] {
   outline-offset: 3px;
   transform: translateY(-2px);
   box-shadow: 0 22px 55px rgba(var(--shadow-color), 0.16);
+}
+
+.kanban-card.is-active {
+  border-color: var(--primary);
+  box-shadow: 0 22px 55px rgba(var(--shadow-color), 0.18);
 }
 
 
@@ -1415,6 +1515,23 @@ button[disabled] {
 
   .kanban-board {
     padding-bottom: 1rem;
+  }
+
+  .kanban-detail-overlay {
+    padding: clamp(0.75rem, 4vw, 1.25rem);
+    align-items: stretch;
+  }
+
+  .kanban-detail-dialog {
+    width: 100%;
+    max-height: calc(100vh - clamp(1.5rem, 6vh, 3rem));
+    border-radius: 16px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .kanban-detail-overlay {
+    align-items: center;
   }
 }
 
@@ -1877,6 +1994,52 @@ th {
   th,
   td {
     padding: 0.6rem;
+  }
+
+  .orders-controls {
+    gap: 1rem;
+  }
+
+  .orders-controls-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+
+  .orders-view-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .orders-view-toggle button {
+    flex: 1 1 0;
+  }
+
+  .orders-controls-actions > * {
+    width: 100%;
+  }
+
+  #ordersCreateToggleButton {
+    width: 100%;
+  }
+}
+
+@media (min-width: 960px) {
+  .orders-controls {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .orders-controls-info {
+    flex: 1 1 auto;
+    max-width: 60ch;
+  }
+
+  .orders-controls-actions {
+    justify-content: flex-end;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the Kanban side panel with a modal overlay that keeps the order detail within the dashboard without warping the board layout
- update dashboard scripts to manage the new overlay, focus handling, and to restore selection state when closing Kanban details
- add styling for the modal overlay and responsive tweaks so the Kanban board and detail view remain usable on all screen sizes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68defc884b9c8332850646d864d38142