### PR TITLE
Add Contifico persona lookup fallback for invoice retrieval

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -97,12 +97,17 @@ CONTIFICO_RETRY_BACKOFF_SECONDS=2
 EOF
 ```
 
-El cliente envía la llave (`API KEY`) directamente en el encabezado `Authorization` y adjunta los
-encabezados estándar de JSON (`Accept` y `Content-Type`) igual que la integración oficial de
-WooCommerce. No es necesario configurar ningún identificador de empresa adicional: con la llave
-(`API KEY`) y el token (`API TOKEN`) es suficiente para consumir los endpoints. Para instalaciones
-heredadas todavía se acepta la variable opcional `CONTIFICO_COMPANY_ID`, pero no es requerida por
-el flujo actual.
+El cliente envía la llave (`API KEY`) directamente en el encabezado `Authorization`, el token en el
+encabezado `api-token` y adjunta los encabezados estándar de JSON (`Accept` y `Content-Type`) igual
+que la integración oficial de WooCommerce. Para las consultas de facturas se agregan filtros por el
+`numero` completo y sus partes (`establecimiento`, `pto_emision` y `secuencial`) con el objetivo de
+acelerar la búsqueda y evitar que Contifico tarde en responder cuando existen muchos documentos.
+Cuando Contifico responde con un error transitorio el cliente vuelve a intentar la consulta
+obteniendo primero el listado de documentos del cliente (`persona_identificacion`) y, con el `numero`
+correspondiente, recupera el detalle por `documento/<ID>` tal como indica la
+[documentación oficial](https://contifico.github.io/registro/documento/). Si tu instancia requiere
+fijar un identificador de empresa, define la variable opcional `CONTIFICO_COMPANY_ID` para incluirlo
+automáticamente en cada solicitud.
 
 Puedes utilizar el
 helper `ContificoClient` para crear y actualizar facturas o consultar clientes por identificación:

--- a/backend/app/integrations/contifico.py
+++ b/backend/app/integrations/contifico.py
@@ -103,6 +103,7 @@ class ContificoClient:
         url = self._build_url(path)
         headers = {
             "Authorization": self.api_key,
+            "api-token": self.api_token,
             "Accept": "application/json",
             "Content-Type": "application/json; charset=UTF-8",
         }
@@ -125,7 +126,7 @@ class ContificoClient:
                 )
             except httpx.RequestError as exc:  # pragma: no cover - httpx RequestError holds detail
                 logger.warning("Transient network error contacting Contifico: %s", exc)
-                if attempt >= self.max_retries:
+                if attempt >= allowed_retries:
                     raise ContificoTransientError("Network error contacting Contifico") from exc
             else:
                 if response.status_code == httpx.codes.TOO_MANY_REQUESTS:
@@ -173,23 +174,102 @@ class ContificoClient:
         body["id"] = invoice_id
         return self._request("PUT", "documento/", json=body)
 
-    def get_invoice(self, invoice_id: str) -> Dict[str, Any]:
+    def get_invoice(
+        self,
+        invoice_id: str,
+        *,
+        customer_document: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Fetch a Contifico document by its identifier."""
 
         if "-" in invoice_id and invoice_id.replace("-", "").isdigit():
-            params = {"numero": invoice_id}
-            return self._request("GET", "documento/", params=params, max_retries=0)
+            parts = invoice_id.split("-")
+            params: Dict[str, Any] = {"numero": invoice_id}
+            if len(parts) == 3:
+                establecimiento, pto_emision, secuencial = parts
+                params.update(
+                    {
+                        "establecimiento": establecimiento,
+                        "pto_emision": pto_emision,
+                        "secuencial": secuencial,
+                    }
+                )
+            if self.company_id:
+                params["empresa"] = self.company_id
+            try:
+                return self._request("GET", "documento/", params=params)
+            except ContificoTransientError:
+                if not customer_document:
+                    raise
+                logger.info(
+                    "Falling back to Contifico persona lookup for invoice %s", invoice_id
+                )
+                fallback_invoice = self._lookup_invoice_by_customer_document(
+                    invoice_number=invoice_id,
+                    customer_document=customer_document,
+                )
+                if fallback_invoice is not None:
+                    return fallback_invoice
+                raise
 
-        params = None
+        params = self._build_company_detail_params()
+
+        return self._request("GET", f"documento/{invoice_id}/", params=params)
+
+    def _build_company_detail_params(self) -> Optional[Dict[str, Any]]:
+        if not self.company_id:
+            return None
+        return {"empresa": self.company_id, "empresa_id": self.company_id}
+
+    def _lookup_invoice_by_customer_document(
+        self,
+        *,
+        invoice_number: str,
+        customer_document: str,
+    ) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {"persona_identificacion": customer_document}
         if self.company_id:
-            params = {"empresa": self.company_id, "empresa_id": self.company_id}
+            params["empresa"] = self.company_id
 
-        return self._request("GET", f"documento/{invoice_id}/", params=params, max_retries=0)
+        listing = self._request("GET", "registro/documento/", params=params)
+        documents = self._extract_document_listing(listing)
+        for document in documents:
+            if not isinstance(document, dict):
+                continue
+            numero = document.get("numero") or document.get("documento_numero")
+            if numero != invoice_number:
+                continue
+            document_id = (
+                document.get("documento")
+                or document.get("documento_id")
+                or document.get("id")
+            )
+            if not document_id:
+                return document
+            return self._request(
+                "GET",
+                f"documento/{document_id}/",
+                params=self._build_company_detail_params(),
+            )
+        return None
+
+    @staticmethod
+    def _extract_document_listing(payload: Any) -> list[Dict[str, Any]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            for key in ("results", "items", "data", "documentos"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return [item for item in value if isinstance(item, dict)]
+        return []
 
     def get_customer_by_document(self, document: str) -> Dict[str, Any]:
         """Fetch Contifico personas (clientes) filtered by identification number."""
 
         params = {"identificacion": document}
+        if self.company_id:
+            params.setdefault("empresa", self.company_id)
         return self._request("GET", "persona/", params=params)
 
     def __enter__(self) -> "ContificoClient":  # pragma: no cover - convenience

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -821,7 +821,10 @@ def get_order_invoice_endpoint(
         )
 
     try:
-        invoice_payload = contifico_client.get_invoice(invoice_number)
+        invoice_payload = contifico_client.get_invoice(
+            invoice_number,
+            customer_document=(order.customer_document or None),
+        )
     except ContificoError as exc:  # pragma: no cover - integration error path
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/backend/tests/test_contifico_integration.py
+++ b/backend/tests/test_contifico_integration.py
@@ -41,7 +41,7 @@ def test_create_invoice_builds_expected_request():
         captured["authorization"] = request.headers.get("authorization")
         captured["accept"] = request.headers.get("accept")
         captured["content-type"] = request.headers.get("content-type")
-        captured["api-key"] = request.headers.get("api-key")
+        captured["api-token"] = request.headers.get("api-token")
         captured["json"] = json.loads(request.content.decode())
         captured["params"] = dict(request.url.params)
         return httpx.Response(201, json={"id": "INV-1"})
@@ -54,7 +54,7 @@ def test_create_invoice_builds_expected_request():
     assert captured["authorization"] == "key-123"
     assert captured["accept"] == "application/json"
     assert captured["content-type"] == "application/json; charset=UTF-8"
-    assert captured["api-key"] is None
+    assert captured["api-token"] == "token-abc"
     assert captured["json"] == {"total": 100}
     assert captured["params"] == {}
 
@@ -92,7 +92,62 @@ def test_get_invoice_fetches_specific_document():
 
     assert response == {"id": "INV-25"}
     assert captured["path"] == "/sistema/api/v1/documento/INV-25/"
-    assert captured["params"] == {}
+    assert captured["params"] == {"empresa": "EMP-001", "empresa_id": "EMP-001"}
+
+
+def test_get_invoice_by_numero_includes_company_param():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"id": "001-001-000123456"})
+
+    client = build_contifico_client(handler)
+    response = client.get_invoice("001-001-000123456", customer_document="0991234567")
+
+    assert response == {"id": "001-001-000123456"}
+    assert captured["path"].endswith("/documento/")
+    assert captured["params"]["numero"] == "001-001-000123456"
+    assert captured["params"]["establecimiento"] == "001"
+    assert captured["params"]["pto_emision"] == "001"
+    assert captured["params"]["secuencial"] == "000123456"
+    assert captured["params"]["empresa"] == "EMP-001"
+
+
+def test_get_invoice_falls_back_to_persona_lookup():
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        if request.url.path == "/sistema/api/v1/documento/":
+            return httpx.Response(504, text="timeout")
+        if request.url.path.endswith("/registro/documento/"):
+            payload = {
+                "results": [
+                    {
+                        "numero": "001-005-000012717",
+                        "documento": "abc123",
+                    }
+                ]
+            }
+            return httpx.Response(200, json=payload)
+        if request.url.path.endswith("/documento/abc123/"):
+            return httpx.Response(200, json={"id": "abc123", "numero": "001-005-000012717"})
+        raise AssertionError(f"Unexpected path: {request.url.path}")
+
+    client = build_contifico_client(handler)
+    response = client.get_invoice(
+        "001-005-000012717",
+        customer_document="0999999999",
+    )
+
+    assert response == {"id": "abc123", "numero": "001-005-000012717"}
+    assert requested_paths == [
+        "/sistema/api/v1/documento/",
+        "/sistema/api/v1/registro/documento/",
+        "/sistema/api/v1/documento/abc123/",
+    ]
 
 
 def test_get_customer_by_document_sets_query_param():
@@ -108,10 +163,10 @@ def test_get_customer_by_document_sets_query_param():
 
     assert (
         captured["url"]
-        == "https://api.example.com/sistema/api/v1/persona/?identificacion=0909090909&empresa=EMP-001&empresa_id=EMP-001"
+        == "https://api.example.com/sistema/api/v1/persona/?identificacion=0909090909&empresa=EMP-001"
     )
     assert captured["params"]["identificacion"] == "0909090909"
-    assert "empresa_id" not in captured["params"]
+    assert captured["params"]["empresa"] == "EMP-001"
 
 
 def test_omits_company_params_when_not_configured():
@@ -121,7 +176,7 @@ def test_omits_company_params_when_not_configured():
         captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"items": []})
 
-    client = build_contifico_client(handler)
+    client = build_contifico_client(handler, company_id=None)
     client.get_customer_by_document("0101010101")
 
     assert captured["params"] == {"identificacion": "0101010101"}

--- a/backend/tests/test_order_invoice_endpoint.py
+++ b/backend/tests/test_order_invoice_endpoint.py
@@ -87,8 +87,8 @@ class DummyContificoClient:
         self.error = error
         self.requested_invoice = None
 
-    def get_invoice(self, invoice_id: str):
-        self.requested_invoice = invoice_id
+    def get_invoice(self, invoice_id: str, customer_document: str | None = None):
+        self.requested_invoice = (invoice_id, customer_document)
         if self.error:
             raise self.error
         return self.payload
@@ -141,7 +141,7 @@ def test_get_order_invoice_returns_summary(db_session):
     assert summary.payment_date == "2024-02-05T10:15:00"
     assert summary.download_url == "https://contifico.example/pdf/INV-500"
     assert summary.share_url == "https://contifico.example/share/INV-500"
-    assert client.requested_invoice == "INV-500"
+    assert client.requested_invoice == ("INV-500", "0991234567")
 
 
 def test_get_order_invoice_handles_contifico_errors(db_session):


### PR DESCRIPTION
## Summary
- add a persona_identificacion-based fallback for Contifico invoice lookups when numero queries fail with transient errors
- pass the customer's document to the invoice lookup endpoint and extend tests to cover the new flow
- document the fallback behaviour in the Contifico integration section of the README

## Testing
- pytest backend/tests/test_contifico_integration.py backend/tests/test_order_invoice_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68e1267ec35483328eda064fdcef20e8