### PR TITLE
Support delivery timestamps and refine order views

### DIFF
--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import DBAPIError
@@ -67,7 +69,50 @@ def ensure_assigned_vendor_column(engine: Engine) -> None:
             raise
 
 
+def ensure_delivery_date_is_datetime(engine: Engine) -> None:
+    """Upgrade the delivery_date column to store date and time information."""
+
+    inspector = inspect(engine)
+    if "orders" not in set(inspector.get_table_names()):
+        return
+
+    columns = inspector.get_columns("orders")
+    delivery_column = next((column for column in columns if column["name"] == "delivery_date"), None)
+    if delivery_column is None:
+        return
+
+    column_type = delivery_column.get("type")
+    python_type = None
+    if column_type is not None:
+        try:
+            python_type = column_type.python_type  # type: ignore[attr-defined]
+        except (NotImplementedError, AttributeError):
+            python_type = None
+
+    if python_type is not None and issubclass(python_type, datetime):
+        return
+
+    dialect = engine.dialect.name
+    if dialect == "sqlite":
+        # SQLite stores dates as TEXT and accepts datetime values without schema changes.
+        return
+    if dialect == "postgresql":
+        ddl = "ALTER TABLE orders ALTER COLUMN delivery_date TYPE TIMESTAMP WITHOUT TIME ZONE"
+    elif dialect in {"mysql", "mariadb"}:
+        ddl = "ALTER TABLE orders MODIFY COLUMN delivery_date DATETIME NULL"
+    else:
+        ddl = "ALTER TABLE orders ALTER COLUMN delivery_date TYPE DATETIME"
+
+    with engine.begin() as connection:
+        try:
+            connection.execute(text(ddl))
+        except DBAPIError:
+            # Best-effort migration: ignore databases that cannot alter the column automatically.
+            return
+
+
 def apply_schema_upgrades(engine: Engine) -> None:
     """Apply idempotent schema upgrades required by the application."""
 
     ensure_assigned_vendor_column(engine)
+    ensure_delivery_date_is_datetime(engine)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,6 @@
 import enum
 
-from sqlalchemy import Column, Date, DateTime, Enum, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, JSON, String, Text
 from sqlalchemy.orm import relationship
 
 from .database import Base
@@ -81,7 +81,7 @@ class Order(Base):
     notes = Column(Text, nullable=True)
     assigned_tailor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     assigned_vendor_id = Column(Integer, ForeignKey("users.id"), nullable=True)
-    delivery_date = Column(Date, nullable=True)
+    delivery_date = Column(DateTime(timezone=False), nullable=True)
     origin_branch = Column(Enum(Establishment), nullable=True)
     invoice_number = Column(String(50), nullable=True)
     created_at = Column(DateTime(timezone=True), default=now, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
@@ -106,7 +106,7 @@ class OrderBase(BaseModel):
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
     assigned_vendor_id: Optional[int] = None
-    delivery_date: Optional[date] = None
+    delivery_date: Optional[datetime] = None
     invoice_number: Optional[str] = None
     origin_branch: Optional[Establishment] = None
 
@@ -131,7 +131,7 @@ class OrderUpdate(BaseModel):
     notes: Optional[str] = None
     assigned_tailor_id: Optional[int] = None
     assigned_vendor_id: Optional[int] = None
-    delivery_date: Optional[date] = None
+    delivery_date: Optional[datetime] = None
     invoice_number: Optional[str] = None
     origin_branch: Optional[Establishment] = None
 
@@ -143,7 +143,7 @@ class OrderPublic(BaseModel):
     status: OrderStatus
     notes: Optional[str]
     updated_at: datetime
-    delivery_date: Optional[date] = None
+    delivery_date: Optional[datetime] = None
     measurements: List[MeasurementItem] = Field(default_factory=list)
     invoice_number: Optional[str] = None
     origin_branch: Optional[Establishment] = None

--- a/backend/seed_database.py
+++ b/backend/seed_database.py
@@ -8,7 +8,7 @@ import re
 import secrets
 import string
 from collections import Counter
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Iterable, List, Optional, Sequence, Tuple
 
 from sqlalchemy import MetaData, Table, delete, inspect, select
@@ -238,19 +238,28 @@ def random_password(length: int = 10) -> str:
     return "".join(secrets.choice(alphabet) for _ in range(length))
 
 
-def random_delivery_date(status: models.OrderStatus) -> date | None:
+def random_delivery_date(status: models.OrderStatus) -> datetime | None:
     today = now().date()
+    delivery_day: Optional[date]
     if status == models.OrderStatus.ENTREGADO:
-        return today - timedelta(days=random.randint(1, 30))
-    if status in {
+        delivery_day = today - timedelta(days=random.randint(1, 30))
+    elif status in {
         models.OrderStatus.LISTO_ENTREGA_BATAN,
         models.OrderStatus.LISTO_ENTREGA_URDESA,
         models.OrderStatus.LISTO_ENVIAR_BATAN,
     }:
-        return today + timedelta(days=random.randint(1, 15))
-    if random.random() < 0.3:
-        return today + timedelta(days=random.randint(1, 20))
-    return None
+        delivery_day = today + timedelta(days=random.randint(1, 15))
+    elif random.random() < 0.3:
+        delivery_day = today + timedelta(days=random.randint(1, 20))
+    else:
+        delivery_day = None
+
+    if delivery_day is None:
+        return None
+
+    hour = random.randint(9, 19)
+    minute = random.choice((0, 15, 30, 45))
+    return datetime.combine(delivery_day, time(hour=hour, minute=minute))
 
 
 def seed_users(db: Session, count: int) -> List[Tuple[models.User, str]]:
@@ -345,20 +354,26 @@ def measurement_payload(items: Iterable[schemas.MeasurementItem]) -> List[dict]:
     return payload
 
 
-def random_entry_date(delivery_date: Optional[date]) -> date:
+def random_entry_date(delivery_date: Optional[datetime]) -> datetime:
     """Produce a plausible entry date respecting the delivery date when present."""
 
-    today = date.today()
-    if delivery_date and delivery_date <= today:
-        latest = max(delivery_date - timedelta(days=1), today - timedelta(days=90))
+    today = datetime.now()
+    delivery_reference = delivery_date
+    if delivery_reference and delivery_reference <= today:
+        latest_day = max(
+            delivery_reference - timedelta(days=1), today - timedelta(days=90)
+        )
     else:
-        latest = today
-    earliest = max(latest - timedelta(days=45), today - timedelta(days=120))
-    if earliest > latest:
-        earliest = latest
-    span = max((latest - earliest).days, 0)
+        latest_day = today
+    earliest_day = max(latest_day - timedelta(days=45), today - timedelta(days=120))
+    if earliest_day > latest_day:
+        earliest_day = latest_day
+    span = max(int((latest_day - earliest_day).days), 0)
     offset = random.randint(0, span) if span else 0
-    return latest - timedelta(days=offset)
+    candidate_day = latest_day - timedelta(days=offset)
+    hour = random.randint(8, 18)
+    minute = random.choice((0, 15, 30, 45))
+    return candidate_day.replace(hour=hour, minute=minute, second=0, microsecond=0)
 
 
 def generate_order_tasks(

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -711,26 +711,58 @@ function hasExplicitTimeComponent(value) {
   return false;
 }
 
+function normalizeDateTimeString(value) {
+  if (!value) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return formatDateTimeForApi(value);
+  }
+  if (typeof value === 'number') {
+    return formatDateTimeForApi(new Date(value));
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '';
+    }
+    const isoMatch = trimmed.match(
+      /^(\d{4}-\d{2}-\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2}))?)?(?:\.\d+)?(?:Z)?$/,
+    );
+    if (isoMatch) {
+      const datePart = isoMatch[1];
+      const hourPart = isoMatch[2] ?? '00';
+      const minutePart = isoMatch[3] ?? '00';
+      const secondPart = isoMatch[4] ?? '00';
+      return `${datePart}T${hourPart}:${minutePart}:${secondPart}`;
+    }
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatDateTimeForApi(parsed);
+    }
+  }
+  return '';
+}
+
 function formatDeliveryDateDisplay(order) {
   if (!order?.delivery_date) {
     return '';
   }
   const deliveryValue = order.delivery_date;
-  if (hasExplicitTimeComponent(deliveryValue)) {
-    return formatDate(deliveryValue);
-  }
-  const dateLabel = formatDateOnly(deliveryValue);
-  if (isOrderDelivered(order.status) && order.updated_at) {
+  const hasTime = hasExplicitTimeComponent(deliveryValue);
+  const normalizedValue = normalizeDateTimeString(deliveryValue) || deliveryValue;
+  if (!hasTime && isOrderDelivered(order.status) && order.updated_at) {
     const updated = new Date(order.updated_at);
     if (!Number.isNaN(updated.getTime())) {
       const timeLabel = updated.toLocaleTimeString('es-EC', {
         hour: '2-digit',
         minute: '2-digit',
       });
+      const dateLabel = formatDateOnly(normalizedValue);
       return `${dateLabel} · ${timeLabel}`;
     }
   }
-  return dateLabel;
+  return formatDate(normalizedValue);
 }
 
 function canModifyOrderTasks() {
@@ -838,25 +870,11 @@ function renderOrderTasks() {
     const meta = document.createElement('div');
     meta.className = 'order-task-meta';
 
-    const responsible = document.createElement('span');
-    responsible.className = 'order-task-responsible';
-    responsible.textContent = task.responsible?.full_name
-      ? `Responsable: ${task.responsible.full_name}`
-      : 'Responsable: Sin asignar';
-    meta.appendChild(responsible);
-
     if (task.updated_at) {
       const updated = document.createElement('span');
       updated.className = 'order-task-updated';
       updated.textContent = `Actualizado: ${formatDate(task.updated_at)}`;
       meta.appendChild(updated);
-    }
-
-    if (task.responsible?.full_name) {
-      const responsible = document.createElement('span');
-      responsible.className = 'order-task-responsible';
-      responsible.textContent = `Responsable: ${task.responsible.full_name}`;
-      meta.appendChild(responsible);
     }
 
     if (meta.children.length > 0) {
@@ -1073,29 +1091,22 @@ function renderPublicOrderResults(orders) {
 
   const listHtml = orders
     .map((order) => {
-      const measurements = order.measurements?.length
-        ? `<div class="measurement-tags">${order.measurements
-            .map((item) => `<span class="tag">${item.nombre}: ${item.valor}</span>`)
-            .join('')}</div>`
-        : '<p class="muted">No hay medidas registradas.</p>';
-      const deliveryLabel = order.delivery_date
-        ? formatDeliveryDateDisplay(order) || formatDateOnly(order.delivery_date)
-        : '';
+      const deliveryLabel = order.delivery_date ? formatDeliveryDateDisplay(order) : '';
       const deliveryInfo = deliveryLabel
         ? `<p><strong>Fecha tentativa de entrega:</strong> ${deliveryLabel}</p>`
         : `<p><strong>Fecha tentativa de entrega:</strong> <span class="muted">Sin definir</span></p>`;
+      const invoiceInfo = order.invoice_number
+        ? `<p class="muted">Factura: ${order.invoice_number}</p>`
+        : '<p class="muted">Factura: Sin registrar</p>';
       return `
         <article class="public-order-card">
           <header>
             <h3>Orden ${order.order_number}</h3>
-            <p><strong>Cliente:</strong> ${order.customer_name}</p>
-            ${order.customer_document ? `<p><strong>Documento:</strong> ${order.customer_document}</p>` : ''}
+            ${invoiceInfo}
           </header>
-          <p><strong>Estado:</strong> ${order.status}</p>
+          <p><strong>Cliente:</strong> ${order.customer_name || '—'}</p>
+          <p><strong>Estado:</strong> ${order.status || 'Sin estado'}</p>
           ${deliveryInfo}
-          ${order.notes ? `<p><strong>Notas:</strong> ${order.notes}</p>` : ''}
-          <p><strong>Última actualización:</strong> ${formatDate(order.updated_at)}</p>
-          ${measurements}
         </article>
       `;
     })
@@ -3539,14 +3550,17 @@ function parseDateValue(value) {
   return parsed;
 }
 
-function formatDateForApi(date) {
+function formatDateTimeForApi(date) {
   if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
     return '';
   }
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
 }
 
 function normalizeDateForApi(value) {
@@ -3554,23 +3568,29 @@ function normalizeDateForApi(value) {
     return '';
   }
   if (value instanceof Date) {
-    return formatDateForApi(value);
+    return formatDateTimeForApi(value);
   }
   if (typeof value === 'number') {
-    return formatDateForApi(new Date(value));
+    return formatDateTimeForApi(new Date(value));
   }
   if (typeof value === 'string') {
     const trimmed = value.trim();
     if (!trimmed) {
       return '';
     }
-    const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})/);
+    const match = trimmed.match(
+      /^(\d{4}-\d{2}-\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2}))?)?(?:\.\d+)?(?:Z)?$/,
+    );
     if (match) {
-      return match[1];
+      const datePart = match[1];
+      const hourPart = match[2] ?? '00';
+      const minutePart = match[3] ?? '00';
+      const secondPart = match[4] ?? '00';
+      return `${datePart}T${hourPart}:${minutePart}:${secondPart}`;
     }
     const parsed = parseDateValue(trimmed);
     if (parsed) {
-      return formatDateForApi(parsed);
+      return formatDateTimeForApi(parsed);
     }
   }
   return '';

--- a/frontend/order-detail.js
+++ b/frontend/order-detail.js
@@ -141,6 +141,52 @@ function hasExplicitTimeComponent(value) {
   return false;
 }
 
+function formatDateTimeLocalString(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+}
+
+function normalizeDateTimeString(value) {
+  if (!value) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return formatDateTimeLocalString(value);
+  }
+  if (typeof value === 'number') {
+    return formatDateTimeLocalString(new Date(value));
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '';
+    }
+    const isoMatch = trimmed.match(
+      /^(\d{4}-\d{2}-\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2}))?)?(?:\.\d+)?(?:Z)?$/,
+    );
+    if (isoMatch) {
+      const datePart = isoMatch[1];
+      const hourPart = isoMatch[2] ?? '00';
+      const minutePart = isoMatch[3] ?? '00';
+      const secondPart = isoMatch[4] ?? '00';
+      return `${datePart}T${hourPart}:${minutePart}:${secondPart}`;
+    }
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatDateTimeLocalString(parsed);
+    }
+  }
+  return '';
+}
+
 function isOrderDelivered(status) {
   return typeof status === 'string' && status.trim().toLowerCase() === 'entregado';
 }
@@ -150,21 +196,20 @@ function formatDeliveryDateLabel(order) {
     return '';
   }
   const deliveryValue = order.delivery_date;
-  if (hasExplicitTimeComponent(deliveryValue)) {
-    return formatDate(deliveryValue);
-  }
-  const dateLabel = formatDateOnly(deliveryValue);
-  if (isOrderDelivered(order.status) && order.updated_at) {
+  const hasTime = hasExplicitTimeComponent(deliveryValue);
+  const normalizedValue = normalizeDateTimeString(deliveryValue) || deliveryValue;
+  if (!hasTime && isOrderDelivered(order.status) && order.updated_at) {
     const updated = new Date(order.updated_at);
     if (!Number.isNaN(updated.getTime())) {
       const timeLabel = updated.toLocaleTimeString('es-EC', {
         hour: '2-digit',
         minute: '2-digit',
       });
+      const dateLabel = formatDateOnly(normalizedValue);
       return `${dateLabel} · ${timeLabel}`;
     }
   }
-  return dateLabel;
+  return formatDate(normalizedValue);
 }
 
 function getStatusBadgeVariant(status) {
@@ -357,9 +402,6 @@ function renderTasks(tasks, { loading = false, error = null } = {}) {
     item.appendChild(description);
 
     const metaParts = [];
-    if (task?.responsible?.full_name) {
-      metaParts.push(`Responsable: ${task.responsible.full_name}`);
-    }
     if (task?.created_at) {
       metaParts.push(`Creada: ${formatDate(task.created_at)}`);
     }


### PR DESCRIPTION
## Summary
- store order delivery dates with timestamp support and migrate existing databases accordingly
- generate delivery times in the seed data and display them throughout the admin and public views
- simplify public order lookups and checklist displays by removing redundant document/responsable details

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68df2ebd29208332a0bbb52c5baddb90