### PR TITLE
Align Contifico integration with official API methods

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -79,6 +79,62 @@ python -m app.main
 
 La documentación interactiva estará disponible en `http://<host>:<puerto>/docs`.
 
+#### Integración con Contifico
+
+El proyecto incluye un cliente HTTP para la API de Contifico descrita en
+https://contifico.github.io/. Configura tus credenciales en el archivo `.env` del
+backend (o como variables de entorno) para poder consumir los endpoints oficiales:
+
+```bash
+cat <<'EOF' >> .env
+CONTIFICO_BASE_URL="https://api.contifico.com/sistema/api/v1"
+CONTIFICO_TOKEN="tu-api-key-entregada-por-contifico"
+CONTIFICO_TIMEOUT_SECONDS=30
+CONTIFICO_RATE_LIMIT_PER_MINUTE=50
+CONTIFICO_MAX_RETRIES=3
+CONTIFICO_RETRY_BACKOFF_SECONDS=2
+EOF
+```
+
+El token se envía en el encabezado `Authorization` tal como exige la documentación
+de Contifico. Puedes utilizar el helper `ContificoClient` para crear y actualizar
+facturas o consultar clientes por identificación:
+
+```python
+from app.integrations import ContificoClient
+from app.config import get_settings
+
+settings = get_settings()
+
+with ContificoClient(
+    base_url=settings.contifico_base_url,
+    token=settings.contifico_token,
+) as contifico:
+    factura = contifico.create_invoice({
+        "tipo_documento": "FAC",
+        "fecha_emision": "01/01/2025",
+        "cliente": {"cedula": "0912345678", "razon_social": "Juan Pérez"},
+        "detalles": [
+            {
+                "producto_id": "COD-PROD",
+                "cantidad": 1,
+                "precio": 100,
+                "porcentaje_iva": 12,
+            }
+        ],
+        "total": 112,
+    })
+
+    # Actualiza la factura agregando el identificador devuelto por Contifico.
+    contifico.update_invoice(factura["id"], {"descripcion": "Pedido actualizado"})
+
+    posibles_clientes = contifico.get_customer_by_document("0912345678")
+```
+
+Cada helper emplea las rutas oficiales (`documento/` y `persona/`) y maneja errores
+transitorios (por ejemplo límites de tasa o respuestas 5xx) para que puedas decidir
+si debes reintentar la operación o informar al usuario.
+
 ### 2. Preparar el frontend
 
 El frontend es una SPA ligera sin dependencias externas. Desde la carpeta `frontend` ejecuta:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,53 @@ class Settings(BaseSettings):
         description="Enable auto reload when running the development server via python -m app.main.",
     )
 
+    contifico_base_url: str = Field(
+        "https://api.contifico.com/sistema/api/v1",
+        description=(
+            "Base URL for Contifico API requests documented at https://contifico.github.io/. "
+            "Loaded from the CONTIFICO_BASE_URL environment variable or the .env file."
+        ),
+    )
+    contifico_token: str | None = Field(
+        None,
+        description=(
+            "Personal access token used to sign Contifico requests. Loaded from the "
+            "CONTIFICO_TOKEN environment variable or the .env file."
+        ),
+    )
+    contifico_timeout_seconds: float = Field(
+        30.0,
+        ge=0,
+        description=(
+            "HTTP timeout (in seconds) for Contifico requests. Loaded from "
+            "CONTIFICO_TIMEOUT_SECONDS or the .env file."
+        ),
+    )
+    contifico_rate_limit_per_minute: int = Field(
+        50,
+        ge=1,
+        description=(
+            "Maximum number of Contifico requests permitted per minute before "
+            "triggering retries. Loaded from CONTIFICO_RATE_LIMIT_PER_MINUTE or the .env file."
+        ),
+    )
+    contifico_max_retries: int = Field(
+        3,
+        ge=0,
+        description=(
+            "Maximum number of retries for transient Contifico errors. Loaded from "
+            "CONTIFICO_MAX_RETRIES or the .env file."
+        ),
+    )
+    contifico_retry_backoff_seconds: float = Field(
+        2.0,
+        ge=0,
+        description=(
+            "Base backoff interval (in seconds) between Contifico retry attempts. "
+            "Loaded from CONTIFICO_RETRY_BACKOFF_SECONDS or the .env file."
+        ),
+    )
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 

--- a/backend/app/integrations/__init__.py
+++ b/backend/app/integrations/__init__.py
@@ -1,0 +1,15 @@
+"""Integration helpers for third-party services."""
+
+from .contifico import (
+    ContificoClient,
+    ContificoError,
+    ContificoPermanentError,
+    ContificoTransientError,
+)
+
+__all__ = [
+    "ContificoClient",
+    "ContificoError",
+    "ContificoPermanentError",
+    "ContificoTransientError",
+]

--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -1,0 +1,171 @@
+"""Helper utilities for interacting with the Contifico API."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from typing import Any, Callable, Deque, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class ContificoError(RuntimeError):
+    """Base class for Contifico integration errors."""
+
+
+class ContificoTransientError(ContificoError):
+    """Raised when a transient Contifico error is detected and the request can be retried."""
+
+
+class ContificoPermanentError(ContificoError):
+    """Raised when the request failed definitively and should not be retried automatically."""
+
+
+class ContificoClient:
+    """Thin HTTP client for the Contifico REST API described at https://contifico.github.io/."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        token: str,
+        timeout: float = 30.0,
+        rate_limit_per_minute: int = 50,
+        max_retries: int = 3,
+        retry_backoff_seconds: float = 2.0,
+        client: Optional[httpx.Client] = None,
+        sleep_func: Callable[[float], None] = time.sleep,
+        monotonic_func: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+        self.rate_limit_per_minute = max(1, rate_limit_per_minute)
+        self.max_retries = max_retries
+        self.retry_backoff_seconds = retry_backoff_seconds
+        self._client = client or httpx.Client(timeout=timeout)
+        self._sleep = sleep_func
+        self._monotonic = monotonic_func
+        self._request_timestamps: Deque[float] = deque()
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+
+        self._client.close()
+
+    def _build_url(self, path: str) -> str:
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def _respect_rate_limit(self) -> None:
+        """Block until a request can be made within the configured limit."""
+
+        if self.rate_limit_per_minute <= 0:
+            return
+
+        window = 60.0
+        while True:
+            now = self._monotonic()
+            while self._request_timestamps and now - self._request_timestamps[0] >= window:
+                self._request_timestamps.popleft()
+
+            if len(self._request_timestamps) < self.rate_limit_per_minute:
+                self._request_timestamps.append(now)
+                return
+
+            wait_seconds = window - (now - self._request_timestamps[0])
+            wait_seconds = max(wait_seconds, 0)
+            logger.info(
+                "Contifico rate limit reached (%s/min). Sleeping for %.2f seconds.",
+                self.rate_limit_per_minute,
+                wait_seconds,
+            )
+            self._sleep(wait_seconds)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = self._build_url(path)
+        headers = {"Authorization": self.token}
+
+        attempt = 0
+        while True:
+            self._respect_rate_limit()
+            try:
+                logger.debug("Sending Contifico request %s %s", method.upper(), url)
+                response = self._client.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json,
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+            except httpx.RequestError as exc:  # pragma: no cover - httpx RequestError holds detail
+                logger.warning("Transient network error contacting Contifico: %s", exc)
+                if attempt >= self.max_retries:
+                    raise ContificoTransientError("Network error contacting Contifico") from exc
+            else:
+                if response.status_code == httpx.codes.TOO_MANY_REQUESTS:
+                    logger.warning("Contifico rate limit exceeded: %s", response.text)
+                    error: ContificoError = ContificoTransientError("Contifico rate limit exceeded")
+                elif 500 <= response.status_code < 600:
+                    logger.warning(
+                        "Contifico server error (%s): %s",
+                        response.status_code,
+                        response.text,
+                    )
+                    error = ContificoTransientError("Contifico service unavailable")
+                elif response.status_code >= 400:
+                    logger.error(
+                        "Contifico request failed permanently (%s): %s",
+                        response.status_code,
+                        response.text,
+                    )
+                    error = ContificoPermanentError("Contifico request failed")
+                else:
+                    logger.debug("Contifico response %s %s", response.status_code, response.text)
+                    try:
+                        return response.json()
+                    except ValueError as exc:  # pragma: no cover - unexpected payload
+                        logger.error("Invalid JSON from Contifico: %s", exc)
+                        raise ContificoPermanentError("Invalid JSON response from Contifico") from exc
+
+                if attempt >= self.max_retries:
+                    raise error
+
+            attempt += 1
+            backoff = self.retry_backoff_seconds * (2 ** (attempt - 1))
+            logger.info("Retrying Contifico request in %.2f seconds (attempt %s)", backoff, attempt)
+            self._sleep(backoff)
+
+    def create_invoice(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new sales document (factura) in Contifico."""
+
+        return self._request("POST", "documento/", json=payload)
+
+    def update_invoice(self, invoice_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Update an existing Contifico document using the documented endpoint."""
+
+        body = dict(payload)
+        body["id"] = invoice_id
+        return self._request("PUT", "documento/", json=body)
+
+    def get_customer_by_document(self, document: str) -> Dict[str, Any]:
+        """Fetch Contifico personas (clientes) filtered by identification number."""
+
+        params = {"identificacion": document}
+        return self._request("GET", "persona/", params=params)
+
+    def __enter__(self) -> "ContificoClient":  # pragma: no cover - convenience
+        return self
+
+    def __exit__(self, *_args: Any) -> None:  # pragma: no cover - convenience
+        self.close()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ passlib[bcrypt]==1.7.4
 pydantic>=2
 pydantic-settings>=2.0.0
 pytest
+httpx

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -1,0 +1,126 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.integrations import (  # noqa: E402
+    ContificoClient,
+    ContificoPermanentError,
+    ContificoTransientError,
+)
+
+
+def build_contifico_client(handler, **kwargs):
+    client = ContificoClient(
+        base_url="https://api.example.com/sistema/api/v1",
+        token="token-abc",
+        max_retries=0,
+        rate_limit_per_minute=100,
+        sleep_func=lambda _seconds: None,
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        **kwargs,
+    )
+    return client
+
+
+def test_create_invoice_builds_expected_request():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("authorization")
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(201, json={"id": "INV-1"})
+
+    client = build_contifico_client(handler)
+    response = client.create_invoice({"total": 100})
+
+    assert response == {"id": "INV-1"}
+    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/"
+    assert captured["authorization"] == "token-abc"
+    assert captured["json"] == {"total": 100}
+
+
+def test_update_invoice_uses_company_id_and_json():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = build_contifico_client(handler)
+    response = client.update_invoice("INV-2", {"total": 200})
+
+    assert response == {"status": "ok"}
+    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/"
+    assert captured["json"] == {"id": "INV-2", "total": 200}
+
+
+def test_get_customer_by_document_sets_query_param():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"items": []})
+
+    client = build_contifico_client(handler)
+    client.get_customer_by_document("0909090909")
+
+    assert (
+        captured["url"]
+        == "https://api.example.com/sistema/api/v1/persona/?identificacion=0909090909"
+    )
+
+
+def test_raises_transient_on_rate_limit():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, json={"detail": "too many"})
+
+    client = build_contifico_client(handler)
+
+    with pytest.raises(ContificoTransientError):
+        client.get_customer_by_document("0909090909")
+
+
+def test_raises_permanent_on_client_error():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": "bad request"})
+
+    client = build_contifico_client(handler)
+
+    with pytest.raises(ContificoPermanentError):
+        client.create_invoice({})
+
+
+def test_retries_and_then_raises_transient_on_request_error(monkeypatch):
+    call_count = {"value": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_count["value"] += 1
+        raise httpx.ConnectError("boom", request=_request)
+
+    transport = httpx.MockTransport(handler)
+    mock_httpx_client = httpx.Client(transport=transport)
+
+    client = ContificoClient(
+        base_url="https://api.example.com",
+        token="token-abc",
+        max_retries=1,
+        retry_backoff_seconds=0,
+        rate_limit_per_minute=100,
+        client=mock_httpx_client,
+        sleep_func=lambda _seconds: None,
+    )
+
+    with pytest.raises(ContificoTransientError):
+        client.get_customer_by_document("0909090909")
+
+    assert call_count["value"] == 2


### PR DESCRIPTION
## Summary
- update Contifico configuration defaults to the documented base URL and add README usage instructions
- adjust the Contifico client to call the documented documento/ and persona/ endpoints with the expected Authorization header
- refresh unit tests to validate the new request payloads and query parameters

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e03413b5048332a1aea880711b0d4c