### PR TITLE
Align Contifico auth headers with WooCommerce client

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -90,7 +90,6 @@ cat <<'EOF' >> .env
 CONTIFICO_BASE_URL="https://api.contifico.com/sistema/api/v1"
 CONTIFICO_API_KEY="tu-api-key-entregada-por-contifico"
 CONTIFICO_API_TOKEN="tu-api-token-entregado-por-contifico"
-CONTIFICO_COMPANY_ID="opcional-si-tu-empresa-lo-requiere"
 CONTIFICO_TIMEOUT_SECONDS=30
 CONTIFICO_RATE_LIMIT_PER_MINUTE=50
 CONTIFICO_MAX_RETRIES=3
@@ -98,10 +97,15 @@ CONTIFICO_RETRY_BACKOFF_SECONDS=2
 EOF
 ```
 
-El cliente envía ambos encabezados (`Authorization: Bearer <token>` y `api-key: <clave>`) tal
-como exige la documentación de Contifico. Puedes utilizar el helper `ContificoClient`
-para crear y actualizar
-facturas o consultar clientes por identificación:
+El cliente envía la llave (`API KEY`) directamente en el encabezado `Authorization` y adjunta los
+encabezados estándar de JSON (`Accept` y `Content-Type`) igual que la integración oficial de
+WooCommerce. No es necesario configurar ningún identificador de empresa adicional: con la llave
+(`API KEY`) y el token (`API TOKEN`) es suficiente para consumir los endpoints. Para instalaciones
+heredadas todavía se acepta la variable opcional `CONTIFICO_COMPANY_ID`, pero no es requerida por
+el flujo actual.
+
+Puedes utilizar el
+helper `ContificoClient` para crear y actualizar facturas o consultar clientes por identificación:
 
 ```python
 from app.integrations import ContificoClient

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -63,8 +63,10 @@ class Settings(BaseSettings):
     contifico_company_id: str | None = Field(
         None,
         description=(
-            "Optional company identifier for Contifico operations when required by "
-            "specific endpoints. Loaded from CONTIFICO_COMPANY_ID or the .env file."
+            "Optional Contifico company identifier kept only for backwards compatibility. "
+            "The integration works with just the API key and token, so this value is not "
+            "required. Loaded from the CONTIFICO_COMPANY_ID environment variable or the .env "
+            "file when present."
         ),
     )
     contifico_timeout_seconds: float = Field(

--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -99,9 +99,12 @@ class ContificoClient:
     ) -> Dict[str, Any]:
         url = self._build_url(path)
         headers = {
-            "Authorization": f"Bearer {self.api_token}",
-            "api-key": self.api_key,
+            "Authorization": self.api_key,
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=UTF-8",
         }
+
+        request_params = dict(params) if params else {}
 
         attempt = 0
         while True:
@@ -111,7 +114,7 @@ class ContificoClient:
                 response = self._client.request(
                     method,
                     url,
-                    params=params,
+                    params=request_params or None,
                     json=json,
                     headers=headers,
                     timeout=self.timeout,

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -36,35 +36,45 @@ def test_create_invoice_builds_expected_request():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["path"] = request.url.path
         captured["authorization"] = request.headers.get("authorization")
+        captured["accept"] = request.headers.get("accept")
+        captured["content-type"] = request.headers.get("content-type")
         captured["api-key"] = request.headers.get("api-key")
         captured["json"] = json.loads(request.content.decode())
+        captured["params"] = dict(request.url.params)
         return httpx.Response(201, json={"id": "INV-1"})
 
     client = build_contifico_client(handler)
     response = client.create_invoice({"total": 100})
 
     assert response == {"id": "INV-1"}
-    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/"
-    assert captured["authorization"] == "Bearer token-abc"
-    assert captured["api-key"] == "key-123"
+    assert captured["path"] == "/sistema/api/v1/documento/"
+    assert captured["authorization"] == "key-123"
+    assert captured["accept"] == "application/json"
+    assert captured["content-type"] == "application/json; charset=UTF-8"
+    assert captured["api-key"] is None
     assert captured["json"] == {"total": 100}
+    assert captured["params"] == {}
 
 
-def test_update_invoice_uses_company_id_and_json():
+def test_update_invoice_sends_payload():
     captured = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["path"] = request.url.path
         captured["json"] = json.loads(request.content.decode())
+        captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"status": "ok"})
 
     client = build_contifico_client(handler)
     response = client.update_invoice("INV-2", {"total": 200})
 
     assert response == {"status": "ok"}
-    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/"
+    assert captured["path"] == "/sistema/api/v1/documento/"
     assert captured["json"] == {"id": "INV-2", "total": 200}
+    assert captured["params"] == {}
 
 
 def test_get_invoice_fetches_specific_document():
@@ -72,13 +82,16 @@ def test_get_invoice_fetches_specific_document():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["path"] = request.url.path
+        captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"id": "INV-25"})
 
     client = build_contifico_client(handler)
     response = client.get_invoice("INV-25")
 
     assert response == {"id": "INV-25"}
-    assert captured["url"] == "https://api.example.com/sistema/api/v1/documento/INV-25/"
+    assert captured["path"] == "/sistema/api/v1/documento/INV-25/"
+    assert captured["params"] == {}
 
 
 def test_get_customer_by_document_sets_query_param():
@@ -86,6 +99,7 @@ def test_get_customer_by_document_sets_query_param():
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"items": []})
 
     client = build_contifico_client(handler)
@@ -95,6 +109,21 @@ def test_get_customer_by_document_sets_query_param():
         captured["url"]
         == "https://api.example.com/sistema/api/v1/persona/?identificacion=0909090909"
     )
+    assert captured["params"]["identificacion"] == "0909090909"
+    assert "empresa_id" not in captured["params"]
+
+
+def test_omits_company_params_when_not_configured():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"items": []})
+
+    client = build_contifico_client(handler)
+    client.get_customer_by_document("0101010101")
+
+    assert captured["params"] == {"identificacion": "0101010101"}
 
 
 def test_raises_transient_on_rate_limit():

--- a/backend/tests/test_order_invoice_endpoint.py
+++ b/backend/tests/test_order_invoice_endpoint.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
@@ -14,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app import auth, main, models  # noqa: E402
 from app.database import Base  # noqa: E402
-from app.integrations import ContificoError  # noqa: E402
+from app.integrations import ContificoClient, ContificoError  # noqa: E402
 
 
 engine = create_engine(
@@ -154,3 +155,83 @@ def test_get_order_invoice_handles_contifico_errors(db_session):
 
     assert exc_info.value.status_code == 502
     assert "Contifico" in exc_info.value.detail
+
+
+def test_get_order_invoice_requests_invoice(db_session):
+    admin = create_user(db_session, "admin", models.UserRole.ADMIN)
+    order = create_order(db_session, invoice_number="INV-600")
+
+    payload = {
+        "estado": "AUTORIZADO",
+        "estado_pago": "PAGADO",
+        "totales": {
+            "subtotal": "100",
+            "impuestos": "12",
+            "total": "112",
+            "pagado": "112",
+        },
+        "fecha_pago": "2024-02-05T10:15:00",
+        "links": {
+            "pdf": "https://contifico.example/pdf/INV-600",
+            "publico": "https://contifico.example/share/INV-600",
+        },
+    }
+    requested_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        return httpx.Response(200, json=payload)
+
+    contifico_client = ContificoClient(
+        base_url="https://api.example.com/sistema/api/v1",
+        api_key="key-123",
+        api_token="token-abc",
+        rate_limit_per_minute=100,
+        max_retries=0,
+        sleep_func=lambda _seconds: None,
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+    try:
+        summary = main.get_order_invoice_endpoint(
+            order.id,
+            db_session,
+            admin,
+            contifico_client=contifico_client,
+        )
+    finally:
+        contifico_client.close()
+
+    assert requested_urls == [
+        "https://api.example.com/sistema/api/v1/documento/INV-600/"
+    ]
+    assert summary.download_url == "https://contifico.example/pdf/INV-600"
+    assert summary.share_url == "https://contifico.example/share/INV-600"
+
+
+def test_get_contifico_client_dependency(monkeypatch):
+    monkeypatch.setattr(main.settings, "contifico_api_key", "key-123")
+    monkeypatch.setattr(main.settings, "contifico_api_token", "token-456")
+
+    created_clients = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+            created_clients.append(self)
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(main, "ContificoClient", FakeClient)
+
+    dependency = main.get_contifico_client_dependency()
+    client = next(dependency)
+
+    assert client is created_clients[0]
+
+    with pytest.raises(StopIteration):
+        next(dependency)
+
+    assert created_clients[0].closed is True


### PR DESCRIPTION
## Summary
- clarify the Contifico setup instructions so they emphasize API key/token usage and describe the Authorization header behavior that matches the WooCommerce integration
- align the Contifico client authentication to send the API key in the Authorization header and refresh the tests to cover the new headers

## Testing
- pytest backend/tests/test_contifico_integration.py backend/tests/test_order_invoice_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ae02883883329382c5a3d30c33ec