### PR TITLE
Prevent deleting customers with orders and add admin order removal

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -287,6 +287,18 @@ def delete_customer(db: Session, db_customer: models.Customer) -> None:
     db.commit()
 
 
+def customer_has_orders(db: Session, customer_id: int) -> bool:
+    """Return True if the customer has at least one linked order."""
+
+    return (
+        db.query(models.Order)
+        .filter(models.Order.customer_id == customer_id)
+        .limit(1)
+        .first()
+        is not None
+    )
+
+
 # Order operations ----------------------------------------------------------
 
 def _measurements_to_dicts(measurements: Iterable[schemas.MeasurementItem]):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -335,6 +335,11 @@ def delete_customer_endpoint(
     customer = crud.get_customer(db, customer_id)
     if not customer:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
+    if crud.customer_has_orders(db, customer.id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se puede eliminar el cliente porque tiene órdenes registradas.",
+        )
     before = crud.serialize_customer(customer)
     crud.delete_customer(db, customer)
     crud.create_audit_log(

--- a/backend/tests/test_customer_deletion.py
+++ b/backend/tests/test_customer_deletion.py
@@ -1,0 +1,103 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import auth, main, models  # noqa: E402
+from app.database import Base  # noqa: E402
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def create_admin(session) -> models.User:
+    admin = models.User(
+        username="admin",
+        full_name="Administrador",
+        role=models.UserRole.ADMIN,
+        password_hash=auth.get_password_hash("secret"),
+    )
+    session.add(admin)
+    session.commit()
+    session.refresh(admin)
+    return admin
+
+
+def create_customer(session, *, document_suffix: str = "1") -> models.Customer:
+    customer = models.Customer(
+        full_name=f"Cliente {document_suffix}",
+        document_id=f"123456789{document_suffix}",
+        phone="0990000000",
+    )
+    session.add(customer)
+    session.commit()
+    session.refresh(customer)
+    return customer
+
+
+def create_order(session, customer: models.Customer, *, order_number: str = "ORD-1") -> models.Order:
+    order = models.Order(
+        order_number=order_number,
+        customer_id=customer.id,
+        customer_name=customer.full_name,
+        customer_document=customer.document_id,
+        customer_contact=customer.phone,
+        status=models.OrderStatus.EN_TIENDA_BATAN,
+        measurements=[],
+        origin_branch=models.Establishment.BATAN,
+    )
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return order
+
+
+def test_admin_cannot_delete_customer_with_orders(db_session):
+    admin = create_admin(db_session)
+    customer = create_customer(db_session)
+    create_order(db_session, customer)
+
+    with pytest.raises(HTTPException) as exc_info:
+        main.delete_customer_endpoint(customer.id, db_session, admin)
+
+    assert exc_info.value.status_code == 400
+    assert "órdenes" in exc_info.value.detail.lower()
+    assert db_session.query(models.Customer).count() == 1
+
+
+def test_admin_can_delete_customer_without_orders(db_session):
+    admin = create_admin(db_session)
+    customer = create_customer(db_session, document_suffix="2")
+
+    response = main.delete_customer_endpoint(customer.id, db_session, admin)
+
+    assert response is None
+    assert db_session.query(models.Customer).count() == 0
+    assert db_session.query(models.Order).count() == 0
+    audit_logs = db_session.query(models.AuditLog).filter_by(entity_type="customer").all()
+    assert any(log.action == "delete" for log in audit_logs)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -35,6 +35,7 @@ const state = {
   kanbanLastUpdated: null,
   activeOrdersView: 'list',
   isCreateCustomerVisible: false,
+  isCustomerDetailVisible: false,
   isCreateUserVisible: false,
   auditLogs: [],
   users: [],
@@ -146,6 +147,8 @@ const updateCustomerForm = document.getElementById('updateCustomerForm');
 const customerSearchInput = document.getElementById('customerSearchInput');
 const showCreateCustomerButton = document.getElementById('showCreateCustomerButton');
 const createCustomerSection = document.getElementById('createCustomerSection');
+const customerCreateOverlay = document.getElementById('customerCreateOverlay');
+const customerCreateDialog = document.getElementById('customerCreateDialog');
 const closeCreateCustomerButton = document.getElementById('closeCreateCustomerButton');
 const customersTableBody = document.getElementById('customersTableBody');
 const customerPageSizeSelect = document.getElementById('customerPageSize');
@@ -153,6 +156,8 @@ const customerPrevPageButton = document.getElementById('customerPrevPage');
 const customerNextPageButton = document.getElementById('customerNextPage');
 const customerPaginationInfo = document.getElementById('customerPaginationInfo');
 const customerDetail = document.getElementById('customerDetail');
+const customerDetailOverlay = document.getElementById('customerDetailOverlay');
+const customerDetailDialog = document.getElementById('customerDetailDialog');
 const customerDetailTitle = document.getElementById('customerDetailTitle');
 const customerDetailSummaryElement = document.getElementById('customerDetailSummary');
 const customerOrderHistoryContainer = document.getElementById('customerOrderHistory');
@@ -197,6 +202,7 @@ const orderDetailInvoiceInput = document.getElementById('orderDetailInvoice');
 const orderDetailOriginSelect = document.getElementById('orderDetailOrigin');
 const orderDetailDeliveryDateInput = document.getElementById('orderDetailDeliveryDate');
 const orderDetailNotesTextarea = document.getElementById('orderDetailNotes');
+const deleteOrderButton = document.getElementById('deleteOrderButton');
 const orderDetailMeasurementsContainer = document.getElementById('orderDetailMeasurements');
 const orderTasksList = document.getElementById('orderTasksList');
 const orderTaskForm = document.getElementById('orderTaskForm');
@@ -257,9 +263,9 @@ const ORDER_TABLE_COLUMN_COUNT = 6;
 const CUSTOMER_TABLE_COLUMN_COUNT = 5;
 let activeOrderDetailRow = null;
 let currentOrderDetailHost = null;
-let activeCustomerDetailRow = null;
 let lastKanbanFocusedElement = null;
 let lastKanbanFocusedOrderId = null;
+let lastCustomerDetailTrigger = null;
 
 
 function setActiveView(viewId) {
@@ -1680,10 +1686,19 @@ function resetCreateCustomerForm() {
   }
 }
 
+function updateModalBodyState() {
+  if (typeof document === 'undefined' || !document.body) return;
+  const hasOpenModal = Boolean(document.querySelector('.modal-overlay:not(.hidden)'));
+  document.body.classList.toggle('modal-open', hasOpenModal);
+}
+
 function setCreateCustomerVisible(visible) {
-  if (!createCustomerSection) return;
+  if (!createCustomerSection || !customerCreateOverlay) return;
   state.isCreateCustomerVisible = visible;
   createCustomerSection.classList.toggle('hidden', !visible);
+  createCustomerSection.setAttribute('aria-hidden', visible ? 'false' : 'true');
+  customerCreateOverlay.classList.toggle('hidden', !visible);
+  customerCreateOverlay.setAttribute('aria-hidden', visible ? 'false' : 'true');
   if (showCreateCustomerButton) {
     showCreateCustomerButton.classList.toggle('hidden', visible);
   }
@@ -1691,12 +1706,37 @@ function setCreateCustomerVisible(visible) {
     if (customerMeasurementsContainer && !customerMeasurementsContainer.children.length) {
       createMeasurementSetBlock(customerMeasurementsContainer);
     }
-    createCustomerSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    const firstField = createCustomerForm?.querySelector('input, textarea, select');
-    firstField?.focus();
+    requestAnimationFrame(() => {
+      if (customerCreateDialog?.isConnected) {
+        customerCreateDialog.focus();
+      }
+      const firstField = createCustomerForm?.querySelector('input, textarea, select');
+      firstField?.focus();
+    });
   } else {
     resetCreateCustomerForm();
+    if (showCreateCustomerButton?.isConnected) {
+      showCreateCustomerButton.focus();
+    }
   }
+  updateModalBodyState();
+}
+
+function setCustomerDetailVisible(visible) {
+  if (!customerDetail || !customerDetailOverlay) return;
+  state.isCustomerDetailVisible = visible;
+  customerDetail.classList.toggle('hidden', !visible);
+  customerDetail.setAttribute('aria-hidden', visible ? 'false' : 'true');
+  customerDetailOverlay.classList.toggle('hidden', !visible);
+  customerDetailOverlay.setAttribute('aria-hidden', visible ? 'false' : 'true');
+  if (visible) {
+    requestAnimationFrame(() => {
+      if (customerDetailDialog?.isConnected) {
+        customerDetailDialog.focus();
+      }
+    });
+  }
+  updateModalBodyState();
 }
 
 function renderCustomerMeasurementOptions(customer) {
@@ -1788,6 +1828,15 @@ function updateUserInfo() {
       deleteCustomerButton.classList.add('hidden');
     }
   }
+  if (deleteOrderButton) {
+    if (state.user.role === 'administrador') {
+      deleteOrderButton.classList.remove('hidden');
+      deleteOrderButton.disabled = state.selectedOrderId === null;
+    } else {
+      deleteOrderButton.classList.add('hidden');
+      deleteOrderButton.disabled = true;
+    }
+  }
   const isAdmin = state.user.role === 'administrador';
   if (!isAdmin && ADMIN_ONLY_TABS.has(activeDashboardTab)) {
     setActiveDashboardTab('ordersPanel');
@@ -1798,6 +1847,7 @@ function updateUserInfo() {
   updateUserCreationForm();
   renderOrderTasks();
   updateDashboardShortcutVisibility();
+  updateOrderActionButtons();
 }
 
 function showDashboard() {
@@ -2315,6 +2365,7 @@ function handleLogout(auto = false) {
   state.kanbanNeedsRefresh = true;
   state.kanbanLastUpdated = null;
   state.isCreateCustomerVisible = false;
+  state.isCustomerDetailVisible = false;
   state.isCreateUserVisible = false;
   state.auditLogs = [];
   state.selectedCustomerId = null;
@@ -2688,7 +2739,6 @@ function renderCustomers() {
   }
 
   customersTableBody.innerHTML = '';
-  activeCustomerDetailRow = null;
 
   if (customerSearchInput && customerSearchInput.value !== state.customerSearchTerm) {
     customerSearchInput.value = state.customerSearchTerm;
@@ -2724,28 +2774,24 @@ function renderCustomers() {
       cell.textContent = hasSearch
         ? 'No se encontraron clientes que coincidan con la búsqueda.'
         : 'No hay clientes registrados aún.';
-      clearCustomerDetail();
+      if (state.isCustomerDetailVisible) {
+        clearCustomerDetail({ skipFocus: true });
+      }
     } else {
       cell.textContent = 'No hay clientes para la página seleccionada.';
     }
     cell.className = 'muted';
     row.appendChild(cell);
     customersTableBody.appendChild(row);
-    if (customerDetail) {
-      customerDetail.classList.add('hidden');
-      activeCustomerDetailRow = null;
-    }
     return;
   }
-
-  let detailRendered = false;
 
   state.customers.forEach((customer) => {
     const row = document.createElement('tr');
     row.classList.add('customer-row');
     row.dataset.customerId = String(customer.id);
 
-    const isSelected = state.selectedCustomerId === customer.id;
+    const isSelected = state.selectedCustomerId === customer.id && state.isCustomerDetailVisible;
     if (isSelected) {
       row.classList.add('is-selected');
     }
@@ -2793,10 +2839,11 @@ function renderCustomers() {
     viewButton.dataset.action = 'toggle-customer-detail';
     viewButton.dataset.customerId = String(customer.id);
     viewButton.setAttribute('aria-controls', 'customerDetail');
-    viewButton.textContent = isSelected ? 'Ocultar detalle' : 'Ver detalle';
+    viewButton.textContent = isSelected ? 'Cerrar detalle' : 'Ver detalle';
     viewButton.setAttribute('aria-expanded', isSelected ? 'true' : 'false');
     viewButton.addEventListener('click', async () => {
-      if (state.selectedCustomerId === customer.id) {
+      lastCustomerDetailTrigger = viewButton;
+      if (state.selectedCustomerId === customer.id && state.isCustomerDetailVisible) {
         clearCustomerDetail({ reRender: true });
       } else {
         await populateCustomerDetail(customer);
@@ -2811,37 +2858,12 @@ function renderCustomers() {
     row.appendChild(actionsCell);
 
     customersTableBody.appendChild(row);
-
-    if (isSelected && customerDetail) {
-      const detailRow = document.createElement('tr');
-      detailRow.className = 'customer-detail-row';
-      detailRow.dataset.customerId = String(customer.id);
-
-      const detailCell = document.createElement('td');
-      detailCell.colSpan = CUSTOMER_TABLE_COLUMN_COUNT;
-      detailCell.className = 'customer-detail-cell';
-      detailCell.appendChild(customerDetail);
-
-      detailRow.appendChild(detailCell);
-      customersTableBody.appendChild(detailRow);
-      activeCustomerDetailRow = detailRow;
-      customerDetail.classList.remove('hidden');
-      viewButton.textContent = 'Ocultar detalle';
-      viewButton.setAttribute('aria-expanded', 'true');
-      detailRendered = true;
-    }
   });
-
-  if (!detailRendered && customerDetail) {
-    customerDetail.classList.add('hidden');
-    activeCustomerDetailRow = null;
-  }
 }
 
 async function populateCustomerDetail(customer) {
   if (!customerDetail) return;
   state.selectedCustomerId = customer.id;
-  customerDetail.classList.remove('hidden');
 
   const cacheKey = String(customer.id);
   const expectedOrderCount =
@@ -2921,20 +2943,15 @@ async function populateCustomerDetail(customer) {
   }
 
   renderCustomerOrderHistory(customer);
+  setCustomerDetailVisible(true);
   renderCustomers();
-  requestAnimationFrame(() => {
-    const detailRow = customersTableBody?.querySelector(
-      `.customer-detail-row[data-customer-id="${customer.id}"]`,
-    );
-    detailRow?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  });
 }
 
 function clearCustomerDetail(options = {}) {
   if (!customerDetail) return;
-  const { reRender = false } = options;
-  customerDetail.classList.add('hidden');
+  const { reRender = false, skipFocus = false } = options;
   state.selectedCustomerId = null;
+  setCustomerDetailVisible(false);
 
   if (customerDetailTitle) {
     customerDetailTitle.textContent = CUSTOMER_DETAIL_DEFAULT_TITLE;
@@ -2949,11 +2966,14 @@ function clearCustomerDetail(options = {}) {
     updateCustomerMeasurementsContainer.innerHTML = '';
   }
 
-  removeCustomerDetailRow();
-
   if (reRender) {
     renderCustomers();
   }
+
+  if (!skipFocus && lastCustomerDetailTrigger?.isConnected) {
+    lastCustomerDetailTrigger.focus();
+  }
+  lastCustomerDetailTrigger = null;
 }
 
 if (closeCustomerDetailButton) {
@@ -2961,6 +2981,23 @@ if (closeCustomerDetailButton) {
     clearCustomerDetail({ reRender: true });
   });
 }
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape' || event.defaultPrevented) {
+    return;
+  }
+  const detailOpen = customerDetailOverlay && !customerDetailOverlay.classList.contains('hidden');
+  if (detailOpen) {
+    event.preventDefault();
+    clearCustomerDetail({ reRender: true });
+    return;
+  }
+  const createOpen = customerCreateOverlay && !customerCreateOverlay.classList.contains('hidden');
+  if (createOpen) {
+    event.preventDefault();
+    setCreateCustomerVisible(false);
+  }
+});
 
 function populateOrderDetail(order, options = {}) {
   if (!orderDetail || !order) return;
@@ -3302,6 +3339,17 @@ if (closeCreateCustomerButton) {
   });
 }
 
+document.querySelectorAll('[data-modal-close]').forEach((element) => {
+  element.addEventListener('click', () => {
+    const target = element.dataset.modalClose;
+    if (target === 'customer-create') {
+      setCreateCustomerVisible(false);
+    } else if (target === 'customer-detail') {
+      clearCustomerDetail({ reRender: true });
+    }
+  });
+});
+
 if (toggleCreateUserButton) {
   toggleCreateUserButton.addEventListener('click', () => {
     const shouldShow = !state.isCreateUserVisible;
@@ -3484,6 +3532,40 @@ if (deleteCustomerButton) {
       state.selectedCustomerId = null;
       await loadCustomers();
       await refreshCustomerOptions();
+    } catch (error) {
+      showToast(error.message, 'error');
+    }
+  });
+}
+
+if (deleteOrderButton) {
+  deleteOrderButton.addEventListener('click', async () => {
+    if (state.selectedOrderId === null) {
+      return;
+    }
+    if (!confirm('¿Estás seguro de eliminar esta orden? Esta acción no se puede deshacer.')) {
+      return;
+    }
+    const orderId = state.selectedOrderId;
+    const orderToDelete = state.orders.find((order) => order.id === orderId);
+    const affectedCustomerId = orderToDelete?.customer_id ?? null;
+    try {
+      await apiFetch(`/orders/${orderId}`, { method: 'DELETE' });
+      showToast('Orden eliminada correctamente.', 'success');
+      if (affectedCustomerId !== null && affectedCustomerId !== undefined) {
+        delete state.customerOrdersCache[String(affectedCustomerId)];
+        delete state.customerDisplayCache[String(affectedCustomerId)];
+        const customerEntry = state.customers.find((customer) => customer.id === affectedCustomerId);
+        if (customerEntry && typeof customerEntry.order_count === 'number' && customerEntry.order_count > 0) {
+          customerEntry.order_count = Math.max(0, customerEntry.order_count - 1);
+        }
+      }
+      clearOrderDetail({ skipRender: true });
+      await loadOrders();
+      if (affectedCustomerId) {
+        await loadCustomers();
+      }
+      markKanbanDataStale();
     } catch (error) {
       showToast(error.message, 'error');
     }
@@ -3790,13 +3872,16 @@ function updateOrderDetailOverlayVisibility() {
       document.body.classList.remove('kanban-detail-open');
     }
   }
+  updateOrderActionButtons();
 }
 
-function removeCustomerDetailRow() {
-  if (activeCustomerDetailRow && activeCustomerDetailRow.parentNode) {
-    activeCustomerDetailRow.parentNode.removeChild(activeCustomerDetailRow);
+function updateOrderActionButtons() {
+  if (!deleteOrderButton) {
+    return;
   }
-  activeCustomerDetailRow = null;
+  const isAdmin = state.user?.role === 'administrador';
+  const hasSelection = typeof state.selectedOrderId === 'number';
+  deleteOrderButton.disabled = !isAdmin || !hasSelection;
 }
 
 function getStatusBadgeVariant(status) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,82 +141,104 @@
                 <h3>Gestión de clientes</h3>
                 <p class="muted">Consulta, busca y administra la información de tus clientes.</p>
               </div>
-            <div class="customer-panel-actions">
-              <div class="customer-search">
-                <label for="customerSearchInput">Buscar</label>
-                <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
-              </div>
-              <div class="table-pagination">
-                <label for="customerPageSize">Filas por página</label>
-                <div class="pagination-controls">
-                  <select id="customerPageSize">
-                    <option value="10" selected>10</option>
-                    <option value="15">15</option>
-                    <option value="20">20</option>
-                    <option value="25">25</option>
-                    <option value="30">30</option>
-                    <option value="35">35</option>
-                    <option value="40">40</option>
-                    <option value="45">45</option>
-                    <option value="50">50</option>
-                  </select>
-                  <div class="pagination-buttons">
-                    <button
-                      type="button"
-                      class="pagination-button"
-                      id="customerPrevPage"
-                      aria-label="Página anterior de clientes"
-                    >
-                      Anterior
-                    </button>
-                    <span
-                      id="customerPaginationInfo"
-                      class="pagination-info"
-                      aria-live="polite"
-                    >
-                      Mostrando 0-0 de 0
-                    </span>
-                    <button
-                      type="button"
-                      class="pagination-button"
-                      id="customerNextPage"
-                      aria-label="Página siguiente de clientes"
-                    >
-                      Siguiente
-                    </button>
+              <div class="customer-panel-actions">
+                <div class="customer-search">
+                  <label for="customerSearchInput">Buscar</label>
+                  <input type="search" id="customerSearchInput" placeholder="Nombre o cédula" />
+                </div>
+                <div class="table-pagination">
+                  <label for="customerPageSize">Filas por página</label>
+                  <div class="pagination-controls">
+                    <select id="customerPageSize">
+                      <option value="10" selected>10</option>
+                      <option value="15">15</option>
+                      <option value="20">20</option>
+                      <option value="25">25</option>
+                      <option value="30">30</option>
+                      <option value="35">35</option>
+                      <option value="40">40</option>
+                      <option value="45">45</option>
+                      <option value="50">50</option>
+                    </select>
+                    <div class="pagination-buttons">
+                      <button
+                        type="button"
+                        class="pagination-button"
+                        id="customerPrevPage"
+                        aria-label="Página anterior de clientes"
+                      >
+                        Anterior
+                      </button>
+                      <span
+                        id="customerPaginationInfo"
+                        class="pagination-info"
+                        aria-live="polite"
+                      >
+                        Mostrando 0-0 de 0
+                      </span>
+                      <button
+                        type="button"
+                        class="pagination-button"
+                        id="customerNextPage"
+                        aria-label="Página siguiente de clientes"
+                      >
+                        Siguiente
+                      </button>
+                    </div>
                   </div>
                 </div>
+                <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
               </div>
-              <button type="button" class="primary" id="showCreateCustomerButton">Añadir cliente</button>
             </div>
-            </div>
-            <div id="createCustomerSection" class="customer-create hidden">
-              <div class="customer-create-header">
-                <h4>Registrar cliente</h4>
-                <button type="button" class="link-button" id="closeCreateCustomerButton">Cerrar</button>
+            <div
+              id="customerCreateOverlay"
+              class="modal-overlay hidden"
+              aria-hidden="true"
+            >
+              <div class="modal-backdrop" data-modal-close="customer-create"></div>
+              <div
+                id="customerCreateDialog"
+                class="modal-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="customerCreateTitle"
+                tabindex="-1"
+              >
+                <div
+                  id="createCustomerSection"
+                  class="modal-content customer-create hidden"
+                  aria-hidden="true"
+                >
+                  <div class="customer-create-header">
+                    <h4 id="customerCreateTitle">Registrar cliente</h4>
+                    <button type="button" class="link-button" id="closeCreateCustomerButton">Cerrar</button>
+                  </div>
+                  <form id="createCustomerForm" class="form-grid">
+                    <div class="form-row">
+                      <label for="customerFullName">Nombre completo</label>
+                      <input type="text" id="customerFullName" required />
+                    </div>
+                    <div class="form-row">
+                      <label for="customerDocumentInput">Cédula o identificación</label>
+                      <input type="text" id="customerDocumentInput" required />
+                    </div>
+                    <div class="form-row">
+                      <label for="customerPhone">Teléfono</label>
+                      <input type="text" id="customerPhone" placeholder="Número de contacto" />
+                    </div>
+                    <div class="form-row">
+                      <label>Conjuntos de medidas</label>
+                      <div id="customerMeasurementsContainer" class="measurement-set-list"></div>
+                      <button type="button" id="addCustomerMeasurementSet" class="secondary">
+                        Agregar conjunto
+                      </button>
+                    </div>
+                    <div class="button-row">
+                      <button type="submit" class="primary">Guardar cliente</button>
+                    </div>
+                  </form>
+                </div>
               </div>
-              <form id="createCustomerForm" class="form-grid">
-                <div class="form-row">
-                  <label for="customerFullName">Nombre completo</label>
-                  <input type="text" id="customerFullName" required />
-                </div>
-                <div class="form-row">
-                  <label for="customerDocumentInput">Cédula o identificación</label>
-                  <input type="text" id="customerDocumentInput" required />
-                </div>
-                <div class="form-row">
-                  <label for="customerPhone">Teléfono</label>
-                  <input type="text" id="customerPhone" placeholder="Número de contacto" />
-                </div>
-                <div class="form-row">
-                  <label>Conjuntos de medidas</label>
-                  <div id="customerMeasurementsContainer" class="measurement-set-list"></div>
-                  <button type="button" id="addCustomerMeasurementSet" class="secondary">Agregar conjunto</button>
-                </div>
-                <div class="button-row">
-                  <button type="submit" class="primary">Guardar cliente</button>
-                </div>
-              </form>
             </div>
             <div class="customer-list">
               <h4>Clientes registrados</h4>
@@ -235,49 +257,70 @@
                 </table>
               </div>
             </div>
-            <div id="customerDetail" class="customer-detail hidden" aria-live="polite">
-              <div class="customer-detail-header">
-                <div>
-                  <h4 id="customerDetailTitle">Detalle del cliente</h4>
-                  <p id="customerDetailSummary" class="muted small">
-                    Selecciona un cliente para ver su información.
-                  </p>
+            <div
+              id="customerDetailOverlay"
+              class="modal-overlay hidden"
+              aria-hidden="true"
+            >
+              <div class="modal-backdrop" data-modal-close="customer-detail"></div>
+              <div
+                id="customerDetailDialog"
+                class="modal-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="customerDetailTitle"
+                tabindex="-1"
+              >
+                <div
+                  id="customerDetail"
+                  class="modal-content customer-detail hidden"
+                  aria-live="polite"
+                  aria-hidden="true"
+                >
+                  <div class="customer-detail-header">
+                    <div>
+                      <h4 id="customerDetailTitle">Detalle del cliente</h4>
+                      <p id="customerDetailSummary" class="muted small">
+                        Selecciona un cliente para ver su información.
+                      </p>
+                    </div>
+                    <button type="button" class="link-button" id="closeCustomerDetailButton">
+                      Cerrar
+                    </button>
+                  </div>
+                  <div class="customer-order-history">
+                    <h5>Órdenes registradas</h5>
+                    <div id="customerOrderHistory" class="customer-order-history-list muted">
+                      Selecciona un cliente para ver sus órdenes anteriores.
+                    </div>
+                  </div>
+                  <form id="updateCustomerForm" class="form-grid">
+                    <div class="form-row">
+                      <label for="updateCustomerName">Nombre completo</label>
+                      <input type="text" id="updateCustomerName" required />
+                    </div>
+                    <div class="form-row">
+                      <label for="updateCustomerDocument">Cédula o identificación</label>
+                      <input type="text" id="updateCustomerDocument" required />
+                    </div>
+                    <div class="form-row">
+                      <label for="updateCustomerPhone">Teléfono</label>
+                      <input type="text" id="updateCustomerPhone" />
+                    </div>
+                    <div class="form-row">
+                      <label>Conjuntos de medidas</label>
+                      <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
+                      <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">
+                        Agregar conjunto
+                      </button>
+                    </div>
+                    <div class="button-row">
+                      <button type="submit" class="primary">Guardar cambios</button>
+                      <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
+                    </div>
+                  </form>
                 </div>
-                <button type="button" class="link-button" id="closeCustomerDetailButton">
-                  Cerrar
-                </button>
               </div>
-              <div class="customer-order-history">
-                <h5>Órdenes registradas</h5>
-                <div id="customerOrderHistory" class="customer-order-history-list muted">
-                  Selecciona un cliente para ver sus órdenes anteriores.
-                </div>
-              </div>
-              <form id="updateCustomerForm" class="form-grid">
-                <div class="form-row">
-                  <label for="updateCustomerName">Nombre completo</label>
-                  <input type="text" id="updateCustomerName" required />
-                </div>
-                <div class="form-row">
-                  <label for="updateCustomerDocument">Cédula o identificación</label>
-                  <input type="text" id="updateCustomerDocument" required />
-                </div>
-                <div class="form-row">
-                  <label for="updateCustomerPhone">Teléfono</label>
-                  <input type="text" id="updateCustomerPhone" />
-                </div>
-                <div class="form-row">
-                  <label>Conjuntos de medidas</label>
-                  <div id="updateCustomerMeasurementsContainer" class="measurement-set-list"></div>
-                  <button type="button" id="addUpdateCustomerMeasurementSet" class="secondary">
-                    Agregar conjunto
-                  </button>
-                </div>
-                <div class="button-row">
-                  <button type="submit" class="primary">Guardar cambios</button>
-                  <button type="button" id="deleteCustomerButton" class="danger">Eliminar cliente</button>
-                </div>
-              </form>
             </div>
           </section>
 
@@ -553,6 +596,9 @@
                   </div>
                   <div class="button-row">
                     <button type="submit" class="primary">Guardar cambios</button>
+                    <button type="button" id="deleteOrderButton" class="danger ghost hidden">
+                      Eliminar orden
+                    </button>
                   </div>
                 </form>
               </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -576,6 +576,10 @@ button[disabled] {
   box-shadow: 0 16px 32px rgba(var(--shadow-color), 0.08);
 }
 
+.modal-content.customer-create {
+  margin-bottom: 0;
+}
+
 .users-panel-header {
   display: flex;
   flex-wrap: wrap;
@@ -681,6 +685,10 @@ button[disabled] {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.modal-content.customer-detail {
+  margin-top: 0;
 }
 
 .customer-detail-row td {
@@ -1317,6 +1325,69 @@ button[disabled] {
   box-shadow: 0 18px 40px rgba(var(--shadow-color), 0.08);
   max-height: 72vh;
   overflow-y: auto;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(1rem, 4vw, 2.5rem);
+  z-index: 1400;
+}
+
+.modal-overlay.hidden {
+  display: none !important;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 10, 12, 0.45);
+}
+
+.modal-dialog {
+  position: relative;
+  background: var(--surface);
+  border-radius: 20px;
+  box-shadow: 0 28px 68px rgba(var(--shadow-color), 0.2);
+  width: min(720px, 100%);
+  max-height: calc(100vh - clamp(2rem, 10vh, 5rem));
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  z-index: 1;
+  outline: none;
+}
+
+.modal-content {
+  padding: clamp(1.25rem, 3vw, 2rem);
+  overflow-y: auto;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+@media (max-width: 768px) {
+  .modal-overlay {
+    align-items: stretch;
+    padding: 0;
+  }
+
+  .modal-dialog {
+    border-radius: 0;
+    max-height: 100vh;
+  }
+
+  .modal-content {
+    padding: clamp(1rem, 4vw, 1.5rem);
+  }
 }
 
 .kanban-detail .muted {


### PR DESCRIPTION
## Summary
- add a backend guard to prevent deleting customers that still have tailoring orders
- cover the new behavior with unit tests to keep the customer deletion workflow safe
- expose an admin-only order deletion control in the dashboard and keep related caches in sync

## Testing
- pytest backend/tests/test_customer_deletion.py

------
https://chatgpt.com/codex/tasks/task_e_68df494dc1908332bf02f8646a4e841c