### PR TITLE
Notify pending invoice balances in UI

### DIFF
--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -166,6 +166,11 @@ class ContificoClient:
         body["id"] = invoice_id
         return self._request("PUT", "documento/", json=body)
 
+    def get_invoice(self, invoice_id: str) -> Dict[str, Any]:
+        """Fetch a Contifico document by its identifier."""
+
+        return self._request("GET", f"documento/{invoice_id}/")
+
     def get_customer_by_document(self, document: str) -> Dict[str, Any]:
         """Fetch Contifico personas (clientes) filtered by identification number."""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 import math
 from contextlib import asynccontextmanager
-from typing import List, Optional, Tuple
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Query, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -16,6 +17,7 @@ from .dependencies import (
     vendor_or_admin_required,
 )
 from .migrations import apply_schema_upgrades
+from .integrations import ContificoClient, ContificoError
 
 settings = get_settings()
 
@@ -104,6 +106,332 @@ def _get_order_or_404(db: Session, order_id: int) -> models.Order:
     if not order:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Orden no encontrada")
     return order
+
+
+def get_contifico_client_dependency() -> Generator[ContificoClient, None, None]:
+    if not settings.contifico_api_key or not settings.contifico_api_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="La integración con Contifico no está configurada.",
+        )
+
+    client = ContificoClient(
+        base_url=settings.contifico_base_url,
+        api_key=settings.contifico_api_key,
+        api_token=settings.contifico_api_token,
+        timeout=settings.contifico_timeout_seconds,
+        rate_limit_per_minute=settings.contifico_rate_limit_per_minute,
+        max_retries=settings.contifico_max_retries,
+        retry_backoff_seconds=settings.contifico_retry_backoff_seconds,
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _flatten_invoice_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+
+    for key in ("documento", "data", "detalle"):
+        nested = payload.get(key)
+        if isinstance(nested, dict):
+            merged: Dict[str, Any] = {**nested}
+            for extra_key, value in payload.items():
+                if extra_key not in merged:
+                    merged[extra_key] = value
+            return merged
+    return dict(payload)
+
+
+def _get_nested_value(data: Any, path: Sequence[str]) -> Any:
+    current = data
+    for key in path:
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return None
+    return current
+
+
+def _extract_value(data: Dict[str, Any], candidates: Iterable[Sequence[str]]) -> Any:
+    for path in candidates:
+        value = _get_nested_value(data, path)
+        if isinstance(value, str):
+            if value.strip():
+                return value
+        elif value not in (None, "", []):
+            return value
+    return None
+
+
+def _extract_text(data: Dict[str, Any], candidates: Iterable[Sequence[str]]) -> Optional[str]:
+    value = _extract_value(data, candidates)
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    if value is not None:
+        text = str(value).strip()
+        return text or None
+    return None
+
+
+def _to_decimal(value: Any) -> Optional[Decimal]:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        normalized = stripped.replace(" ", "")
+        if normalized.count(",") > 1 and "." not in normalized:
+            normalized = normalized.replace(".", "").replace(",", ".")
+        elif normalized.count(",") == 1 and normalized.count(".") == 0:
+            normalized = normalized.replace(",", ".")
+        else:
+            normalized = normalized.replace(",", "")
+        try:
+            return Decimal(normalized)
+        except InvalidOperation:
+            return None
+    return None
+
+
+def _extract_decimal(data: Dict[str, Any], candidates: Iterable[Sequence[str]]) -> Optional[Decimal]:
+    raw_value = _extract_value(data, candidates)
+    return _to_decimal(raw_value)
+
+
+def _decimal_to_float(value: Optional[Decimal]) -> Optional[float]:
+    if value is None:
+        return None
+    quantized = value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    result = float(quantized)
+    if abs(result) < 0.0005:
+        return 0.0
+    return result
+
+
+def _extract_payment_date(invoice: Dict[str, Any]) -> Optional[str]:
+    direct = _extract_text(
+        invoice,
+        [
+            ("fecha_pago",),
+            ("fechaPago",),
+            ("fecha_cobro",),
+            ("fechaCobro",),
+            ("fecha_cancelacion",),
+            ("fechaCancelacion",),
+        ],
+    )
+    if direct:
+        return direct
+
+    payments = invoice.get("pagos")
+    if isinstance(payments, list):
+        candidates: List[str] = []
+        for item in payments:
+            if isinstance(item, dict):
+                candidate = _extract_text(
+                    item,
+                    [
+                        ("fecha",),
+                        ("fecha_pago",),
+                        ("fechaPago",),
+                        ("fecha_registro",),
+                        ("fechaRegistro",),
+                    ],
+                )
+                if candidate:
+                    candidates.append(candidate)
+        if candidates:
+            candidates.sort()
+            return candidates[-1]
+    return None
+
+
+def _extract_currency(invoice: Dict[str, Any]) -> Optional[str]:
+    value = _extract_value(
+        invoice,
+        [
+            ("moneda",),
+            ("divisa",),
+            ("currency",),
+            ("totales", "moneda"),
+            ("totales", "currency"),
+            ("totals", "moneda"),
+            ("totals", "currency"),
+        ],
+    )
+    if isinstance(value, dict):
+        nested = _extract_text(value, [("codigo",), ("code",)])
+        return nested.upper() if nested else None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed.upper() if trimmed else None
+    return None
+
+
+def _build_invoice_summary(invoice_number: str, payload: Any) -> schemas.InvoiceSummary:
+    if isinstance(payload, list):
+        payload = next((item for item in payload if isinstance(item, dict)), {})
+    elif not isinstance(payload, dict):
+        payload = {}
+
+    invoice = _flatten_invoice_payload(payload)
+    subtotal_decimal = _extract_decimal(
+        invoice,
+        [
+            ("subtotal",),
+            ("subtotal_sin_impuestos",),
+            ("subtotalSinImpuestos",),
+            ("totales", "subtotal"),
+            ("totales", "subtotal_sin_impuestos"),
+            ("totales", "subtotalSinImpuestos"),
+            ("totals", "subtotal"),
+            ("totals", "subtotalSinImpuestos"),
+        ],
+    )
+    tax_decimal = _extract_decimal(
+        invoice,
+        [
+            ("total_impuestos",),
+            ("totalImpuestos",),
+            ("impuestos",),
+            ("iva",),
+            ("totales", "impuestos"),
+            ("totales", "iva"),
+            ("totals", "impuestos"),
+            ("totals", "taxes"),
+        ],
+    )
+    total_decimal = _extract_decimal(
+        invoice,
+        [
+            ("total",),
+            ("total_final",),
+            ("totalFinal",),
+            ("total_con_impuestos",),
+            ("totalConImpuestos",),
+            ("totales", "total"),
+            ("totals", "total"),
+        ],
+    )
+    paid_decimal = _extract_decimal(
+        invoice,
+        [
+            ("total_pagado",),
+            ("totalPagado",),
+            ("pagado",),
+            ("totales", "pagado"),
+            ("totals", "paid"),
+        ],
+    )
+    pending_decimal = _extract_decimal(
+        invoice,
+        [
+            ("saldo",),
+            ("saldo_pendiente",),
+            ("saldoPendiente",),
+            ("pendiente",),
+            ("totales", "saldo"),
+            ("totales", "pendiente"),
+            ("totals", "pending"),
+        ],
+    )
+
+    if pending_decimal is None and total_decimal is not None and paid_decimal is not None:
+        pending_decimal = total_decimal - paid_decimal
+    if paid_decimal is None and total_decimal is not None and pending_decimal is not None:
+        paid_decimal = total_decimal - pending_decimal
+
+    if pending_decimal is not None and pending_decimal < Decimal("0"):
+        pending_decimal = max(pending_decimal, Decimal("0"))
+
+    subtotal = _decimal_to_float(subtotal_decimal)
+    tax_total = _decimal_to_float(tax_decimal)
+    total = _decimal_to_float(total_decimal)
+    paid_total = _decimal_to_float(paid_decimal)
+    pending_total = _decimal_to_float(pending_decimal)
+
+    status = _extract_text(
+        invoice,
+        [
+            ("estado",),
+            ("estado_documento",),
+            ("estadoDocumento",),
+            ("estado_autorizacion",),
+            ("estadoAutorizacion",),
+        ],
+    )
+    payment_status = _extract_text(
+        invoice,
+        [
+            ("estado_pago",),
+            ("estadoPago",),
+            ("estado_cobro",),
+            ("estadoCobro",),
+            ("estado_pago_actual",),
+            ("estadoPagoActual",),
+        ],
+    )
+    if not payment_status:
+        payment_status = status
+
+    payment_date = _extract_payment_date(invoice)
+    currency = _extract_currency(invoice)
+    download_url = _extract_text(
+        invoice,
+        [
+            ("url_pdf",),
+            ("urlPdf",),
+            ("enlace_pdf",),
+            ("link_descarga",),
+            ("linkDescarga",),
+            ("links", "pdf"),
+            ("links", "descarga"),
+            ("links", "download"),
+            ("links", "pdf_url"),
+            ("links", "pdfUrl"),
+        ],
+    )
+    share_url = _extract_text(
+        invoice,
+        [
+            ("url_compartir",),
+            ("urlCompartir",),
+            ("enlace_publico",),
+            ("enlacePublico",),
+            ("link_publico",),
+            ("linkPublico",),
+            ("links", "publico"),
+            ("links", "public"),
+            ("links", "share"),
+        ],
+    )
+
+    has_pending_balance = bool(pending_total is not None and pending_total > 0.009)
+
+    return schemas.InvoiceSummary(
+        invoice_number=invoice_number,
+        status=status,
+        payment_status=payment_status,
+        subtotal=subtotal,
+        tax_total=tax_total,
+        total=total,
+        paid_total=paid_total,
+        pending_total=pending_total,
+        has_pending_balance=has_pending_balance,
+        currency=currency,
+        payment_date=payment_date,
+        download_url=download_url,
+        share_url=share_url,
+    )
 
 
 @app.get("/health")
@@ -473,6 +801,33 @@ def get_order_endpoint(
     if not order:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Orden no encontrada")
     return order
+
+
+@app.get("/orders/{order_id}/invoice", response_model=schemas.InvoiceSummary)
+def get_order_invoice_endpoint(
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(staff_required()),
+    contifico_client: ContificoClient = Depends(get_contifico_client_dependency),
+):
+    _ = current_user
+    order = _get_order_or_404(db, order_id)
+    invoice_number = (order.invoice_number or "").strip()
+    if not invoice_number:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="La orden no tiene número de factura registrado.",
+        )
+
+    try:
+        invoice_payload = contifico_client.get_invoice(invoice_number)
+    except ContificoError as exc:  # pragma: no cover - integration error path
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="No se pudo consultar la factura en Contifico. Inténtalo más tarde.",
+        ) from exc
+
+    return _build_invoice_summary(invoice_number, invoice_payload)
 
 
 @app.patch("/orders/{order_id}", response_model=schemas.OrderRead)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -161,6 +161,22 @@ class OrderRead(OrderPublic):
     created_at: datetime
 
 
+class InvoiceSummary(BaseModel):
+    invoice_number: str
+    status: Optional[str] = None
+    payment_status: Optional[str] = None
+    subtotal: Optional[float] = None
+    tax_total: Optional[float] = None
+    total: Optional[float] = None
+    paid_total: Optional[float] = None
+    pending_total: Optional[float] = None
+    has_pending_balance: bool = False
+    currency: Optional[str] = None
+    payment_date: Optional[str] = None
+    download_url: Optional[str] = None
+    share_url: Optional[str] = None
+
+
 class OrderTaskBase(BaseModel):
     description: str = Field(..., max_length=255)
 

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -67,6 +67,20 @@ def test_update_invoice_uses_company_id_and_json():
     assert captured["json"] == {"id": "INV-2", "total": 200}
 
 
+def test_get_invoice_fetches_specific_document():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"id": "INV-25"})
+
+    client = build_contifico_client(handler)
+    response = client.get_invoice("INV-25")
+
+    assert response == {"id": "INV-25"}
+    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/INV-25/"
+
+
 def test_get_customer_by_document_sets_query_param():
     captured = {}
 
@@ -112,7 +126,8 @@ def test_does_not_retry_permanent_error(monkeypatch):
 
     client = ContificoClient(
         base_url="https://api.example.com",
-        token="token-abc",
+        api_key="key-123",
+        api_token="token-abc",
         max_retries=3,
         retry_backoff_seconds=0,
         rate_limit_per_minute=100,

--- a/backend/tests/test_order_invoice_endpoint.py
+++ b/backend/tests/test_order_invoice_endpoint.py
@@ -1,0 +1,156 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import auth, main, models  # noqa: E402
+from app.database import Base  # noqa: E402
+from app.integrations import ContificoError  # noqa: E402
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def create_user(session, username: str, role: models.UserRole) -> models.User:
+    user = models.User(
+        username=username,
+        full_name=username.title(),
+        role=role,
+        password_hash=auth.get_password_hash("secret"),
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def create_customer(session) -> models.Customer:
+    customer = models.Customer(
+        full_name="Cliente Factura",
+        document_id="0991234567",
+        phone="0991231234",
+    )
+    session.add(customer)
+    session.commit()
+    session.refresh(customer)
+    return customer
+
+
+def create_order(session, invoice_number: str | None = "INV-001") -> models.Order:
+    customer = create_customer(session)
+    order = models.Order(
+        order_number="ORD-900",
+        customer_id=customer.id,
+        customer_name=customer.full_name,
+        customer_document=customer.document_id,
+        customer_contact=customer.phone,
+        status=models.OrderStatus.EN_TIENDA_BATAN,
+        measurements=[],
+        origin_branch=models.Establishment.BATAN,
+        invoice_number=invoice_number,
+    )
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return order
+
+
+class DummyContificoClient:
+    def __init__(self, payload=None, error: Exception | None = None):
+        self.payload = payload or {}
+        self.error = error
+        self.requested_invoice = None
+
+    def get_invoice(self, invoice_id: str):
+        self.requested_invoice = invoice_id
+        if self.error:
+            raise self.error
+        return self.payload
+
+
+def test_get_order_invoice_requires_invoice_number(db_session):
+    admin = create_user(db_session, "admin", models.UserRole.ADMIN)
+    order = create_order(db_session, invoice_number=None)
+
+    client = DummyContificoClient()
+    with pytest.raises(HTTPException) as exc_info:
+        main.get_order_invoice_endpoint(order.id, db_session, admin, contifico_client=client)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "La orden no tiene número de factura registrado."
+    assert client.requested_invoice is None
+
+
+def test_get_order_invoice_returns_summary(db_session):
+    admin = create_user(db_session, "admin", models.UserRole.ADMIN)
+    order = create_order(db_session, invoice_number="INV-500")
+
+    payload = {
+        "estado": "AUTORIZADO",
+        "estado_pago": "PAGADO",
+        "totales": {
+            "subtotal": "100",
+            "impuestos": "12",
+            "total": "112",
+            "pagado": "112",
+        },
+        "fecha_pago": "2024-02-05T10:15:00",
+        "links": {
+            "pdf": "https://contifico.example/pdf/INV-500",
+            "publico": "https://contifico.example/share/INV-500",
+        },
+    }
+    client = DummyContificoClient(payload=payload)
+
+    summary = main.get_order_invoice_endpoint(order.id, db_session, admin, contifico_client=client)
+
+    assert summary.invoice_number == "INV-500"
+    assert summary.status == "AUTORIZADO"
+    assert summary.payment_status == "PAGADO"
+    assert summary.total == 112.0
+    assert summary.subtotal == 100.0
+    assert summary.tax_total == 12.0
+    assert summary.pending_total == 0.0
+    assert summary.has_pending_balance is False
+    assert summary.payment_date == "2024-02-05T10:15:00"
+    assert summary.download_url == "https://contifico.example/pdf/INV-500"
+    assert summary.share_url == "https://contifico.example/share/INV-500"
+    assert client.requested_invoice == "INV-500"
+
+
+def test_get_order_invoice_handles_contifico_errors(db_session):
+    admin = create_user(db_session, "admin", models.UserRole.ADMIN)
+    order = create_order(db_session, invoice_number="INV-404")
+
+    client = DummyContificoClient(error=ContificoError("fallo"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        main.get_order_invoice_endpoint(order.id, db_session, admin, contifico_client=client)
+
+    assert exc_info.value.status_code == 502
+    assert "Contifico" in exc_info.value.detail

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -51,6 +51,11 @@ const state = {
   customerRequestId: 0,
   orderRequestId: 0,
   customerOptionsRequestId: 0,
+  orderInvoiceCache: {},
+  orderInvoicePending: {},
+  orderInvoiceErrorCache: {},
+  orderInvoiceErrorNotified: {},
+  orderInvoicePendingBalanceNotified: {},
 };
 
 const TOKEN_STORAGE_KEY = 'sastreria.authToken';
@@ -199,6 +204,7 @@ const orderDetailStatusSelect = document.getElementById('orderDetailStatus');
 const orderDetailTailorSelect = document.getElementById('orderDetailTailor');
 const orderDetailVendorSelect = document.getElementById('orderDetailVendor');
 const orderDetailInvoiceInput = document.getElementById('orderDetailInvoice');
+const orderDetailInvoiceInfo = document.getElementById('orderDetailInvoiceInfo');
 const orderDetailOriginSelect = document.getElementById('orderDetailOrigin');
 const orderDetailDeliveryDateInput = document.getElementById('orderDetailDeliveryDate');
 const orderDetailNotesTextarea = document.getElementById('orderDetailNotes');
@@ -218,6 +224,10 @@ const currentUserRoleElement = document.getElementById('currentUserRole');
 const usersTabButton = document.getElementById('usersTabButton');
 const auditLogTabButton = document.getElementById('auditLogTabButton');
 const auditLogTableBody = document.getElementById('auditLogTableBody');
+
+if (orderDetailInvoiceInfo) {
+  renderInvoicePlaceholder(orderDetailInvoiceInfo, '', 'Sin número registrado', { muted: true });
+}
 const usersTableBody = document.getElementById('usersTableBody');
 const userCreateContainer = document.getElementById('userCreateContainer');
 const toggleCreateUserButton = document.getElementById('toggleCreateUserButton');
@@ -660,6 +670,487 @@ function toInputDateTimeValue(value) {
   }
 
   return '';
+}
+
+let invoiceRenderSequence = 0;
+
+function normalizeInvoiceNumber(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+}
+
+function getInvoiceCacheKey(orderId, invoiceNumber) {
+  const normalizedNumber = normalizeInvoiceNumber(invoiceNumber);
+  const numericId = Number(orderId);
+  if (!normalizedNumber || !Number.isFinite(numericId)) {
+    return '';
+  }
+  return `${numericId}::${normalizedNumber.toUpperCase()}`;
+}
+
+function ensureInvoiceCacheState() {
+  if (!state.orderInvoiceCache) {
+    state.orderInvoiceCache = {};
+  }
+  if (!state.orderInvoicePending) {
+    state.orderInvoicePending = {};
+  }
+  if (!state.orderInvoiceErrorCache) {
+    state.orderInvoiceErrorCache = {};
+  }
+  if (!state.orderInvoiceErrorNotified) {
+    state.orderInvoiceErrorNotified = {};
+  }
+  if (!state.orderInvoicePendingBalanceNotified) {
+    state.orderInvoicePendingBalanceNotified = {};
+  }
+}
+
+function resetInvoiceCaches() {
+  state.orderInvoiceCache = {};
+  state.orderInvoicePending = {};
+  state.orderInvoiceErrorCache = {};
+  state.orderInvoiceErrorNotified = {};
+  state.orderInvoicePendingBalanceNotified = {};
+}
+
+function clearInvoiceCacheForOrder(orderId) {
+  ensureInvoiceCacheState();
+  const numericId = Number(orderId);
+  if (!Number.isFinite(numericId)) {
+    return;
+  }
+  const prefix = `${numericId}::`;
+  Object.keys(state.orderInvoiceCache).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      delete state.orderInvoiceCache[key];
+    }
+  });
+  Object.keys(state.orderInvoicePending).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      delete state.orderInvoicePending[key];
+    }
+  });
+  Object.keys(state.orderInvoiceErrorCache).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      delete state.orderInvoiceErrorCache[key];
+    }
+  });
+  Object.keys(state.orderInvoiceErrorNotified).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      delete state.orderInvoiceErrorNotified[key];
+    }
+  });
+  Object.keys(state.orderInvoicePendingBalanceNotified).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      delete state.orderInvoicePendingBalanceNotified[key];
+    }
+  });
+}
+
+function fetchInvoiceSummary(orderId, invoiceNumber) {
+  ensureInvoiceCacheState();
+  const cacheKey = getInvoiceCacheKey(orderId, invoiceNumber);
+  if (!cacheKey) {
+    return Promise.resolve(null);
+  }
+  if (state.orderInvoiceCache[cacheKey]) {
+    return Promise.resolve(state.orderInvoiceCache[cacheKey]);
+  }
+  if (state.orderInvoiceErrorCache[cacheKey]) {
+    return Promise.reject(new Error(state.orderInvoiceErrorCache[cacheKey]));
+  }
+  if (state.orderInvoicePending[cacheKey]) {
+    return state.orderInvoicePending[cacheKey];
+  }
+  const request = apiFetch(`/orders/${orderId}/invoice`)
+    .then((data) => {
+      state.orderInvoiceCache[cacheKey] = data;
+      delete state.orderInvoiceErrorCache[cacheKey];
+      return data;
+    })
+    .catch((error) => {
+      state.orderInvoiceErrorCache[cacheKey] = error?.message || 'No se pudo consultar la factura.';
+      throw error;
+    })
+    .finally(() => {
+      delete state.orderInvoicePending[cacheKey];
+    });
+  state.orderInvoicePending[cacheKey] = request;
+  return request;
+}
+
+function formatInvoiceAmount(amount, currency) {
+  if (typeof amount !== 'number' || Number.isNaN(amount)) {
+    return '';
+  }
+  const normalizedCurrency = typeof currency === 'string' && currency.trim()
+    ? currency.trim().toUpperCase()
+    : 'USD';
+  try {
+    return new Intl.NumberFormat('es-EC', {
+      style: 'currency',
+      currency: normalizedCurrency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch (error) {
+    return `${normalizedCurrency} ${amount.toFixed(2)}`;
+  }
+}
+
+function formatInvoiceDateForDisplay(rawDate) {
+  if (!rawDate) {
+    return '';
+  }
+  if (rawDate instanceof Date) {
+    return formatDate(rawDate.toISOString());
+  }
+  const stringValue = String(rawDate).trim();
+  if (!stringValue) {
+    return '';
+  }
+  const direct = new Date(stringValue);
+  if (!Number.isNaN(direct.getTime())) {
+    return formatDate(direct.toISOString());
+  }
+  const slashMatch = stringValue.match(
+    /^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s+(\d{2}):(\d{2})(?::(\d{2}))?)?$/,
+  );
+  if (slashMatch) {
+    const [, day, month, year, hour = '00', minute = '00', second = '00'] = slashMatch;
+    const isoCandidate = `${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T${hour.padStart(2, '0')}:${minute.padStart(2, '0')}:${second.padStart(2, '0')}`;
+    const parsed = new Date(isoCandidate);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatDate(parsed.toISOString());
+    }
+  }
+  return stringValue;
+}
+
+function renderInvoicePlaceholder(element, invoiceNumber, message = '', options = {}) {
+  if (!element) {
+    return;
+  }
+  const normalizedNumber = normalizeInvoiceNumber(invoiceNumber);
+  element.innerHTML = '';
+  element.classList.add('invoice-meta');
+  element.classList.toggle('muted', options.muted === true);
+  element.classList.remove('has-pending-balance');
+  const numberSpan = document.createElement('span');
+  numberSpan.className = 'invoice-meta-number';
+  numberSpan.textContent = normalizedNumber
+    ? `Factura: ${normalizedNumber}`
+    : 'Factura: Sin número registrado';
+  element.appendChild(numberSpan);
+  if (message) {
+    const note = document.createElement('span');
+    note.className = 'invoice-meta-note';
+    note.textContent = message;
+    element.appendChild(note);
+  }
+  delete element.dataset.invoiceCacheKey;
+}
+
+function createInvoiceChip(text, variant = 'info') {
+  const chip = document.createElement('span');
+  chip.className = 'invoice-chip';
+  if (variant) {
+    chip.classList.add(`invoice-chip--${variant}`);
+  }
+  chip.textContent = text;
+  return chip;
+}
+
+function getInvoiceStatusVariant(text, hasPendingBalance) {
+  const normalized = typeof text === 'string' ? text.toLowerCase() : '';
+  if (hasPendingBalance || normalized.includes('pend') || normalized.includes('deud')) {
+    return 'pending';
+  }
+  if (normalized.includes('rech') || normalized.includes('anul')) {
+    return 'error';
+  }
+  if (
+    normalized.includes('pag') ||
+    normalized.includes('cobr') ||
+    normalized.includes('autoriz') ||
+    normalized.includes('emit') ||
+    normalized.includes('cancel')
+  ) {
+    return 'success';
+  }
+  return 'info';
+}
+
+function renderInvoiceSummaryElement(element, invoiceNumber, summary) {
+  if (!element) {
+    return;
+  }
+  const normalizedNumber = normalizeInvoiceNumber(invoiceNumber);
+  element.innerHTML = '';
+  element.classList.add('invoice-meta');
+  element.classList.remove('muted');
+  element.classList.toggle('has-pending-balance', Boolean(summary?.has_pending_balance));
+
+  const numberSpan = document.createElement('span');
+  numberSpan.className = 'invoice-meta-number';
+  numberSpan.textContent = normalizedNumber
+    ? `Factura: ${normalizedNumber}`
+    : 'Factura: Sin número registrado';
+  element.appendChild(numberSpan);
+
+  const seenStatuses = new Set();
+  const statusesToShow = [];
+  if (summary?.payment_status) {
+    statusesToShow.push({
+      text: summary.payment_status,
+      variant: getInvoiceStatusVariant(summary.payment_status, summary?.has_pending_balance),
+    });
+  }
+  if (summary?.status && summary.status !== summary.payment_status) {
+    statusesToShow.push({
+      text: summary.status,
+      variant: getInvoiceStatusVariant(summary.status, summary?.has_pending_balance),
+    });
+  }
+  statusesToShow.forEach((statusInfo) => {
+    const normalizedStatus = normalizeInvoiceNumber(statusInfo.text);
+    if (!normalizedStatus) {
+      return;
+    }
+    const lowered = normalizedStatus.toLowerCase();
+    if (seenStatuses.has(lowered)) {
+      return;
+    }
+    seenStatuses.add(lowered);
+    element.appendChild(createInvoiceChip(normalizedStatus, statusInfo.variant));
+  });
+
+  if (typeof summary?.total === 'number' && !Number.isNaN(summary.total)) {
+    const totalLabel = document.createElement('span');
+    totalLabel.className = 'invoice-meta-amount';
+    const formattedTotal = formatInvoiceAmount(summary.total, summary?.currency);
+    totalLabel.textContent = formattedTotal ? `Total: ${formattedTotal}` : `Total: ${summary.total.toFixed(2)}`;
+    element.appendChild(totalLabel);
+  }
+
+  if (typeof summary?.pending_total === 'number' && summary.pending_total > 0) {
+    const formattedPending = formatInvoiceAmount(summary.pending_total, summary?.currency);
+    const pendingChip = createInvoiceChip(
+      formattedPending ? `Pendiente: ${formattedPending}` : `Pendiente: ${summary.pending_total.toFixed(2)}`,
+      'pending',
+    );
+    element.appendChild(pendingChip);
+  }
+
+  if (summary?.payment_date) {
+    const formattedDate = formatInvoiceDateForDisplay(summary.payment_date);
+    if (formattedDate) {
+      const paymentNote = document.createElement('span');
+      paymentNote.className = 'invoice-meta-note';
+      paymentNote.textContent = `Pago: ${formattedDate}`;
+      element.appendChild(paymentNote);
+    }
+  }
+
+  const links = [];
+  if (summary?.download_url) {
+    const downloadLink = document.createElement('a');
+    downloadLink.href = summary.download_url;
+    downloadLink.target = '_blank';
+    downloadLink.rel = 'noopener noreferrer';
+    downloadLink.textContent = 'Descargar';
+    links.push(downloadLink);
+  }
+  if (summary?.share_url && summary.share_url !== summary.download_url) {
+    const shareLink = document.createElement('a');
+    shareLink.href = summary.share_url;
+    shareLink.target = '_blank';
+    shareLink.rel = 'noopener noreferrer';
+    shareLink.textContent = 'Ver en línea';
+    links.push(shareLink);
+  }
+  if (links.length) {
+    const linksWrapper = document.createElement('span');
+    linksWrapper.className = 'invoice-meta-links';
+    links.forEach((link) => {
+      linksWrapper.appendChild(link);
+    });
+    element.appendChild(linksWrapper);
+  }
+}
+
+function getInvoiceErrorMessages(error) {
+  const baseInline = 'No se pudo obtener los detalles de la factura.';
+  const baseToast = 'No fue posible consultar la factura en Contifico.';
+  const message = typeof error?.message === 'string' ? error.message.trim() : '';
+  const isGeneric = !message || message === 'Error en la solicitud';
+  return {
+    inline: isGeneric ? baseInline : `${baseInline} (${message})`,
+    toast: isGeneric ? `${baseToast} Intenta nuevamente más tarde.` : `${baseToast} ${message}.`,
+    detail: message,
+  };
+}
+
+function maybeNotifyInvoiceError(cacheKey, toastMessage) {
+  if (!toastMessage) {
+    return;
+  }
+  ensureInvoiceCacheState();
+  if (cacheKey && state.orderInvoiceErrorNotified[cacheKey]) {
+    return;
+  }
+  if (cacheKey) {
+    state.orderInvoiceErrorNotified[cacheKey] = true;
+  }
+  showToast(toastMessage, 'error');
+}
+
+function renderInvoiceErrorElement(element, invoiceNumber, error, cacheKey, options = {}) {
+  if (!element) {
+    return;
+  }
+  const normalizedNumber = normalizeInvoiceNumber(invoiceNumber);
+  const messages = getInvoiceErrorMessages(error);
+  element.innerHTML = '';
+  element.classList.add('invoice-meta');
+  element.classList.remove('muted');
+  element.classList.remove('has-pending-balance');
+
+  const numberSpan = document.createElement('span');
+  numberSpan.className = 'invoice-meta-number';
+  numberSpan.textContent = normalizedNumber
+    ? `Factura: ${normalizedNumber}`
+    : 'Factura: Sin número registrado';
+  element.appendChild(numberSpan);
+
+  const errorSpan = document.createElement('span');
+  errorSpan.className = 'invoice-meta-error';
+  errorSpan.textContent = messages.inline;
+  if (messages.detail) {
+    errorSpan.title = messages.detail;
+  }
+  element.appendChild(errorSpan);
+
+  if (options.notify === true) {
+    maybeNotifyInvoiceError(cacheKey, messages.toast);
+  }
+}
+
+function maybeNotifyInvoicePendingBalance(cacheKey, summary, invoiceNumber) {
+  ensureInvoiceCacheState();
+  if (!cacheKey || !summary) {
+    return;
+  }
+  const hasPendingBalance =
+    summary.has_pending_balance === true ||
+    (typeof summary.pending_total === 'number' && summary.pending_total > 0);
+  if (!hasPendingBalance) {
+    return;
+  }
+  if (state.orderInvoicePendingBalanceNotified[cacheKey]) {
+    return;
+  }
+  state.orderInvoicePendingBalanceNotified[cacheKey] = true;
+
+  let formattedPending = null;
+  if (typeof summary.pending_total === 'number' && summary.pending_total > 0) {
+    formattedPending = formatInvoiceAmount(summary.pending_total, summary.currency);
+    if (!formattedPending) {
+      formattedPending = summary.pending_total.toFixed(2);
+    }
+  }
+
+  const normalizedNumber = normalizeInvoiceNumber(invoiceNumber || summary.invoice_number || '');
+  const invoiceLabel = normalizedNumber ? `Factura ${normalizedNumber}` : 'Esta factura';
+  const message = formattedPending
+    ? `${invoiceLabel} tiene un saldo pendiente de ${formattedPending}.`
+    : `${invoiceLabel} tiene un saldo pendiente.`;
+  showToast(message, 'warning');
+}
+
+function updateInvoiceInfoDisplay(element, order, options = {}) {
+  if (!element) {
+    return;
+  }
+  const invoiceNumber = normalizeInvoiceNumber(order?.invoice_number || '');
+  invoiceRenderSequence += 1;
+  const renderId = `invoice-${invoiceRenderSequence}`;
+  element.dataset.invoiceRenderId = renderId;
+
+  if (!invoiceNumber) {
+    renderInvoicePlaceholder(element, '', 'Sin número registrado', { muted: true });
+    return;
+  }
+
+  const orderId = Number(order?.id);
+  if (!Number.isFinite(orderId)) {
+    renderInvoicePlaceholder(element, invoiceNumber, '', { muted: false });
+    return;
+  }
+
+  if (!state.token) {
+    renderInvoicePlaceholder(
+      element,
+      invoiceNumber,
+      'Inicia sesión para consultar la factura.',
+      { muted: false },
+    );
+    return;
+  }
+
+  const cacheKey = getInvoiceCacheKey(orderId, invoiceNumber);
+  element.dataset.invoiceCacheKey = cacheKey;
+
+  ensureInvoiceCacheState();
+  if (state.orderInvoiceCache[cacheKey]) {
+    if (options.context === 'detail') {
+      maybeNotifyInvoicePendingBalance(cacheKey, state.orderInvoiceCache[cacheKey], invoiceNumber);
+    }
+    renderInvoiceSummaryElement(element, invoiceNumber, state.orderInvoiceCache[cacheKey]);
+    return;
+  }
+  if (state.orderInvoiceErrorCache[cacheKey]) {
+    renderInvoiceErrorElement(
+      element,
+      invoiceNumber,
+      new Error(state.orderInvoiceErrorCache[cacheKey]),
+      cacheKey,
+      { notify: options.context === 'detail' },
+    );
+    return;
+  }
+
+  renderInvoicePlaceholder(element, invoiceNumber, 'Consultando estado…', { muted: false });
+
+  fetchInvoiceSummary(orderId, invoiceNumber)
+    .then((summary) => {
+      if (element.dataset.invoiceRenderId !== renderId) {
+        return;
+      }
+      if (summary) {
+        if (options.context === 'detail') {
+          maybeNotifyInvoicePendingBalance(cacheKey, summary, invoiceNumber);
+        }
+        renderInvoiceSummaryElement(element, invoiceNumber, summary);
+      } else {
+        renderInvoicePlaceholder(element, invoiceNumber, 'Sin información disponible.', { muted: false });
+      }
+    })
+    .catch((error) => {
+      if (element.dataset.invoiceRenderId !== renderId) {
+        return;
+      }
+      renderInvoiceErrorElement(
+        element,
+        invoiceNumber,
+        error,
+        cacheKey,
+        { notify: options.context === 'detail' },
+      );
+    });
 }
 
 function normalizeText(value) {
@@ -2343,6 +2834,7 @@ function handleLogout(auto = false) {
   clearStoredToken();
   state.token = null;
   state.user = null;
+  resetInvoiceCaches();
   state.orders = [];
   state.tailors = [];
   state.vendors = [];
@@ -2657,9 +3149,7 @@ function renderCustomerOrderHistory(customer) {
 
     const invoice = document.createElement('p');
     invoice.className = 'customer-order-history-item-invoice';
-    invoice.textContent = order.invoice_number
-      ? `Factura: ${order.invoice_number}`
-      : 'Factura: Sin número registrado';
+    updateInvoiceInfoDisplay(invoice, order, { context: 'history' });
 
     const meta = document.createElement('p');
     meta.className = 'customer-order-history-item-meta';
@@ -3042,6 +3532,9 @@ function populateOrderDetail(order, options = {}) {
   if (orderDetailInvoiceInput) {
     orderDetailInvoiceInput.value = order.invoice_number || '';
   }
+  if (orderDetailInvoiceInfo) {
+    updateInvoiceInfoDisplay(orderDetailInvoiceInfo, order, { context: 'detail' });
+  }
   if (orderDetailOriginSelect) {
     populateEstablishmentSelect(orderDetailOriginSelect, order.origin_branch || '');
   }
@@ -3103,6 +3596,9 @@ function clearOrderDetail(options = {}) {
   if (orderDetailTailorSelect) populateTailorSelect(orderDetailTailorSelect);
   if (orderDetailVendorSelect) populateVendorSelect(orderDetailVendorSelect);
   if (orderDetailInvoiceInput) orderDetailInvoiceInput.value = '';
+  if (orderDetailInvoiceInfo) {
+    renderInvoicePlaceholder(orderDetailInvoiceInfo, '', 'Sin número registrado', { muted: true });
+  }
   if (orderDetailOriginSelect) populateEstablishmentSelect(orderDetailOriginSelect);
   if (orderDetailDeliveryDateInput) orderDetailDeliveryDateInput.value = '';
   if (orderDetailNotesTextarea) orderDetailNotesTextarea.value = '';
@@ -3191,6 +3687,18 @@ async function handleOrderUpdate(event) {
       },
     });
     orderUpdatedSuccessfully = true;
+    clearInvoiceCacheForOrder(state.selectedOrderId);
+    if (orderDetailInvoiceInfo) {
+      if (invoiceValueRaw) {
+        updateInvoiceInfoDisplay(
+          orderDetailInvoiceInfo,
+          { id: state.selectedOrderId, invoice_number: invoiceValueRaw },
+          { context: 'detail' },
+        );
+      } else {
+        renderInvoicePlaceholder(orderDetailInvoiceInfo, '', 'Sin número registrado', { muted: true });
+      }
+    }
     if (affectedCustomerId) {
       delete state.customerOrdersCache[String(affectedCustomerId)];
       delete state.customerDisplayCache[String(affectedCustomerId)];
@@ -3552,6 +4060,7 @@ if (deleteOrderButton) {
     try {
       await apiFetch(`/orders/${orderId}`, { method: 'DELETE' });
       showToast('Orden eliminada correctamente.', 'success');
+      clearInvoiceCacheForOrder(orderId);
       if (affectedCustomerId !== null && affectedCustomerId !== undefined) {
         delete state.customerOrdersCache[String(affectedCustomerId)];
         delete state.customerDisplayCache[String(affectedCustomerId)];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -538,6 +538,7 @@
                   <div class="form-row">
                     <label for="orderDetailInvoice">Número de factura</label>
                     <input type="text" id="orderDetailInvoice" />
+                    <div id="orderDetailInvoiceInfo" class="invoice-meta muted small"></div>
                   </div>
                   <div class="form-row">
                     <label for="orderDetailStatus">Estado</label>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -784,6 +784,94 @@ button[disabled] {
   color: var(--primary-dark);
 }
 
+.invoice-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.order-detail .invoice-meta {
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.invoice-meta-number {
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.invoice-meta-note {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.invoice-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(17, 17, 17, 0.08);
+  color: var(--primary-dark);
+  font-weight: 700;
+}
+
+.invoice-chip--success {
+  background: rgba(15, 129, 66, 0.16);
+  color: #0f8142;
+}
+
+.invoice-chip--pending {
+  background: rgba(255, 153, 0, 0.18);
+  color: #b15000;
+}
+
+.invoice-chip--info {
+  background: rgba(17, 17, 17, 0.08);
+}
+
+.invoice-chip--error {
+  background: rgba(158, 8, 8, 0.18);
+  color: #8a1010;
+}
+
+.invoice-meta-amount {
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.invoice-meta-links {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.invoice-meta-links a {
+  color: var(--primary);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.invoice-meta-error {
+  color: #8a1010;
+  font-weight: 600;
+}
+
+.invoice-meta.has-pending-balance .invoice-meta-number,
+.invoice-meta.has-pending-balance .invoice-meta-amount {
+  color: #b15000;
+}
+
+.customer-order-history-item-invoice.invoice-meta {
+  margin-top: 0.25rem;
+}
+
 
 .tag.muted-tag {
   background: rgba(89, 90, 90, 0.18);


### PR DESCRIPTION
## Summary
- track invoice pending-balance notifications in the frontend cache helpers
- show a warning toast when an order's invoice still has an outstanding balance in the order detail view

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0459cef788332b1abb3ab3e0412ad