### PR TITLE
Add Contifico company parameter handling

### DIFF
--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -40,6 +40,7 @@ class ContificoClient:
         client: Optional[httpx.Client] = None,
         sleep_func: Callable[[float], None] = time.sleep,
         monotonic_func: Callable[[], float] = time.monotonic,
+        company_id: Optional[str] = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         if not api_key or not api_token:
@@ -55,6 +56,7 @@ class ContificoClient:
         self._sleep = sleep_func
         self._monotonic = monotonic_func
         self._request_timestamps: Deque[float] = deque()
+        self.company_id = company_id
 
     def close(self) -> None:
         """Close the underlying HTTP client."""
@@ -103,6 +105,11 @@ class ContificoClient:
             "api-key": self.api_key,
         }
 
+        request_params = dict(params) if params else {}
+        if self.company_id:
+            for key in ("empresa", "empresa_id"):
+                request_params.setdefault(key, self.company_id)
+
         attempt = 0
         while True:
             self._respect_rate_limit()
@@ -111,7 +118,7 @@ class ContificoClient:
                 response = self._client.request(
                     method,
                     url,
-                    params=params,
+                    params=request_params or None,
                     json=json,
                     headers=headers,
                     timeout=self.timeout,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -123,6 +123,7 @@ def get_contifico_client_dependency() -> Generator[ContificoClient, None, None]:
         rate_limit_per_minute=settings.contifico_rate_limit_per_minute,
         max_retries=settings.contifico_max_retries,
         retry_backoff_seconds=settings.contifico_retry_backoff_seconds,
+        company_id=settings.contifico_company_id,
     )
     try:
         yield client

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -17,7 +17,7 @@ from app.integrations import (  # noqa: E402
 )
 
 
-def build_contifico_client(handler, **kwargs):
+def build_contifico_client(handler, *, company_id: str | None = "EMP-001", **kwargs):
     client = ContificoClient(
         base_url="https://api.example.com/sistema/api/v1",
         api_key="key-123",
@@ -26,6 +26,7 @@ def build_contifico_client(handler, **kwargs):
         rate_limit_per_minute=100,
         sleep_func=lambda _seconds: None,
         client=httpx.Client(transport=httpx.MockTransport(handler)),
+        company_id=company_id,
         **kwargs,
     )
     return client
@@ -36,19 +37,23 @@ def test_create_invoice_builds_expected_request():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["path"] = request.url.path
         captured["authorization"] = request.headers.get("authorization")
         captured["api-key"] = request.headers.get("api-key")
         captured["json"] = json.loads(request.content.decode())
+        captured["params"] = dict(request.url.params)
         return httpx.Response(201, json={"id": "INV-1"})
 
     client = build_contifico_client(handler)
     response = client.create_invoice({"total": 100})
 
     assert response == {"id": "INV-1"}
-    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/"
+    assert captured["path"] == "/sistema/api/v1/documento/"
     assert captured["authorization"] == "Bearer token-abc"
     assert captured["api-key"] == "key-123"
     assert captured["json"] == {"total": 100}
+    assert captured["params"]["empresa"] == "EMP-001"
+    assert captured["params"]["empresa_id"] == "EMP-001"
 
 
 def test_update_invoice_uses_company_id_and_json():
@@ -56,15 +61,19 @@ def test_update_invoice_uses_company_id_and_json():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["path"] = request.url.path
         captured["json"] = json.loads(request.content.decode())
+        captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"status": "ok"})
 
     client = build_contifico_client(handler)
     response = client.update_invoice("INV-2", {"total": 200})
 
     assert response == {"status": "ok"}
-    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/"
+    assert captured["path"] == "/sistema/api/v1/documento/"
     assert captured["json"] == {"id": "INV-2", "total": 200}
+    assert captured["params"]["empresa"] == "EMP-001"
+    assert captured["params"]["empresa_id"] == "EMP-001"
 
 
 def test_get_invoice_fetches_specific_document():
@@ -72,13 +81,17 @@ def test_get_invoice_fetches_specific_document():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["path"] = request.url.path
+        captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"id": "INV-25"})
 
     client = build_contifico_client(handler)
     response = client.get_invoice("INV-25")
 
     assert response == {"id": "INV-25"}
-    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/INV-25/"
+    assert captured["path"] == "/sistema/api/v1/documento/INV-25/"
+    assert captured["params"]["empresa"] == "EMP-001"
+    assert captured["params"]["empresa_id"] == "EMP-001"
 
 
 def test_get_customer_by_document_sets_query_param():
@@ -86,6 +99,7 @@ def test_get_customer_by_document_sets_query_param():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"items": []})
 
     client = build_contifico_client(handler)
@@ -93,8 +107,39 @@ def test_get_customer_by_document_sets_query_param():
 
     assert (
         captured["url"]
-        == "https://api.example.com/sistema/api/v1/persona/?identificacion=0909090909"
+        == "https://api.example.com/sistema/api/v1/persona/?identificacion=0909090909&empresa=EMP-001&empresa_id=EMP-001"
     )
+    assert captured["params"]["identificacion"] == "0909090909"
+    assert captured["params"]["empresa"] == "EMP-001"
+    assert captured["params"]["empresa_id"] == "EMP-001"
+
+
+def test_company_id_does_not_override_explicit_param():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"items": []})
+
+    client = build_contifico_client(handler)
+    client._request("GET", "persona/", params={"empresa": "EXPL", "otro": "valor"})
+
+    assert captured["params"]["empresa"] == "EXPL"
+    assert captured["params"]["otro"] == "valor"
+    assert captured["params"]["empresa_id"] == "EMP-001"
+
+
+def test_omits_company_params_when_not_configured():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"items": []})
+
+    client = build_contifico_client(handler, company_id=None)
+    client.get_customer_by_document("0101010101")
+
+    assert captured["params"] == {"identificacion": "0101010101"}
 
 
 def test_raises_transient_on_rate_limit():

--- a/backend/tests/test_order_invoice_endpoint.py
+++ b/backend/tests/test_order_invoice_endpoint.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
@@ -14,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app import auth, main, models  # noqa: E402
 from app.database import Base  # noqa: E402
-from app.integrations import ContificoError  # noqa: E402
+from app.integrations import ContificoClient, ContificoError  # noqa: E402
 
 
 engine = create_engine(
@@ -154,3 +155,85 @@ def test_get_order_invoice_handles_contifico_errors(db_session):
 
     assert exc_info.value.status_code == 502
     assert "Contifico" in exc_info.value.detail
+
+
+def test_get_order_invoice_forwards_company_param(db_session):
+    admin = create_user(db_session, "admin", models.UserRole.ADMIN)
+    order = create_order(db_session, invoice_number="INV-600")
+
+    payload = {
+        "estado": "AUTORIZADO",
+        "estado_pago": "PAGADO",
+        "totales": {
+            "subtotal": "100",
+            "impuestos": "12",
+            "total": "112",
+            "pagado": "112",
+        },
+        "fecha_pago": "2024-02-05T10:15:00",
+        "links": {
+            "pdf": "https://contifico.example/pdf/INV-600",
+            "publico": "https://contifico.example/share/INV-600",
+        },
+    }
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(dict(request.url.params))
+        return httpx.Response(200, json=payload)
+
+    contifico_client = ContificoClient(
+        base_url="https://api.example.com/sistema/api/v1",
+        api_key="key-123",
+        api_token="token-abc",
+        rate_limit_per_minute=100,
+        max_retries=0,
+        sleep_func=lambda _seconds: None,
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        company_id="EMP-ORDER",
+    )
+
+    try:
+        summary = main.get_order_invoice_endpoint(
+            order.id,
+            db_session,
+            admin,
+            contifico_client=contifico_client,
+        )
+    finally:
+        contifico_client.close()
+
+    assert captured["empresa"] == "EMP-ORDER"
+    assert captured["empresa_id"] == "EMP-ORDER"
+    assert summary.download_url == "https://contifico.example/pdf/INV-600"
+    assert summary.share_url == "https://contifico.example/share/INV-600"
+
+
+def test_get_contifico_client_dependency_includes_company_id(monkeypatch):
+    monkeypatch.setattr(main.settings, "contifico_api_key", "key-123")
+    monkeypatch.setattr(main.settings, "contifico_api_token", "token-456")
+    monkeypatch.setattr(main.settings, "contifico_company_id", "EMP-XYZ")
+
+    created_clients = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+            created_clients.append(self)
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(main, "ContificoClient", FakeClient)
+
+    dependency = main.get_contifico_client_dependency()
+    client = next(dependency)
+
+    assert created_clients[0].kwargs["company_id"] == "EMP-XYZ"
+    assert client is created_clients[0]
+
+    with pytest.raises(StopIteration):
+        next(dependency)
+
+    assert created_clients[0].closed is True


### PR DESCRIPTION
## Summary
- add optional `company_id` support to `ContificoClient` so requests automatically append the empresa identifiers when configured
- propagate `settings.contifico_company_id` through the Contifico dependency factory
- expand Contifico integration and invoice endpoint tests to cover company parameter forwarding

## Testing
- pytest backend/tests/test_contifico_integration.py backend/tests/test_order_invoice_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ae02883883329382c5a3d30c33ec