### PR TITLE
Align Contifico client authentication headers

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -99,8 +99,9 @@ CONTIFICO_RETRY_BACKOFF_SECONDS=2
 EOF
 ```
 
-El cliente envía ambos encabezados (`Authorization: Bearer <token>` y `api-key: <clave>`) tal
-como exige la documentación de Contifico. Puedes utilizar el
+El cliente envía el encabezado `Authorization` con la API key (sin el prefijo `Bearer`),
+replicando el esquema de autenticación del plugin oficial de WooCommerce y evitando
+duplicar el valor en un encabezado `api-key` separado. Puedes utilizar el
 helper `ContificoClient` para crear y actualizar facturas o consultar clientes por identificación:
 
 ```python

--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -101,11 +101,13 @@ class ContificoClient:
     ) -> Dict[str, Any]:
         url = self._build_url(path)
         headers = {
-            "Authorization": f"Bearer {self.api_token}",
-            "api-key": self.api_key,
+            "Authorization": self.api_key,
         }
 
         request_params = dict(params) if params else {}
+        if self.company_id and params is not None:
+            request_params.setdefault("empresa", self.company_id)
+            request_params.setdefault("empresa_id", self.company_id)
 
         attempt = 0
         while True:

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -49,8 +49,8 @@ def test_create_invoice_builds_expected_request():
 
     assert response == {"id": "INV-1"}
     assert captured["path"] == "/sistema/api/v1/documento/"
-    assert captured["authorization"] == "Bearer token-abc"
-    assert captured["api-key"] == "key-123"
+    assert captured["authorization"] == "key-123"
+    assert captured["api-key"] is None
     assert captured["json"] == {"total": 100}
     assert captured["params"] == {}
 
@@ -107,7 +107,8 @@ def test_get_customer_by_document_sets_query_param():
         == "https://api.example.com/sistema/api/v1/persona/?identificacion=0909090909&empresa=EMP-001&empresa_id=EMP-001"
     )
     assert captured["params"]["identificacion"] == "0909090909"
-    assert "empresa_id" not in captured["params"]
+    assert captured["params"]["empresa"] == "EMP-001"
+    assert captured["params"]["empresa_id"] == "EMP-001"
 
 
 def test_omits_company_params_when_not_configured():
@@ -117,7 +118,7 @@ def test_omits_company_params_when_not_configured():
         captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"items": []})
 
-    client = build_contifico_client(handler)
+    client = build_contifico_client(handler, company_id=None)
     client.get_customer_by_document("0101010101")
 
     assert captured["params"] == {"identificacion": "0101010101"}


### PR DESCRIPTION
## Summary
- update the Contifico client to send the API key through the Authorization header and mirror the WooCommerce plugin behaviour
- ensure company-specific query parameters are added when configured and update the associated tests
- refresh the Contifico README section to document the revised authentication scheme

## Testing
- pytest backend/tests/test_contifico_integration.py backend/tests/test_order_invoice_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68e11a16ad8c8332bef8f2b4310e9971