### PR TITLE
Restore Contifico token header

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -97,12 +97,12 @@ CONTIFICO_RETRY_BACKOFF_SECONDS=2
 EOF
 ```
 
-El cliente envía la llave (`API KEY`) directamente en el encabezado `Authorization` y adjunta los
-encabezados estándar de JSON (`Accept` y `Content-Type`) igual que la integración oficial de
-WooCommerce. No es necesario configurar ningún identificador de empresa adicional: con la llave
-(`API KEY`) y el token (`API TOKEN`) es suficiente para consumir los endpoints. Para instalaciones
-heredadas todavía se acepta la variable opcional `CONTIFICO_COMPANY_ID`, pero no es requerida por
-el flujo actual.
+El cliente envía la llave (`API KEY`) directamente en el encabezado `Authorization`, el token en el
+encabezado `api-token` y adjunta los encabezados estándar de JSON (`Accept` y `Content-Type`) igual
+que la integración oficial de WooCommerce. No es necesario configurar ningún identificador de
+empresa adicional: con la llave (`API KEY`) y el token (`API TOKEN`) es suficiente para consumir los
+endpoints. Para instalaciones heredadas todavía se acepta la variable opcional
+`CONTIFICO_COMPANY_ID`, pero no es requerida por el flujo actual.
 
 Puedes utilizar el
 helper `ContificoClient` para crear y actualizar facturas o consultar clientes por identificación:

--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -103,6 +103,7 @@ class ContificoClient:
         url = self._build_url(path)
         headers = {
             "Authorization": self.api_key,
+            "api-token": self.api_token,
             "Accept": "application/json",
             "Content-Type": "application/json; charset=UTF-8",
         }

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -41,7 +41,7 @@ def test_create_invoice_builds_expected_request():
         captured["authorization"] = request.headers.get("authorization")
         captured["accept"] = request.headers.get("accept")
         captured["content-type"] = request.headers.get("content-type")
-        captured["api-key"] = request.headers.get("api-key")
+        captured["api-token"] = request.headers.get("api-token")
         captured["json"] = json.loads(request.content.decode())
         captured["params"] = dict(request.url.params)
         return httpx.Response(201, json={"id": "INV-1"})
@@ -54,7 +54,7 @@ def test_create_invoice_builds_expected_request():
     assert captured["authorization"] == "key-123"
     assert captured["accept"] == "application/json"
     assert captured["content-type"] == "application/json; charset=UTF-8"
-    assert captured["api-key"] is None
+    assert captured["api-token"] == "token-abc"
     assert captured["json"] == {"total": 100}
     assert captured["params"] == {}
 


### PR DESCRIPTION
## Summary
- add the Contifico `api-token` header back into the client so authenticated calls keep working
- refresh the README notes to document that the key goes in `Authorization` and the token in `api-token`
- update the Contifico integration test to assert that the token header is sent

## Testing
- pytest backend/tests/test_contifico_integration.py backend/tests/test_order_invoice_endpoint.py *(fails: assertions about company parameters already failing on main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68e1267ec35483328eda064fdcef20e8