### PR TITLE
Ensure staff overlays close when leaving their tab

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -132,6 +132,10 @@ const orderKanbanDetailOverlay = document.getElementById('orderKanbanDetailOverl
 const orderKanbanDetailDialog = document.getElementById('orderKanbanDetailDialog');
 const orderKanbanDetailMessage = document.getElementById('orderKanbanDetailMessage');
 const kanbanDetailCloseElements = document.querySelectorAll('[data-kanban-detail-close]');
+const dashboardOverlay = document.getElementById('dashboardOverlay');
+const dashboardOverlayDialog = document.getElementById('dashboardOverlayDialog');
+const dashboardOverlayContent = document.getElementById('dashboardOverlayContent');
+const dashboardOverlayCloseElements = document.querySelectorAll('[data-dashboard-overlay-close]');
 const orderLookupForm = document.getElementById('orderLookupForm');
 const orderNumberInput = document.getElementById('orderNumber');
 const orderDocumentInput = document.getElementById('customerDocument');
@@ -257,9 +261,11 @@ const ORDER_TABLE_COLUMN_COUNT = 6;
 const CUSTOMER_TABLE_COLUMN_COUNT = 5;
 let activeOrderDetailRow = null;
 let currentOrderDetailHost = null;
-let activeCustomerDetailRow = null;
 let lastKanbanFocusedElement = null;
 let lastKanbanFocusedOrderId = null;
+let activeDashboardOverlayElement = null;
+let activeDashboardOverlayOptions = null;
+const dashboardOverlayOrigins = new WeakMap();
 
 
 function setActiveView(viewId) {
@@ -276,6 +282,9 @@ function setActiveView(viewId) {
   if (loginNavButton) {
     const shouldHighlightLogin = viewId === 'staff-view' && !state.token;
     loginNavButton.classList.toggle('active', shouldHighlightLogin);
+  }
+  if (viewId !== 'staff-view' && isDashboardOverlayActive()) {
+    closeDashboardOverlaySection();
   }
 }
 
@@ -418,8 +427,13 @@ function applyRoleVisibility() {
     }
     if (element === ordersCreateButton) {
       element.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
-      if (shouldHide && activeDashboardTab === 'orderCreatePanel') {
-        setActiveDashboardTab('ordersPanel');
+      if (shouldHide) {
+        if (isDashboardOverlayActive(orderCreatePanel)) {
+          closeDashboardOverlaySection();
+        }
+        if (activeDashboardTab === 'orderCreatePanel') {
+          setActiveDashboardTab('ordersPanel');
+        }
       }
     }
   });
@@ -444,15 +458,11 @@ function setActiveOrdersView(view) {
   }
   if (nextView === 'kanban') {
     ensureKanbanDataLoaded();
-    updateKanbanDetailVisibility();
   } else {
-    if (currentOrderDetailHost === 'kanban') {
-      currentOrderDetailHost = null;
-    }
-    updateKanbanDetailVisibility();
     renderOrders();
-    renderOrderKanban();
   }
+  updateOrderDetailOverlayVisibility();
+  renderOrderKanban();
 }
 
 function setActiveDashboardTab(tabId = 'ordersPanel') {
@@ -462,6 +472,12 @@ function setActiveDashboardTab(tabId = 'ordersPanel') {
   if (ADMIN_ONLY_TABS.has(targetTab) && userRole !== 'administrador') {
     targetTab = 'ordersPanel';
   }
+
+  const overlayContextTab = activeDashboardOverlayOptions?.contextTab || null;
+  if (isDashboardOverlayActive() && overlayContextTab && overlayContextTab !== targetTab) {
+    closeDashboardOverlaySection();
+  }
+
   activeDashboardTab = targetTab;
 
   const highlightTabId = targetTab === 'orderCreatePanel' ? 'ordersPanel' : targetTab;
@@ -534,23 +550,35 @@ if (ordersCreateButton) {
     }
     lastOrdersViewBeforeCreate = state.activeOrdersView || 'list';
     setActiveView('staff-view');
-    setActiveDashboardTab('orderCreatePanel');
-    if (orderCreatePanel && orderCreatePanel.scrollIntoView) {
-      orderCreatePanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
+    setActiveDashboardTab('ordersPanel');
+    openDashboardOverlaySection(orderCreatePanel, {
+      labelledBy: 'orderCreateHeading',
+      contextTab: 'ordersPanel',
+      focusSelector: '#newOrderNumber',
+      restoreFocus: ordersCreateButton,
+      onClose: () => {
+        syncCreateOrderFormDisabled();
+        setActiveOrdersView(lastOrdersViewBeforeCreate || 'list');
+      },
+    });
+    syncCreateOrderFormDisabled();
   });
 }
 
 if (orderCreateBackButton) {
   orderCreateBackButton.addEventListener('click', () => {
-    setActiveDashboardTab('ordersPanel');
-    setActiveOrdersView(lastOrdersViewBeforeCreate || 'list');
-    if (
-      ordersCreateButton &&
-      !ordersCreateButton.classList.contains('hidden') &&
-      !ordersCreateButton.disabled
-    ) {
-      ordersCreateButton.focus();
+    if (isDashboardOverlayActive(orderCreatePanel)) {
+      closeDashboardOverlaySection();
+    } else {
+      setActiveDashboardTab('ordersPanel');
+      setActiveOrdersView(lastOrdersViewBeforeCreate || 'list');
+      if (
+        ordersCreateButton &&
+        !ordersCreateButton.classList.contains('hidden') &&
+        !ordersCreateButton.disabled
+      ) {
+        ordersCreateButton.focus();
+      }
     }
   });
 }
@@ -1675,22 +1703,187 @@ function resetCreateCustomerForm() {
   }
 }
 
-function setCreateCustomerVisible(visible) {
-  if (!createCustomerSection) return;
-  state.isCreateCustomerVisible = visible;
-  createCustomerSection.classList.toggle('hidden', !visible);
-  if (showCreateCustomerButton) {
-    showCreateCustomerButton.classList.toggle('hidden', visible);
+function rememberDashboardOverlayOrigin(element) {
+  if (!element || dashboardOverlayOrigins.has(element)) {
+    return;
   }
+  dashboardOverlayOrigins.set(element, {
+    parent: element.parentNode,
+    nextSibling: element.nextSibling,
+  });
+}
+
+function isDashboardOverlayActive(element = null) {
+  if (!element) {
+    return Boolean(activeDashboardOverlayElement);
+  }
+  return activeDashboardOverlayElement === element;
+}
+
+function updateDashboardOverlayOptions(updates = {}) {
+  if (!activeDashboardOverlayElement) {
+    return;
+  }
+  activeDashboardOverlayOptions = {
+    ...(activeDashboardOverlayOptions || {}),
+    ...updates,
+  };
+}
+
+function openDashboardOverlaySection(element, options = {}) {
+  if (!element || !dashboardOverlay || !dashboardOverlayContent) {
+    return;
+  }
+
+  rememberDashboardOverlayOrigin(element);
+
+  if (activeDashboardOverlayElement === element) {
+    updateDashboardOverlayOptions(options);
+    if (dashboardOverlayDialog) {
+      if (options.labelledBy) {
+        dashboardOverlayDialog.setAttribute('aria-labelledby', options.labelledBy);
+      } else if (options.labelledBy === null) {
+        dashboardOverlayDialog.removeAttribute('aria-labelledby');
+      }
+    }
+  } else {
+    if (activeDashboardOverlayElement) {
+      closeDashboardOverlaySection();
+    }
+    activeDashboardOverlayElement = element;
+    activeDashboardOverlayOptions = { ...options };
+    dashboardOverlayContent.innerHTML = '';
+    dashboardOverlayContent.appendChild(element);
+    if (dashboardOverlayDialog) {
+      if (options.labelledBy) {
+        dashboardOverlayDialog.setAttribute('aria-labelledby', options.labelledBy);
+      } else {
+        dashboardOverlayDialog.removeAttribute('aria-labelledby');
+      }
+    }
+  }
+
+  element.classList.remove('hidden');
+  element.setAttribute('aria-hidden', 'false');
+
+  dashboardOverlay.classList.remove('hidden');
+  dashboardOverlay.setAttribute('aria-hidden', 'false');
+
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.classList.add('dashboard-overlay-open');
+  }
+
+  requestAnimationFrame(() => {
+    let focusTarget = null;
+    if (options.focusSelector) {
+      focusTarget = element.querySelector(options.focusSelector);
+    } else if (options.focusElement instanceof HTMLElement) {
+      focusTarget = options.focusElement;
+    }
+    if (!(focusTarget instanceof HTMLElement) && dashboardOverlayDialog instanceof HTMLElement) {
+      focusTarget = dashboardOverlayDialog;
+    }
+    if (focusTarget instanceof HTMLElement) {
+      focusTarget.focus();
+    }
+  });
+}
+
+function closeDashboardOverlaySection(options = {}) {
+  if (!dashboardOverlay || !dashboardOverlayContent) {
+    return;
+  }
+  if (!activeDashboardOverlayElement) {
+    return;
+  }
+
+  const overlayElement = activeDashboardOverlayElement;
+  const overlayOptions = activeDashboardOverlayOptions || {};
+  const { skipCallbacks = false, restoreFocus } = options;
+
+  const origin = dashboardOverlayOrigins.get(overlayElement);
+  if (origin?.parent) {
+    if (origin.nextSibling && origin.nextSibling.parentNode === origin.parent) {
+      origin.parent.insertBefore(overlayElement, origin.nextSibling);
+    } else {
+      origin.parent.appendChild(overlayElement);
+    }
+  } else if (dashboardOverlayContent.contains(overlayElement)) {
+    dashboardOverlayContent.removeChild(overlayElement);
+  }
+
+  overlayElement.classList.add('hidden');
+  overlayElement.setAttribute('aria-hidden', 'true');
+
+  dashboardOverlayContent.innerHTML = '';
+  dashboardOverlay.classList.add('hidden');
+  dashboardOverlay.setAttribute('aria-hidden', 'true');
+
+  if (dashboardOverlayDialog) {
+    dashboardOverlayDialog.removeAttribute('aria-labelledby');
+  }
+
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.classList.remove('dashboard-overlay-open');
+  }
+
+  const focusTarget =
+    restoreFocus instanceof HTMLElement
+      ? restoreFocus
+      : overlayOptions.restoreFocus instanceof HTMLElement
+        ? overlayOptions.restoreFocus
+        : null;
+
+  if (focusTarget instanceof HTMLElement) {
+    requestAnimationFrame(() => {
+      if (focusTarget.isConnected) {
+        focusTarget.focus();
+      }
+    });
+  }
+
+  activeDashboardOverlayElement = null;
+  activeDashboardOverlayOptions = null;
+
+  if (!skipCallbacks && typeof overlayOptions.onClose === 'function') {
+    overlayOptions.onClose();
+  }
+}
+
+function setCreateCustomerVisible(visible, options = {}) {
+  if (!createCustomerSection) return;
+  const triggerElement = options.trigger instanceof HTMLElement ? options.trigger : null;
+
   if (visible) {
+    if (state.isCreateCustomerVisible) {
+      if (triggerElement) {
+        updateDashboardOverlayOptions({ restoreFocus: triggerElement });
+      }
+      return;
+    }
+    state.isCreateCustomerVisible = true;
+    if (showCreateCustomerButton) {
+      showCreateCustomerButton.classList.add('hidden');
+    }
     if (customerMeasurementsContainer && !customerMeasurementsContainer.children.length) {
       createMeasurementSetBlock(customerMeasurementsContainer);
     }
-    createCustomerSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    const firstField = createCustomerForm?.querySelector('input, textarea, select');
-    firstField?.focus();
-  } else {
-    resetCreateCustomerForm();
+    openDashboardOverlaySection(createCustomerSection, {
+      labelledBy: 'createCustomerHeading',
+      contextTab: 'customersPanel',
+      focusSelector: '#customerFullName',
+      restoreFocus:
+        triggerElement || (showCreateCustomerButton instanceof HTMLElement ? showCreateCustomerButton : null),
+      onClose: () => {
+        state.isCreateCustomerVisible = false;
+        if (showCreateCustomerButton) {
+          showCreateCustomerButton.classList.remove('hidden');
+        }
+        resetCreateCustomerForm();
+      },
+    });
+  } else if (state.isCreateCustomerVisible) {
+    closeDashboardOverlaySection();
   }
 }
 
@@ -1811,6 +2004,9 @@ function hideDashboard() {
   }
   if (staffLoginCard) {
     staffLoginCard.classList.remove('hidden');
+  }
+  if (isDashboardOverlayActive()) {
+    closeDashboardOverlaySection();
   }
 }
 
@@ -2581,8 +2777,23 @@ function renderCustomerOrderHistory(customer) {
     const statusWrapper = document.createElement('div');
     statusWrapper.appendChild(createStatusBadge(order.status));
 
+    const actions = document.createElement('div');
+    actions.className = 'customer-order-history-item-actions';
+    actions.appendChild(statusWrapper);
+
+    if (state.token) {
+      const openButton = document.createElement('button');
+      openButton.type = 'button';
+      openButton.className = 'link-button customer-order-history-open';
+      openButton.textContent = 'Ver orden';
+      openButton.addEventListener('click', () => {
+        openOrderDetailFromCustomerHistory(order);
+      });
+      actions.appendChild(openButton);
+    }
+
     header.appendChild(orderNumber);
-    header.appendChild(statusWrapper);
+    header.appendChild(actions);
 
     const invoice = document.createElement('p');
     invoice.className = 'customer-order-history-item-invoice';
@@ -2615,6 +2826,50 @@ function renderCustomerOrderHistory(customer) {
 
   customerOrderHistoryContainer.appendChild(list);
 }
+
+async function openOrderDetailFromCustomerHistory(order) {
+  if (!state.token) {
+    showToast('Inicia sesión para gestionar las órdenes.', 'error');
+    return;
+  }
+  if (!order || order.id === undefined || order.id === null) {
+    showToast('No se pudo abrir el detalle de la orden seleccionada.', 'error');
+    return;
+  }
+
+  const orderIdKey = String(order.id);
+  setActiveDashboardTab('ordersPanel');
+  if (state.activeOrdersView !== 'list') {
+    setActiveOrdersView('list');
+  }
+
+  let detail = state.orders.find((item) => String(item.id) === orderIdKey);
+  if (!detail) {
+    try {
+      detail = await apiFetch(`/orders/${encodeURIComponent(orderIdKey)}`);
+    } catch (error) {
+      /* ignore fetch failure and fall back to cached data */
+    }
+  }
+
+  if (!detail) {
+    detail = order;
+  }
+
+  if (!detail || detail.id === undefined || detail.id === null) {
+    showToast('No se pudo abrir el detalle de la orden seleccionada.', 'error');
+    return;
+  }
+
+  const remainingOrders = state.orders.filter((item) => String(item.id) !== orderIdKey);
+  state.orders = [...remainingOrders, detail];
+  if (typeof state.orderTotal !== 'number' || state.orderTotal < state.orders.length) {
+    state.orderTotal = state.orders.length;
+  }
+
+  populateOrderDetail(detail, { focusOnDetail: false });
+  attachOrderDetailToOverlay();
+}
 function renderCustomers() {
   if (!customersTableBody) return;
 
@@ -2624,7 +2879,6 @@ function renderCustomers() {
   }
 
   customersTableBody.innerHTML = '';
-  activeCustomerDetailRow = null;
 
   if (customerSearchInput && customerSearchInput.value !== state.customerSearchTerm) {
     customerSearchInput.value = state.customerSearchTerm;
@@ -2667,14 +2921,8 @@ function renderCustomers() {
     cell.className = 'muted';
     row.appendChild(cell);
     customersTableBody.appendChild(row);
-    if (customerDetail) {
-      customerDetail.classList.add('hidden');
-      activeCustomerDetailRow = null;
-    }
     return;
   }
-
-  let detailRendered = false;
 
   state.customers.forEach((customer) => {
     const row = document.createElement('tr');
@@ -2682,9 +2930,7 @@ function renderCustomers() {
     row.dataset.customerId = String(customer.id);
 
     const isSelected = state.selectedCustomerId === customer.id;
-    if (isSelected) {
-      row.classList.add('is-selected');
-    }
+    row.classList.toggle('is-selected', isSelected);
 
     const cachedOrders = getOrdersForCustomer(customer.id);
     const orderCount =
@@ -2733,12 +2979,18 @@ function renderCustomers() {
     viewButton.setAttribute('aria-expanded', isSelected ? 'true' : 'false');
     viewButton.addEventListener('click', async () => {
       if (state.selectedCustomerId === customer.id) {
-        clearCustomerDetail({ reRender: true });
+        clearCustomerDetail({ reRender: true, restoreFocus: viewButton });
       } else {
-        await populateCustomerDetail(customer);
+        await populateCustomerDetail(customer, { trigger: viewButton });
       }
     });
     actionsCell.appendChild(viewButton);
+
+    if (isSelected && isDashboardOverlayActive(customerDetail)) {
+      updateDashboardOverlayOptions({ restoreFocus: viewButton });
+      viewButton.textContent = 'Ocultar detalle';
+      viewButton.setAttribute('aria-expanded', 'true');
+    }
 
     row.appendChild(nameCell);
     row.appendChild(documentCell);
@@ -2747,37 +2999,24 @@ function renderCustomers() {
     row.appendChild(actionsCell);
 
     customersTableBody.appendChild(row);
-
-    if (isSelected && customerDetail) {
-      const detailRow = document.createElement('tr');
-      detailRow.className = 'customer-detail-row';
-      detailRow.dataset.customerId = String(customer.id);
-
-      const detailCell = document.createElement('td');
-      detailCell.colSpan = CUSTOMER_TABLE_COLUMN_COUNT;
-      detailCell.className = 'customer-detail-cell';
-      detailCell.appendChild(customerDetail);
-
-      detailRow.appendChild(detailCell);
-      customersTableBody.appendChild(detailRow);
-      activeCustomerDetailRow = detailRow;
-      customerDetail.classList.remove('hidden');
-      viewButton.textContent = 'Ocultar detalle';
-      viewButton.setAttribute('aria-expanded', 'true');
-      detailRendered = true;
-    }
   });
-
-  if (!detailRendered && customerDetail) {
-    customerDetail.classList.add('hidden');
-    activeCustomerDetailRow = null;
-  }
 }
 
-async function populateCustomerDetail(customer) {
+async function populateCustomerDetail(customer, options = {}) {
   if (!customerDetail) return;
+
+  const triggerElement = options.trigger instanceof HTMLElement ? options.trigger : null;
   state.selectedCustomerId = customer.id;
-  customerDetail.classList.remove('hidden');
+
+  openDashboardOverlaySection(customerDetail, {
+    labelledBy: 'customerDetailTitle',
+    contextTab: 'customersPanel',
+    focusSelector: '#updateCustomerName',
+    restoreFocus: triggerElement || null,
+    onClose: () => {
+      clearCustomerDetail({ skipOverlayClose: true, reRender: true });
+    },
+  });
 
   const cacheKey = String(customer.id);
   const expectedOrderCount =
@@ -2859,18 +3098,21 @@ async function populateCustomerDetail(customer) {
   renderCustomerOrderHistory(customer);
   renderCustomers();
   requestAnimationFrame(() => {
-    const detailRow = customersTableBody?.querySelector(
-      `.customer-detail-row[data-customer-id="${customer.id}"]`,
+    const row = customersTableBody?.querySelector(
+      `.customer-row[data-customer-id="${customer.id}"]`,
     );
-    detailRow?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    row?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   });
 }
 
 function clearCustomerDetail(options = {}) {
   if (!customerDetail) return;
-  const { reRender = false } = options;
-  customerDetail.classList.add('hidden');
+
+  const { reRender = false, skipOverlayClose = false, restoreFocus = null } = options;
+
   state.selectedCustomerId = null;
+  customerDetail.classList.add('hidden');
+  customerDetail.setAttribute('aria-hidden', 'true');
 
   if (customerDetailTitle) {
     customerDetailTitle.textContent = CUSTOMER_DETAIL_DEFAULT_TITLE;
@@ -2885,7 +3127,15 @@ function clearCustomerDetail(options = {}) {
     updateCustomerMeasurementsContainer.innerHTML = '';
   }
 
-  removeCustomerDetailRow();
+  if (!skipOverlayClose && isDashboardOverlayActive(customerDetail)) {
+    closeDashboardOverlaySection({ skipCallbacks: true, restoreFocus });
+  } else if (restoreFocus instanceof HTMLElement) {
+    requestAnimationFrame(() => {
+      if (restoreFocus.isConnected) {
+        restoreFocus.focus();
+      }
+    });
+  }
 
   if (reRender) {
     renderCustomers();
@@ -2978,14 +3228,15 @@ function populateOrderDetail(order, options = {}) {
   }
 
   refreshOrderTasks(order.id);
-  updateKanbanDetailVisibility();
+  updateOrderDetailOverlayVisibility();
 }
 
 function clearOrderDetail(options = {}) {
   if (!orderDetail) return;
-  const wasKanbanHost = currentOrderDetailHost === 'kanban';
+  const wasOverlayHost = currentOrderDetailHost === 'overlay';
+  const defaultSkipRender = wasOverlayHost && state.activeOrdersView === 'kanban';
   const skipRenderOption =
-    typeof options.skipRender === 'boolean' ? options.skipRender : wasKanbanHost;
+    typeof options.skipRender === 'boolean' ? options.skipRender : defaultSkipRender;
   const focusOrderId = lastKanbanFocusedOrderId;
   const focusElement = lastKanbanFocusedElement;
 
@@ -3014,17 +3265,17 @@ function clearOrderDetail(options = {}) {
   removeOrderDetailRow();
   orderDetail.classList.add('hidden');
 
-  if (wasKanbanHost) {
+  if (wasOverlayHost) {
     currentOrderDetailHost = null;
   }
-  updateKanbanDetailVisibility();
+  updateOrderDetailOverlayVisibility();
 
   if (!skipRenderOption) {
     renderOrders();
   }
   renderOrderKanban();
 
-  if (wasKanbanHost) {
+  if (wasOverlayHost) {
     requestAnimationFrame(() => {
       let focusTarget = null;
       if (focusOrderId && orderKanbanColumns) {
@@ -3227,7 +3478,7 @@ if (orderNextPageButton) {
 
 if (showCreateCustomerButton) {
   showCreateCustomerButton.addEventListener('click', () => {
-    setCreateCustomerVisible(true);
+    setCreateCustomerVisible(true, { trigger: showCreateCustomerButton });
   });
 }
 
@@ -3295,16 +3546,33 @@ kanbanDetailCloseElements.forEach((element) => {
     if (
       orderKanbanDetailOverlay &&
       !orderKanbanDetailOverlay.classList.contains('hidden') &&
-      currentOrderDetailHost === 'kanban'
+      currentOrderDetailHost === 'overlay'
     ) {
       clearOrderDetail();
     }
   });
 });
 
+dashboardOverlayCloseElements.forEach((element) => {
+  element.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (isDashboardOverlayActive()) {
+      closeDashboardOverlaySection();
+    }
+  });
+});
+
+if (dashboardOverlay) {
+  dashboardOverlay.addEventListener('click', (event) => {
+    if (event.target === dashboardOverlay && isDashboardOverlayActive()) {
+      closeDashboardOverlaySection();
+    }
+  });
+}
+
 if (orderKanbanDetailOverlay) {
   orderKanbanDetailOverlay.addEventListener('click', (event) => {
-    if (event.target === orderKanbanDetailOverlay && currentOrderDetailHost === 'kanban') {
+    if (event.target === orderKanbanDetailOverlay && currentOrderDetailHost === 'overlay') {
       clearOrderDetail();
     }
   });
@@ -3312,9 +3580,15 @@ if (orderKanbanDetailOverlay) {
 
 if (typeof document !== 'undefined') {
   document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') {
+      return;
+    }
+    if (isDashboardOverlayActive()) {
+      closeDashboardOverlaySection();
+      return;
+    }
     if (
-      event.key === 'Escape' &&
-      currentOrderDetailHost === 'kanban' &&
+      currentOrderDetailHost === 'overlay' &&
       orderKanbanDetailOverlay &&
       !orderKanbanDetailOverlay.classList.contains('hidden')
     ) {
@@ -3657,17 +3931,13 @@ function compareOrdersForDisplay(a, b) {
 }
 
 function removeOrderDetailRow() {
-  if (currentOrderDetailHost !== 'table') {
-    activeOrderDetailRow = null;
-    return;
-  }
   if (activeOrderDetailRow && activeOrderDetailRow.parentNode) {
     activeOrderDetailRow.parentNode.removeChild(activeOrderDetailRow);
   }
   activeOrderDetailRow = null;
 }
 
-function attachOrderDetailToKanban() {
+function attachOrderDetailToOverlay() {
   if (!orderDetail || !orderKanbanDetailContainer) {
     return;
   }
@@ -3676,9 +3946,9 @@ function attachOrderDetailToKanban() {
     activeOrderDetailRow = null;
   }
   orderKanbanDetailContainer.appendChild(orderDetail);
-  currentOrderDetailHost = 'kanban';
+  currentOrderDetailHost = 'overlay';
   orderDetail.classList.remove('hidden');
-  updateKanbanDetailVisibility();
+  updateOrderDetailOverlayVisibility();
   requestAnimationFrame(() => {
     if (orderKanbanDetailDialog?.isConnected) {
       orderKanbanDetailDialog.focus();
@@ -3686,14 +3956,14 @@ function attachOrderDetailToKanban() {
   });
 }
 
-function updateKanbanDetailVisibility() {
+function updateOrderDetailOverlayVisibility() {
   if (!orderKanbanDetailContainer) {
     return;
   }
-  const isKanbanHost =
-    currentOrderDetailHost === 'kanban' && orderKanbanDetailContainer.contains(orderDetail);
-  const shouldShowDetail = isKanbanHost && state.selectedOrderId !== null;
-  if (currentOrderDetailHost === 'kanban') {
+  const isOverlayHost =
+    currentOrderDetailHost === 'overlay' && orderKanbanDetailContainer.contains(orderDetail);
+  const shouldShowDetail = isOverlayHost && state.selectedOrderId !== null;
+  if (currentOrderDetailHost === 'overlay') {
     orderKanbanDetailContainer.classList.toggle('hidden', !shouldShowDetail);
     if (orderKanbanDetailOverlay) {
       orderKanbanDetailOverlay.classList.toggle('hidden', !shouldShowDetail);
@@ -3713,9 +3983,9 @@ function updateKanbanDetailVisibility() {
     }
   }
   if (orderDetail) {
-    orderDetail.classList.toggle('kanban-mode', isKanbanHost);
-    const hideDetailElement = currentOrderDetailHost === 'kanban' && !shouldShowDetail;
-    if (currentOrderDetailHost === 'kanban') {
+    orderDetail.classList.toggle('kanban-mode', isOverlayHost);
+    const hideDetailElement = currentOrderDetailHost === 'overlay' && !shouldShowDetail;
+    if (currentOrderDetailHost === 'overlay') {
       orderDetail.classList.toggle('hidden', hideDetailElement);
       orderDetail.setAttribute('aria-hidden', shouldShowDetail ? 'false' : 'true');
     } else {
@@ -3723,19 +3993,12 @@ function updateKanbanDetailVisibility() {
     }
   }
   if (document.body) {
-    if (currentOrderDetailHost === 'kanban') {
+    if (currentOrderDetailHost === 'overlay') {
       document.body.classList.toggle('kanban-detail-open', shouldShowDetail);
     } else {
       document.body.classList.remove('kanban-detail-open');
     }
   }
-}
-
-function removeCustomerDetailRow() {
-  if (activeCustomerDetailRow && activeCustomerDetailRow.parentNode) {
-    activeCustomerDetailRow.parentNode.removeChild(activeCustomerDetailRow);
-  }
-  activeCustomerDetailRow = null;
 }
 
 function getStatusBadgeVariant(status) {
@@ -3904,7 +4167,7 @@ async function openOrderDetailFromKanban(order) {
   }
 
   populateOrderDetail(detail, { skipRender: true, focusOnDetail: false });
-  attachOrderDetailToKanban();
+  attachOrderDetailToOverlay();
   renderOrderKanban();
 }
 
@@ -4020,7 +4283,7 @@ function renderOrderKanban() {
     return;
   }
 
-  updateKanbanDetailVisibility();
+  updateOrderDetailOverlayVisibility();
 
   if (orderKanbanSearchInput && orderKanbanSearchInput.value !== state.kanbanSearchTerm) {
     orderKanbanSearchInput.value = state.kanbanSearchTerm;
@@ -4037,7 +4300,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = 'Inicia sesión para ver el tablero de órdenes.';
       orderKanbanStatus.classList.remove('hidden');
     }
-    updateKanbanDetailVisibility();
+    updateOrderDetailOverlayVisibility();
     return;
   }
 
@@ -4046,7 +4309,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = 'Cargando tablero Kanban...';
       orderKanbanStatus.classList.remove('hidden');
     }
-    updateKanbanDetailVisibility();
+    updateOrderDetailOverlayVisibility();
     return;
   }
 
@@ -4055,7 +4318,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = state.kanbanError;
       orderKanbanStatus.classList.remove('hidden');
     }
-    updateKanbanDetailVisibility();
+    updateOrderDetailOverlayVisibility();
     return;
   }
 
@@ -4067,7 +4330,7 @@ function renderOrderKanban() {
         : 'No hay órdenes registradas.';
       orderKanbanStatus.classList.remove('hidden');
     }
-    updateKanbanDetailVisibility();
+    updateOrderDetailOverlayVisibility();
     return;
   }
 
@@ -4081,7 +4344,7 @@ function renderOrderKanban() {
       orderKanbanStatus.textContent = 'No se encontraron órdenes que coincidan con la búsqueda actual.';
       orderKanbanStatus.classList.remove('hidden');
     }
-    updateKanbanDetailVisibility();
+    updateOrderDetailOverlayVisibility();
     return;
   }
 
@@ -4175,7 +4438,7 @@ function renderOrderKanban() {
     }
   }
 
-  updateKanbanDetailVisibility();
+  updateOrderDetailOverlayVisibility();
 }
 
 function renderOrders() {
@@ -4294,7 +4557,8 @@ function renderOrders() {
       if (state.selectedOrderId === order.id) {
         clearOrderDetail();
       } else {
-        populateOrderDetail(order);
+        populateOrderDetail(order, { focusOnDetail: false });
+        attachOrderDetailToOverlay();
       }
     });
     actionsCell.appendChild(detailButton);
@@ -4310,34 +4574,20 @@ function renderOrders() {
 
     if (isSelected) {
       hasActiveDetail = true;
-      if (orderDetail && currentOrderDetailHost !== 'kanban') {
-        const detailRow = document.createElement('tr');
-        detailRow.className = 'order-detail-row';
-        detailRow.dataset.orderId = String(order.id);
-
-        const detailCell = document.createElement('td');
-        detailCell.colSpan = ORDER_TABLE_COLUMN_COUNT;
-        detailCell.className = 'order-detail-cell';
-        detailCell.appendChild(orderDetail);
-
-        detailRow.appendChild(detailCell);
-        ordersTableBody.appendChild(detailRow);
-        activeOrderDetailRow = detailRow;
-        orderDetail.classList.remove('hidden');
-        detailButton.textContent = 'Ocultar detalle';
-        detailButton.setAttribute('aria-expanded', 'true');
-        currentOrderDetailHost = 'table';
-        updateKanbanDetailVisibility();
+      detailButton.textContent = 'Ocultar detalle';
+      detailButton.setAttribute('aria-expanded', 'true');
+      if (currentOrderDetailHost !== 'overlay') {
+        attachOrderDetailToOverlay();
       }
     }
   });
 
   if (!hasActiveDetail && orderDetail) {
     orderDetail.classList.add('hidden');
-    if (currentOrderDetailHost !== 'kanban') {
+    if (currentOrderDetailHost !== 'overlay') {
       currentOrderDetailHost = null;
     }
-    updateKanbanDetailVisibility();
+    updateOrderDetailOverlayVisibility();
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -190,9 +190,9 @@
               <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
             </div>
             </div>
-            <div id="createCustomerSection" class="customer-create hidden">
+            <div id="createCustomerSection" class="customer-create hidden" aria-labelledby="createCustomerHeading">
               <div class="customer-create-header">
-                <h4>Registrar cliente</h4>
+                <h4 id="createCustomerHeading">Registrar cliente</h4>
                 <button type="button" class="link-button" id="closeCreateCustomerButton">Cerrar</button>
               </div>
               <form id="createCustomerForm" class="form-grid">
@@ -281,13 +281,17 @@
             </div>
           </section>
 
-          <section class="card dashboard-panel hidden" id="orderCreatePanel">
+          <section
+            class="card dashboard-panel hidden"
+            id="orderCreatePanel"
+            aria-labelledby="orderCreateHeading"
+          >
             <div class="order-create-toolbar">
               <button type="button" class="secondary" id="orderCreateBackButton">
                 ← Volver a órdenes
               </button>
             </div>
-            <h3>Crear nueva orden</h3>
+            <h3 id="orderCreateHeading">Crear nueva orden</h3>
             <form id="createOrderForm" class="form-grid">
               <div class="form-row">
                 <label for="newOrderNumber">Número de orden</label>
@@ -756,6 +760,18 @@
               </table>
             </div>
           </section>
+          <div id="dashboardOverlay" class="kanban-detail-overlay hidden" aria-hidden="true">
+            <div class="kanban-detail-backdrop" data-dashboard-overlay-close></div>
+            <div
+              id="dashboardOverlayDialog"
+              class="kanban-detail-dialog"
+              role="dialog"
+              aria-modal="true"
+              tabindex="-1"
+            >
+              <div id="dashboardOverlayContent" class="kanban-detail-content"></div>
+            </div>
+          </div>
         </div>
       </section>
     </main>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -752,6 +752,18 @@ button[disabled] {
   font-size: 1rem;
 }
 
+.customer-order-history-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.customer-order-history-item-actions .customer-order-history-open {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
 .customer-order-history-item-meta {
   margin: 0;
   color: var(--muted);
@@ -1367,6 +1379,19 @@ body.kanban-detail-open {
   overflow: hidden;
 }
 
+body.dashboard-overlay-open {
+  overflow: hidden;
+}
+
+#dashboardOverlayContent > * {
+  width: 100%;
+}
+
+#dashboardOverlayContent .customer-create,
+#dashboardOverlayContent .customer-detail {
+  margin-top: 0;
+}
+
 .kanban-column {
   background: var(--surface-muted);
   border: 1px solid rgba(7, 10, 12, 0.08);
@@ -1547,6 +1572,26 @@ body.kanban-detail-open {
     width: 100%;
     max-height: calc(100vh - clamp(1.5rem, 6vh, 3rem));
     border-radius: 16px;
+  }
+}
+
+@media (max-width: 540px) {
+  .kanban-detail-overlay {
+    padding: 0;
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-left: env(safe-area-inset-left, 0px);
+  }
+
+  .kanban-detail-dialog {
+    height: calc(100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+    max-height: none;
+    border-radius: 0;
+  }
+
+  .kanban-detail-content {
+    padding: clamp(1rem, 6vw, 1.5rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- close the shared staff overlay when switching dashboard tabs to avoid leaving modals open on unrelated sections
- tag the create order, create customer, and customer detail overlays with their owning tabs so the shared manager can restore focus and teardown correctly

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68df38dbcebc833285595e0148026078