### PR TITLE
Align Contifico integration with official API methods

### DIFF
--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -129,7 +129,7 @@ class ContificoClient:
                         response.status_code,
                         response.text,
                     )
-                    error = ContificoPermanentError("Contifico request failed")
+                    raise ContificoPermanentError("Contifico request failed")
                 else:
                     logger.debug("Contifico response %s %s", response.status_code, response.text)
                     try:

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -100,6 +100,29 @@ def test_raises_permanent_on_client_error():
         client.create_invoice({})
 
 
+def test_does_not_retry_permanent_error(monkeypatch):
+    call_count = {"value": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_count["value"] += 1
+        return httpx.Response(401, json={"detail": "unauthorized"})
+
+    client = ContificoClient(
+        base_url="https://api.example.com",
+        token="token-abc",
+        max_retries=3,
+        retry_backoff_seconds=0,
+        rate_limit_per_minute=100,
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        sleep_func=lambda _seconds: None,
+    )
+
+    with pytest.raises(ContificoPermanentError):
+        client.create_invoice({})
+
+    assert call_count["value"] == 1
+
+
 def test_retries_and_then_raises_transient_on_request_error(monkeypatch):
     call_count = {"value": 0}
 


### PR DESCRIPTION
## Summary
- update Contifico configuration defaults to the documented base URL and add README usage instructions
- adjust the Contifico client to call the documented documento/ and persona/ endpoints with the expected Authorization header
- refresh unit tests to validate the new request payloads and query parameters
- stop retrying Contifico requests after permanent API errors

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e03846bb848332ae96e1379d210cc4