### PR TITLE
Clear order overlay state when leaving dashboard tabs

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -458,6 +458,7 @@ function setActiveDashboardTab(tabId = 'ordersPanel') {
   if (ADMIN_ONLY_TABS.has(targetTab) && userRole !== 'administrador') {
     targetTab = 'ordersPanel';
   }
+  const previousTab = activeDashboardTab;
   activeDashboardTab = targetTab;
 
   const highlightTabId = targetTab === 'orderCreatePanel' ? 'ordersPanel' : targetTab;
@@ -483,6 +484,14 @@ function setActiveDashboardTab(tabId = 'ordersPanel') {
       panel.classList.toggle('hidden', id !== targetTab);
     }
   });
+
+  if (previousTab === 'ordersPanel' && targetTab !== 'ordersPanel') {
+    if (currentOrderDetailHost === 'overlay' && state.selectedOrderId !== null) {
+      clearOrderDetail({ skipRender: true });
+    } else if (document.body) {
+      document.body.classList.remove('kanban-detail-open');
+    }
+  }
 
   if (targetTab === 'usersPanel' && userRole === 'administrador') {
     loadUsers();


### PR DESCRIPTION
## Summary
- track the previously active dashboard tab when switching views
- clear the order overlay selection when navigating away from the orders panel to restore body scrolling

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68df447f8d9c8332906d1ce471658e9e