### PR TITLE
Enable opening customer history orders

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2581,8 +2581,23 @@ function renderCustomerOrderHistory(customer) {
     const statusWrapper = document.createElement('div');
     statusWrapper.appendChild(createStatusBadge(order.status));
 
+    const actions = document.createElement('div');
+    actions.className = 'customer-order-history-item-actions';
+    actions.appendChild(statusWrapper);
+
+    if (state.token) {
+      const openButton = document.createElement('button');
+      openButton.type = 'button';
+      openButton.className = 'link-button customer-order-history-open';
+      openButton.textContent = 'Ver orden';
+      openButton.addEventListener('click', () => {
+        openOrderDetailFromCustomerHistory(order);
+      });
+      actions.appendChild(openButton);
+    }
+
     header.appendChild(orderNumber);
-    header.appendChild(statusWrapper);
+    header.appendChild(actions);
 
     const invoice = document.createElement('p');
     invoice.className = 'customer-order-history-item-invoice';
@@ -2614,6 +2629,49 @@ function renderCustomerOrderHistory(customer) {
   });
 
   customerOrderHistoryContainer.appendChild(list);
+}
+
+async function openOrderDetailFromCustomerHistory(order) {
+  if (!state.token) {
+    showToast('Inicia sesión para gestionar las órdenes.', 'error');
+    return;
+  }
+  if (!order || order.id === undefined || order.id === null) {
+    showToast('No se pudo abrir el detalle de la orden seleccionada.', 'error');
+    return;
+  }
+
+  const orderIdKey = String(order.id);
+  setActiveDashboardTab('ordersPanel');
+  if (state.activeOrdersView !== 'list') {
+    setActiveOrdersView('list');
+  }
+
+  let detail = state.orders.find((item) => String(item.id) === orderIdKey);
+  if (!detail) {
+    try {
+      detail = await apiFetch(`/orders/${encodeURIComponent(orderIdKey)}`);
+    } catch (error) {
+      /* ignore fetch failure and fall back to cached data */
+    }
+  }
+
+  if (!detail) {
+    detail = order;
+  }
+
+  if (!detail || detail.id === undefined || detail.id === null) {
+    showToast('No se pudo abrir el detalle de la orden seleccionada.', 'error');
+    return;
+  }
+
+  const remainingOrders = state.orders.filter((item) => String(item.id) !== orderIdKey);
+  state.orders = [...remainingOrders, detail];
+  if (typeof state.orderTotal !== 'number' || state.orderTotal < state.orders.length) {
+    state.orderTotal = state.orders.length;
+  }
+
+  populateOrderDetail(detail);
 }
 function renderCustomers() {
   if (!customersTableBody) return;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -752,6 +752,18 @@ button[disabled] {
   font-size: 1rem;
 }
 
+.customer-order-history-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.customer-order-history-item-actions .customer-order-history-open {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
 .customer-order-history-item-meta {
   margin: 0;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- add a "Ver orden" action to each customer order history entry so staff can open the order detail
- reuse the orders panel detail view when opening an order from the customer history, fetching fresh data if needed
- tweak the customer history styles to accommodate the new action button

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68df38dbcebc833285595e0148026078