### PR TITLE
Ensure Contífico client sends API token header

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -71,6 +71,7 @@ class ContificoClient:
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
         headers = {
             "Authorization": self.api_key,
+            "X-Api-Token": self.api_token,
             "Accept": "application/json",
             "Content-Type": "application/json; charset=UTF-8",
         }

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -29,6 +29,7 @@ def test_list_products_success() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["authorization"] = request.headers.get("Authorization")
+        captured["api_token"] = request.headers.get("X-Api-Token")
         captured["url"] = str(request.url)
         captured["params"] = dict(request.url.params)
         return httpx.Response(200, json=[{"id": 1, "codigo": "SKU-1"}])
@@ -45,6 +46,7 @@ def test_list_products_success() -> None:
 
     assert products == [{"id": 1, "codigo": "SKU-1"}]
     assert captured["authorization"] == "key123"
+    assert captured["api_token"] == "pos-token-abc"
     assert client.api_token == "pos-token-abc"
     params = captured["params"]
     assert isinstance(params, dict)
@@ -75,6 +77,8 @@ def test_list_products_error_response() -> None:
 def test_list_warehouses_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path.endswith("/bodega/")
+        assert request.headers.get("Authorization") == "key123"
+        assert request.headers.get("X-Api-Token") == "token-xyz"
         return httpx.Response(200, json=[{"id": 10, "codigo": "BOD"}])
 
     transport = httpx.MockTransport(handler)


### PR DESCRIPTION
## Summary
- ensure the Contífico client attaches the X-Api-Token header on every request
- assert the warehouse listing test captures both Authorization and X-Api-Token headers

## Testing
- pytest backend/tests/test_contifico_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e144aad6648332909a6a1ff9af7d85