### PR TITLE
Add Contífico invoice previews and search tooling

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -151,3 +151,66 @@ class ContificoClient:
             payload=data,
         )
 
+    def list_invoices(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+        customer_document: str | None = None,
+        document_number: str | None = None,
+    ) -> Iterable[Dict[str, Any]]:
+        """Obtiene facturas desde Contífico con los filtros disponibles."""
+
+        params: Dict[str, Any] = {"result_page": page, "result_size": page_size}
+        if customer_document:
+            params["cliente_identificacion"] = customer_document.strip()
+        if document_number:
+            params["numero_documento"] = document_number.strip()
+
+        data = self._request("GET", "factura/", params=params)
+        if data is None:
+            return []
+        if isinstance(data, list):
+            return data
+        raise ContificoAPIError(
+            status_code=200,
+            detail="El formato de respuesta para facturas no es el esperado.",
+            payload=data,
+        )
+
+    def list_invoices_by_customer_document(
+        self,
+        document_id: str,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> Iterable[Dict[str, Any]]:
+        """Lista facturas usando la identificación del cliente registrado en Contífico."""
+
+        if not document_id or not document_id.strip():
+            raise ValueError("El número de documento del cliente es obligatorio.")
+        return self.list_invoices(
+            page=page,
+            page_size=page_size,
+            customer_document=document_id.strip(),
+        )
+
+    def find_invoice_by_document_number(
+        self, document_number: str
+    ) -> Optional[Dict[str, Any]]:
+        """Busca una factura específica por su número de documento."""
+
+        if not document_number or not document_number.strip():
+            raise ValueError("El número de documento de la factura es obligatorio.")
+
+        invoices = list(
+            self.list_invoices(
+                page=1,
+                page_size=1,
+                document_number=document_number.strip(),
+            )
+        )
+        if not invoices:
+            return None
+        return invoices[0]
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -291,3 +291,61 @@ class ContificoWarehouse(BaseModel):
             direccion=payload.get("direccion"),
             raw=payload,
         )
+
+
+class ContificoInvoice(BaseModel):
+    id: Optional[Union[int, str]] = None
+    numero: Optional[str] = None
+    cliente: Optional[str] = None
+    identificacion: Optional[str] = None
+    fecha_emision: Optional[str] = None
+    estado: Optional[str] = None
+    total: Optional[float] = None
+    raw: Dict[str, Any] = Field(default_factory=dict, description="Respuesta original de Contífico.")
+
+    @classmethod
+    def from_api(cls, payload: Dict[str, Any]) -> "ContificoInvoice":
+        if not isinstance(payload, dict):
+            raise TypeError("La factura devuelta por Contífico debe ser un diccionario")
+
+        numero = (
+            payload.get("numero")
+            or payload.get("numero_documento")
+            or payload.get("numero_comprobante")
+        )
+        cliente = payload.get("cliente") or payload.get("cliente_nombre")
+        identificacion = (
+            payload.get("cliente_identificacion")
+            or payload.get("identificacion_cliente")
+            or payload.get("cliente_documento")
+            or payload.get("identificacion")
+        )
+        fecha = payload.get("fecha_emision") or payload.get("fecha") or payload.get("fecha_autorizacion")
+        estado = payload.get("estado") or payload.get("estado_sri")
+        total = (
+            payload.get("total")
+            or payload.get("total_con_impuestos")
+            or payload.get("total_sin_impuestos")
+        )
+
+        try:
+            normalized_total = float(total) if total is not None else None
+        except (TypeError, ValueError):
+            normalized_total = None
+
+        return cls(
+            id=payload.get("id"),
+            numero=numero,
+            cliente=cliente,
+            identificacion=identificacion,
+            fecha_emision=fecha,
+            estado=estado,
+            total=normalized_total,
+            raw=payload,
+        )
+
+
+class ContificoInvoicePage(BaseModel):
+    items: List[ContificoInvoice] = Field(default_factory=list)
+    page: int
+    page_size: int

--- a/backend/app/temp_contifico.py
+++ b/backend/app/temp_contifico.py
@@ -51,6 +51,54 @@ def build_warehouse_list(contifico_client: ContificoClient) -> list[schemas.Cont
     return [schemas.ContificoWarehouse.from_api(warehouse) for warehouse in warehouses]
 
 
+def build_invoice_page(
+    contifico_client: ContificoClient,
+    *,
+    page: int,
+    page_size: int,
+    document_id: str,
+) -> schemas.ContificoInvoicePage:
+    try:
+        invoices = contifico_client.list_invoices_by_customer_document(
+            document_id, page=page, page_size=page_size
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except ContificoTransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.detail,
+        ) from exc
+    except ContificoAPIError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    items = [schemas.ContificoInvoice.from_api(invoice) for invoice in invoices]
+    return schemas.ContificoInvoicePage(page=page, page_size=page_size, items=items)
+
+
+def fetch_invoice_by_document_number(
+    contifico_client: ContificoClient, *, document_number: str
+) -> schemas.ContificoInvoice:
+    try:
+        invoice = contifico_client.find_invoice_by_document_number(document_number)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except ContificoTransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.detail,
+        ) from exc
+    except ContificoAPIError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    if invoice is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No se encontró una factura con ese número de documento.",
+        )
+    return schemas.ContificoInvoice.from_api(invoice)
+
+
 @router.get("/products", response_model=schemas.ContificoProductPage)
 def preview_contifico_products(
     page: int = Query(default=1, ge=1),
@@ -75,8 +123,45 @@ def preview_contifico_warehouses(
     return build_warehouse_list(contifico_client)
 
 
+@router.get("/invoices/by-customer", response_model=schemas.ContificoInvoicePage)
+def preview_contifico_invoices_by_customer(
+    document_id: str = Query(..., min_length=3, max_length=30),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user=Depends(admin_required()),
+):
+    """Consulta facturas filtrando por la cédula o RUC del cliente."""
+
+    _ = current_user
+    normalized_document = document_id.strip()
+    return build_invoice_page(
+        contifico_client,
+        page=page,
+        page_size=page_size,
+        document_id=normalized_document,
+    )
+
+
+@router.get("/invoices/by-number", response_model=schemas.ContificoInvoice)
+def preview_contifico_invoice_by_number(
+    document_number: str = Query(..., min_length=3, max_length=40),
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user=Depends(admin_required()),
+):
+    """Busca una factura por su número de documento."""
+
+    _ = current_user
+    normalized_number = document_number.strip()
+    return fetch_invoice_by_document_number(
+        contifico_client, document_number=normalized_number
+    )
+
+
 __all__ = [
     "router",
     "build_product_page",
     "build_warehouse_list",
+    "build_invoice_page",
+    "fetch_invoice_by_document_number",
 ]

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -16,7 +16,12 @@ from app.contifico import (
     ContificoConfigurationError,
     ContificoTransportError,
 )
-from app.temp_contifico import build_product_page, build_warehouse_list
+from app.temp_contifico import (
+    build_invoice_page,
+    build_product_page,
+    build_warehouse_list,
+    fetch_invoice_by_document_number,
+)
 
 
 def test_client_requires_key_and_token() -> None:
@@ -97,6 +102,106 @@ def test_list_warehouses_success() -> None:
     assert warehouses == [{"id": 10, "codigo": "BOD"}]
 
 
+def test_list_invoices_success() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        assert request.url.path.endswith("/factura/")
+        return httpx.Response(200, json=[{"id": "inv-1", "numero": "001-001-0000001"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoices = list(
+        client.list_invoices(
+            page=3,
+            page_size=25,
+            customer_document="0912345678",
+            document_number="001-001-0000001",
+        )
+    )
+
+    assert len(invoices) == 1
+    params = captured["params"]
+    assert isinstance(params, dict)
+    assert params["result_page"] == "3"
+    assert params["result_size"] == "25"
+    assert params["cliente_identificacion"] == "0912345678"
+    assert params["numero_documento"] == "001-001-0000001"
+
+
+def test_list_invoices_requires_list_response() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"detalle": "unexpected"})
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    with pytest.raises(ContificoAPIError) as exc_info:
+        list(client.list_invoices())
+
+    assert "facturas" in exc_info.value.detail
+
+
+def test_list_invoices_by_customer_document_validates_input() -> None:
+    client = ContificoClient("key", "token")
+
+    with pytest.raises(ValueError):
+        list(client.list_invoices_by_customer_document(""))
+
+
+def test_find_invoice_by_document_number_returns_first() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params.get("numero_documento") == "001-001-0000001"
+        return httpx.Response(
+            200,
+            json=[
+                {"id": 1, "numero": "001-001-0000001"},
+                {"id": 2, "numero": "001-001-0000001"},
+            ],
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000001")
+
+    assert invoice == {"id": 1, "numero": "001-001-0000001"}
+
+
+def test_find_invoice_by_document_number_handles_missing() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000002")
+
+    assert invoice is None
+
+
 def test_build_product_page_success() -> None:
     class StubClient:
         def list_products(self, *, page: int, page_size: int):
@@ -148,3 +253,59 @@ def test_build_warehouse_list_propagates_http_error() -> None:
 
     assert exc_info.value.status_code == 400
     assert "Bad request" in exc_info.value.detail
+
+
+def test_build_invoice_page_success() -> None:
+    class StubClient:
+        def list_invoices_by_customer_document(self, document_id: str, *, page: int, page_size: int):
+            assert document_id == "0912345678"
+            assert page == 2
+            assert page_size == 10
+            return [
+                {"id": 1, "numero": "001-001-0000001", "cliente": "María"},
+                {"id": 2, "numero": "001-001-0000002", "cliente": "Juan"},
+            ]
+
+    result = build_invoice_page(StubClient(), page=2, page_size=10, document_id="0912345678")
+
+    assert result.page == 2
+    assert result.page_size == 10
+    assert len(result.items) == 2
+    assert result.items[0].numero == "001-001-0000001"
+
+
+def test_build_invoice_page_handles_errors() -> None:
+    class StubClient:
+        def list_invoices_by_customer_document(self, document_id: str, *, page: int, page_size: int):
+            raise ContificoTransportError("timeout")
+
+    with pytest.raises(HTTPException) as exc_info:
+        build_invoice_page(StubClient(), page=1, page_size=25, document_id="0912345678")
+
+    assert exc_info.value.status_code == 503
+    assert "timeout" in exc_info.value.detail
+
+
+def test_fetch_invoice_by_document_number_success() -> None:
+    class StubClient:
+        def find_invoice_by_document_number(self, document_number: str):
+            assert document_number == "001-001-0000003"
+            return {"id": 3, "numero": "001-001-0000003", "cliente": "Lucía"}
+
+    result = fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000003")
+
+    assert result.numero == "001-001-0000003"
+    assert result.cliente == "Lucía"
+
+
+def test_fetch_invoice_by_document_number_not_found() -> None:
+    class StubClient:
+        def find_invoice_by_document_number(self, document_number: str):
+            assert document_number == "001-001-0000004"
+            return None
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000004")
+
+    assert exc_info.value.status_code == 404
+    assert "No se encontró" in exc_info.value.detail

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -63,6 +63,18 @@ const state = {
   contificoPreviewWarehousesLoading: false,
   contificoPreviewWarehousesError: null,
   contificoPreviewWarehousesFetched: false,
+  contificoPreviewCustomerInvoices: [],
+  contificoPreviewCustomerInvoicesPage: 1,
+  contificoPreviewCustomerInvoicesPageSize: CONTIFICO_DEFAULT_PAGE_SIZE,
+  contificoPreviewCustomerInvoicesLoading: false,
+  contificoPreviewCustomerInvoicesError: null,
+  contificoPreviewCustomerInvoicesFetched: false,
+  contificoPreviewCustomerInvoicesDocument: '',
+  contificoPreviewInvoiceLookup: null,
+  contificoPreviewInvoiceLookupLoading: false,
+  contificoPreviewInvoiceLookupError: null,
+  contificoPreviewInvoiceLookupFetched: false,
+  contificoPreviewInvoiceLookupNumber: '',
 };
 
 const TOKEN_STORAGE_KEY = 'sastreria.authToken';
@@ -240,6 +252,16 @@ const contificoPreviewProductsTableBody = document.getElementById('contificoPrev
 const contificoPreviewWarehousesButton = document.getElementById('contificoPreviewWarehousesButton');
 const contificoPreviewWarehousesStatus = document.getElementById('contificoPreviewWarehousesStatus');
 const contificoPreviewWarehousesTableBody = document.getElementById('contificoPreviewWarehousesTableBody');
+const contificoCustomerInvoicesForm = document.getElementById('contificoCustomerInvoicesForm');
+const contificoCustomerInvoicesDocumentInput = document.getElementById('contificoCustomerInvoicesDocument');
+const contificoCustomerInvoicesPageInput = document.getElementById('contificoCustomerInvoicesPage');
+const contificoCustomerInvoicesPageSizeInput = document.getElementById('contificoCustomerInvoicesPageSize');
+const contificoCustomerInvoicesStatus = document.getElementById('contificoCustomerInvoicesStatus');
+const contificoCustomerInvoicesTableBody = document.getElementById('contificoCustomerInvoicesTableBody');
+const contificoInvoiceLookupForm = document.getElementById('contificoInvoiceLookupForm');
+const contificoInvoiceLookupNumberInput = document.getElementById('contificoInvoiceLookupNumber');
+const contificoInvoiceLookupStatus = document.getElementById('contificoInvoiceLookupStatus');
+const contificoInvoiceLookupDetails = document.getElementById('contificoInvoiceLookupDetails');
 const usersTableBody = document.getElementById('usersTableBody');
 const userCreateContainer = document.getElementById('userCreateContainer');
 const toggleCreateUserButton = document.getElementById('toggleCreateUserButton');
@@ -2553,6 +2575,14 @@ if (contificoPreviewProductsForm) {
 
 if (contificoPreviewWarehousesButton) {
   contificoPreviewWarehousesButton.addEventListener('click', handleContificoPreviewWarehousesFetch);
+}
+
+if (contificoCustomerInvoicesForm) {
+  contificoCustomerInvoicesForm.addEventListener('submit', handleContificoCustomerInvoicesFetch);
+}
+
+if (contificoInvoiceLookupForm) {
+  contificoInvoiceLookupForm.addEventListener('submit', handleContificoInvoiceLookup);
 }
 
 function getOrdersForCustomer(customerId) {
@@ -4995,6 +5025,18 @@ function resetContificoPreviewState() {
   state.contificoPreviewWarehousesLoading = false;
   state.contificoPreviewWarehousesError = null;
   state.contificoPreviewWarehousesFetched = false;
+  state.contificoPreviewCustomerInvoices = [];
+  state.contificoPreviewCustomerInvoicesPage = 1;
+  state.contificoPreviewCustomerInvoicesPageSize = CONTIFICO_DEFAULT_PAGE_SIZE;
+  state.contificoPreviewCustomerInvoicesLoading = false;
+  state.contificoPreviewCustomerInvoicesError = null;
+  state.contificoPreviewCustomerInvoicesFetched = false;
+  state.contificoPreviewCustomerInvoicesDocument = '';
+  state.contificoPreviewInvoiceLookup = null;
+  state.contificoPreviewInvoiceLookupLoading = false;
+  state.contificoPreviewInvoiceLookupError = null;
+  state.contificoPreviewInvoiceLookupFetched = false;
+  state.contificoPreviewInvoiceLookupNumber = '';
   renderContificoPreview();
 }
 
@@ -5226,9 +5268,258 @@ function renderContificoPreviewWarehouses() {
   updateContificoStatus(contificoPreviewWarehousesStatus, { text: statusMessage, tone });
 }
 
+function renderContificoPreviewCustomerInvoices() {
+  const isAdmin = state.token && state.user?.role === 'administrador';
+  if (!isAdmin) {
+    if (contificoCustomerInvoicesForm) {
+      const elements = contificoCustomerInvoicesForm.querySelectorAll('input, button');
+      elements.forEach((element) => {
+        element.disabled = true;
+      });
+    }
+    if (contificoCustomerInvoicesDocumentInput) {
+      contificoCustomerInvoicesDocumentInput.value = '';
+    }
+    if (contificoCustomerInvoicesPageInput) {
+      contificoCustomerInvoicesPageInput.value = '1';
+    }
+    if (contificoCustomerInvoicesPageSizeInput) {
+      contificoCustomerInvoicesPageSizeInput.value = String(CONTIFICO_DEFAULT_PAGE_SIZE);
+    }
+    if (contificoCustomerInvoicesTableBody) {
+      contificoCustomerInvoicesTableBody.innerHTML = '';
+    }
+    updateContificoStatus(contificoCustomerInvoicesStatus, {
+      text: 'Inicia sesión como administrador para consultar facturas en Contífico.',
+      tone: 'info',
+    });
+    return;
+  }
+
+  if (contificoCustomerInvoicesForm) {
+    const elements = contificoCustomerInvoicesForm.querySelectorAll('input, button');
+    elements.forEach((element) => {
+      element.disabled = state.contificoPreviewCustomerInvoicesLoading;
+    });
+  }
+
+  if (contificoCustomerInvoicesDocumentInput) {
+    contificoCustomerInvoicesDocumentInput.value = state.contificoPreviewCustomerInvoicesDocument || '';
+  }
+  if (contificoCustomerInvoicesPageInput) {
+    contificoCustomerInvoicesPageInput.value = String(
+      state.contificoPreviewCustomerInvoicesPage || 1
+    );
+  }
+  if (contificoCustomerInvoicesPageSizeInput) {
+    contificoCustomerInvoicesPageSizeInput.value = String(
+      state.contificoPreviewCustomerInvoicesPageSize || CONTIFICO_DEFAULT_PAGE_SIZE
+    );
+  }
+
+  if (contificoCustomerInvoicesTableBody) {
+    contificoCustomerInvoicesTableBody.innerHTML = '';
+    const invoices = Array.isArray(state.contificoPreviewCustomerInvoices)
+      ? state.contificoPreviewCustomerInvoices
+      : [];
+
+    if (invoices.length) {
+      invoices.forEach((invoice) => {
+        const row = document.createElement('tr');
+
+        const numberCell = document.createElement('td');
+        const invoiceNumber = invoice?.numero;
+        numberCell.textContent = invoiceNumber ? String(invoiceNumber) : '—';
+        numberCell.dataset.label = 'Documento';
+
+        const clientCell = document.createElement('td');
+        const clientName = invoice?.cliente;
+        clientCell.textContent = clientName ? String(clientName) : '—';
+        clientCell.dataset.label = 'Cliente';
+
+        const idCell = document.createElement('td');
+        const identification = invoice?.identificacion;
+        idCell.textContent = identification ? String(identification) : '—';
+        idCell.dataset.label = 'Identificación';
+
+        const dateCell = document.createElement('td');
+        const emissionDate = invoice?.fecha_emision;
+        dateCell.textContent = emissionDate ? String(emissionDate) : '—';
+        dateCell.dataset.label = 'Fecha';
+
+        const statusCell = document.createElement('td');
+        const invoiceStatus = invoice?.estado;
+        statusCell.textContent = invoiceStatus ? String(invoiceStatus) : '—';
+        statusCell.dataset.label = 'Estado';
+
+        const totalCell = document.createElement('td');
+        const invoiceTotal = invoice?.total;
+        totalCell.textContent =
+          typeof invoiceTotal === 'number' && Number.isFinite(invoiceTotal)
+            ? invoiceTotal.toFixed(2)
+            : '—';
+        totalCell.dataset.label = 'Total';
+
+        const rawCell = document.createElement('td');
+        rawCell.dataset.label = 'Detalle';
+        const detailsElement = document.createElement('details');
+        const summaryElement = document.createElement('summary');
+        summaryElement.textContent = 'Ver JSON';
+        const preElement = document.createElement('pre');
+        preElement.textContent = JSON.stringify(invoice?.raw ?? invoice, null, 2);
+        detailsElement.appendChild(summaryElement);
+        detailsElement.appendChild(preElement);
+        rawCell.appendChild(detailsElement);
+
+        row.appendChild(numberCell);
+        row.appendChild(clientCell);
+        row.appendChild(idCell);
+        row.appendChild(dateCell);
+        row.appendChild(statusCell);
+        row.appendChild(totalCell);
+        row.appendChild(rawCell);
+
+        contificoCustomerInvoicesTableBody.appendChild(row);
+      });
+    } else if (
+      state.contificoPreviewCustomerInvoicesFetched &&
+      !state.contificoPreviewCustomerInvoicesLoading &&
+      !state.contificoPreviewCustomerInvoicesError
+    ) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 7;
+      cell.textContent = 'No se encontraron facturas para el documento consultado.';
+      cell.className = 'muted';
+      row.appendChild(cell);
+      contificoCustomerInvoicesTableBody.appendChild(row);
+    }
+  }
+
+  let statusMessage = '';
+  let tone = 'info';
+  if (state.contificoPreviewCustomerInvoicesLoading) {
+    statusMessage = 'Consultando facturas en Contífico...';
+    tone = 'loading';
+  } else if (state.contificoPreviewCustomerInvoicesError) {
+    statusMessage = state.contificoPreviewCustomerInvoicesError;
+    tone = 'error';
+  } else if (state.contificoPreviewCustomerInvoicesFetched) {
+    if (state.contificoPreviewCustomerInvoices.length) {
+      statusMessage = `Se muestran ${state.contificoPreviewCustomerInvoices.length} facturas.`;
+      tone = 'success';
+    } else if (state.contificoPreviewCustomerInvoicesDocument) {
+      statusMessage = `No se encontraron facturas para ${state.contificoPreviewCustomerInvoicesDocument}.`;
+    } else {
+      statusMessage = 'No se encontraron facturas con los filtros seleccionados.';
+    }
+  } else {
+    statusMessage = 'Ingresa un número de documento para consultar facturas del cliente en Contífico.';
+  }
+  updateContificoStatus(contificoCustomerInvoicesStatus, { text: statusMessage, tone });
+}
+
+function renderContificoPreviewInvoiceLookup() {
+  const isAdmin = state.token && state.user?.role === 'administrador';
+  if (!isAdmin) {
+    if (contificoInvoiceLookupForm) {
+      const elements = contificoInvoiceLookupForm.querySelectorAll('input, button');
+      elements.forEach((element) => {
+        element.disabled = true;
+      });
+    }
+    if (contificoInvoiceLookupNumberInput) {
+      contificoInvoiceLookupNumberInput.value = '';
+    }
+    if (contificoInvoiceLookupDetails) {
+      contificoInvoiceLookupDetails.innerHTML = '';
+    }
+    updateContificoStatus(contificoInvoiceLookupStatus, {
+      text: 'Inicia sesión como administrador para buscar facturas puntuales.',
+      tone: 'info',
+    });
+    return;
+  }
+
+  if (contificoInvoiceLookupForm) {
+    const elements = contificoInvoiceLookupForm.querySelectorAll('input, button');
+    elements.forEach((element) => {
+      element.disabled = state.contificoPreviewInvoiceLookupLoading;
+    });
+  }
+
+  if (contificoInvoiceLookupNumberInput) {
+    contificoInvoiceLookupNumberInput.value = state.contificoPreviewInvoiceLookupNumber || '';
+  }
+
+  if (contificoInvoiceLookupDetails) {
+    contificoInvoiceLookupDetails.innerHTML = '';
+    const invoice = state.contificoPreviewInvoiceLookup;
+    if (invoice && !state.contificoPreviewInvoiceLookupLoading && !state.contificoPreviewInvoiceLookupError) {
+      const list = document.createElement('dl');
+      list.className = 'contifico-invoice-detail-list';
+
+      const appendItem = (label, value) => {
+        const term = document.createElement('dt');
+        term.textContent = label;
+        const description = document.createElement('dd');
+        description.textContent = value ?? '—';
+        list.appendChild(term);
+        list.appendChild(description);
+      };
+
+      appendItem('Documento', invoice.numero ? String(invoice.numero) : '—');
+      appendItem('Cliente', invoice.cliente ? String(invoice.cliente) : '—');
+      appendItem('Identificación', invoice.identificacion ? String(invoice.identificacion) : '—');
+      appendItem('Fecha de emisión', invoice.fecha_emision ? String(invoice.fecha_emision) : '—');
+      appendItem('Estado', invoice.estado ? String(invoice.estado) : '—');
+      appendItem(
+        'Total',
+        typeof invoice.total === 'number' && Number.isFinite(invoice.total)
+          ? invoice.total.toFixed(2)
+          : '—'
+      );
+
+      const rawDetails = document.createElement('details');
+      rawDetails.className = 'contifico-invoice-raw';
+      const summary = document.createElement('summary');
+      summary.textContent = 'Ver respuesta completa';
+      const pre = document.createElement('pre');
+      pre.textContent = JSON.stringify(invoice.raw ?? invoice, null, 2);
+      rawDetails.appendChild(summary);
+      rawDetails.appendChild(pre);
+
+      contificoInvoiceLookupDetails.appendChild(list);
+      contificoInvoiceLookupDetails.appendChild(rawDetails);
+    }
+  }
+
+  let statusMessage = '';
+  let tone = 'info';
+  if (state.contificoPreviewInvoiceLookupLoading) {
+    statusMessage = 'Buscando factura en Contífico...';
+    tone = 'loading';
+  } else if (state.contificoPreviewInvoiceLookupError) {
+    statusMessage = state.contificoPreviewInvoiceLookupError;
+    tone = 'error';
+  } else if (state.contificoPreviewInvoiceLookupFetched) {
+    if (state.contificoPreviewInvoiceLookup) {
+      statusMessage = 'Factura encontrada correctamente.';
+      tone = 'success';
+    } else {
+      statusMessage = 'No se encontraron facturas con el número consultado.';
+    }
+  } else {
+    statusMessage = 'Ingresa el número exacto de documento para buscar una factura específica.';
+  }
+  updateContificoStatus(contificoInvoiceLookupStatus, { text: statusMessage, tone });
+}
+
 function renderContificoPreview() {
   renderContificoPreviewProducts();
   renderContificoPreviewWarehouses();
+  renderContificoPreviewCustomerInvoices();
+  renderContificoPreviewInvoiceLookup();
 }
 
 async function handleContificoPreviewProductsFetch(event) {
@@ -5313,6 +5604,132 @@ async function handleContificoPreviewWarehousesFetch() {
   } finally {
     state.contificoPreviewWarehousesLoading = false;
     renderContificoPreviewWarehouses();
+  }
+}
+
+async function handleContificoCustomerInvoicesFetch(event) {
+  if (event) {
+    event.preventDefault();
+  }
+  if (!state.token || !state.user || state.user.role !== 'administrador') {
+    showToast('Solo los administradores pueden consultar Contífico.', 'error');
+    return;
+  }
+  if (state.contificoPreviewCustomerInvoicesLoading) {
+    return;
+  }
+
+  const rawDocument =
+    contificoCustomerInvoicesDocumentInput?.value ?? state.contificoPreviewCustomerInvoicesDocument ?? '';
+  const normalizedDocument = String(rawDocument).trim();
+
+  if (!normalizedDocument) {
+    state.contificoPreviewCustomerInvoicesError = 'Ingresa un número de documento válido.';
+    state.contificoPreviewCustomerInvoices = [];
+    state.contificoPreviewCustomerInvoicesFetched = true;
+    renderContificoPreviewCustomerInvoices();
+    showToast(state.contificoPreviewCustomerInvoicesError, 'error');
+    return;
+  }
+
+  const rawPage = Number(
+    contificoCustomerInvoicesPageInput?.value ?? state.contificoPreviewCustomerInvoicesPage ?? 1
+  );
+  const rawPageSize = Number(
+    contificoCustomerInvoicesPageSizeInput?.value ??
+      state.contificoPreviewCustomerInvoicesPageSize ??
+      CONTIFICO_DEFAULT_PAGE_SIZE
+  );
+  const normalizedPage = Number.isFinite(rawPage) && rawPage > 0 ? Math.floor(rawPage) : 1;
+  const normalizedPageSize = Number.isFinite(rawPageSize) && rawPageSize > 0
+    ? Math.min(Math.floor(rawPageSize), CONTIFICO_MAX_PAGE_SIZE)
+    : CONTIFICO_DEFAULT_PAGE_SIZE;
+
+  state.contificoPreviewCustomerInvoicesDocument = normalizedDocument;
+  state.contificoPreviewCustomerInvoicesPage = normalizedPage;
+  state.contificoPreviewCustomerInvoicesPageSize = normalizedPageSize;
+  state.contificoPreviewCustomerInvoicesLoading = true;
+  state.contificoPreviewCustomerInvoicesError = null;
+  state.contificoPreviewCustomerInvoicesFetched = false;
+  renderContificoPreviewCustomerInvoices();
+
+  try {
+    const response = await apiFetch(
+      `/temp/contifico/invoices/by-customer?document_id=${encodeURIComponent(
+        normalizedDocument
+      )}&page=${normalizedPage}&page_size=${normalizedPageSize}`
+    );
+    const items = Array.isArray(response?.items) ? response.items : [];
+    state.contificoPreviewCustomerInvoices = items;
+    state.contificoPreviewCustomerInvoicesPage = Number.isFinite(response?.page)
+      ? response.page
+      : normalizedPage;
+    state.contificoPreviewCustomerInvoicesPageSize = Number.isFinite(response?.page_size)
+      ? response.page_size
+      : normalizedPageSize;
+    state.contificoPreviewCustomerInvoicesFetched = true;
+    renderContificoPreviewCustomerInvoices();
+  } catch (error) {
+    state.contificoPreviewCustomerInvoicesError =
+      error.message || 'No se pudieron consultar las facturas.';
+    state.contificoPreviewCustomerInvoices = [];
+    state.contificoPreviewCustomerInvoicesFetched = true;
+    renderContificoPreviewCustomerInvoices();
+    showToast(state.contificoPreviewCustomerInvoicesError, 'error');
+  } finally {
+    state.contificoPreviewCustomerInvoicesLoading = false;
+    renderContificoPreviewCustomerInvoices();
+  }
+}
+
+async function handleContificoInvoiceLookup(event) {
+  if (event) {
+    event.preventDefault();
+  }
+  if (!state.token || !state.user || state.user.role !== 'administrador') {
+    showToast('Solo los administradores pueden consultar Contífico.', 'error');
+    return;
+  }
+  if (state.contificoPreviewInvoiceLookupLoading) {
+    return;
+  }
+
+  const rawNumber =
+    contificoInvoiceLookupNumberInput?.value ?? state.contificoPreviewInvoiceLookupNumber ?? '';
+  const normalizedNumber = String(rawNumber).trim();
+
+  if (!normalizedNumber) {
+    state.contificoPreviewInvoiceLookupError = 'Ingresa un número de documento válido.';
+    state.contificoPreviewInvoiceLookup = null;
+    state.contificoPreviewInvoiceLookupFetched = true;
+    renderContificoPreviewInvoiceLookup();
+    showToast(state.contificoPreviewInvoiceLookupError, 'error');
+    return;
+  }
+
+  state.contificoPreviewInvoiceLookupNumber = normalizedNumber;
+  state.contificoPreviewInvoiceLookupLoading = true;
+  state.contificoPreviewInvoiceLookupError = null;
+  state.contificoPreviewInvoiceLookupFetched = false;
+  renderContificoPreviewInvoiceLookup();
+
+  try {
+    const response = await apiFetch(
+      `/temp/contifico/invoices/by-number?document_number=${encodeURIComponent(normalizedNumber)}`
+    );
+    state.contificoPreviewInvoiceLookup = response ?? null;
+    state.contificoPreviewInvoiceLookupFetched = true;
+    renderContificoPreviewInvoiceLookup();
+  } catch (error) {
+    state.contificoPreviewInvoiceLookupError =
+      error.message || 'No se pudo consultar la factura solicitada.';
+    state.contificoPreviewInvoiceLookup = null;
+    state.contificoPreviewInvoiceLookupFetched = true;
+    renderContificoPreviewInvoiceLookup();
+    showToast(state.contificoPreviewInvoiceLookupError, 'error');
+  } finally {
+    state.contificoPreviewInvoiceLookupLoading = false;
+    renderContificoPreviewInvoiceLookup();
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -896,6 +896,105 @@
                   </table>
                 </div>
               </article>
+
+              <article class="contifico-preview-card">
+                <header class="contifico-preview-card-header">
+                  <div>
+                    <h4>Facturas por cliente</h4>
+                    <p class="muted small">
+                      Consulta todas las facturas asociadas a un número de cédula o RUC.
+                    </p>
+                  </div>
+                </header>
+                <form id="contificoCustomerInvoicesForm" class="form-grid contifico-preview-form">
+                  <div class="form-row">
+                    <label for="contificoCustomerInvoicesDocument">Documento del cliente</label>
+                    <input
+                      type="text"
+                      id="contificoCustomerInvoicesDocument"
+                      name="document_id"
+                      inputmode="numeric"
+                      autocomplete="off"
+                      placeholder="Ej. 0912345678"
+                      required
+                    />
+                  </div>
+                  <div class="form-row">
+                    <label for="contificoCustomerInvoicesPage">Página</label>
+                    <input type="number" id="contificoCustomerInvoicesPage" min="1" step="1" value="1" />
+                  </div>
+                  <div class="form-row">
+                    <label for="contificoCustomerInvoicesPageSize">Filas por página</label>
+                    <input
+                      type="number"
+                      id="contificoCustomerInvoicesPageSize"
+                      min="1"
+                      max="200"
+                      step="1"
+                      value="25"
+                    />
+                  </div>
+                  <div class="form-row contifico-preview-submit">
+                    <button type="submit" class="primary">Consultar facturas</button>
+                  </div>
+                </form>
+                <p
+                  id="contificoCustomerInvoicesStatus"
+                  class="contifico-preview-status muted small"
+                  role="status"
+                  aria-live="polite"
+                ></p>
+                <div class="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Número</th>
+                        <th>Cliente</th>
+                        <th>Documento</th>
+                        <th>Fecha</th>
+                        <th>Estado</th>
+                        <th>Total</th>
+                        <th>Detalle</th>
+                      </tr>
+                    </thead>
+                    <tbody id="contificoCustomerInvoicesTableBody"></tbody>
+                  </table>
+                </div>
+              </article>
+
+              <article class="contifico-preview-card">
+                <header class="contifico-preview-card-header">
+                  <div>
+                    <h4>Buscar factura puntual</h4>
+                    <p class="muted small">
+                      Introduce el número completo del documento para validar una factura específica.
+                    </p>
+                  </div>
+                </header>
+                <form id="contificoInvoiceLookupForm" class="form-grid contifico-preview-form">
+                  <div class="form-row">
+                    <label for="contificoInvoiceLookupNumber">Número de documento</label>
+                    <input
+                      type="text"
+                      id="contificoInvoiceLookupNumber"
+                      name="document_number"
+                      autocomplete="off"
+                      placeholder="Ej. 001-001-0000001"
+                      required
+                    />
+                  </div>
+                  <div class="form-row contifico-preview-submit">
+                    <button type="submit" class="primary">Buscar factura</button>
+                  </div>
+                </form>
+                <p
+                  id="contificoInvoiceLookupStatus"
+                  class="contifico-preview-status muted small"
+                  role="status"
+                  aria-live="polite"
+                ></p>
+                <div id="contificoInvoiceLookupDetails" class="contifico-invoice-details"></div>
+              </article>
             </div>
           </section>
         </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2108,6 +2108,52 @@ th {
   color: var(--primary);
 }
 
+.contifico-invoice-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.contifico-invoice-detail-list {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(160px, 2fr);
+  gap: 0.35rem 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.contifico-invoice-detail-list dt {
+  font-weight: 600;
+  color: var(--muted-strong);
+}
+
+.contifico-invoice-detail-list dd {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.contifico-preview-card details {
+  font-size: 0.85rem;
+}
+
+.contifico-preview-card summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.contifico-preview-card details pre {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: rgba(7, 10, 12, 0.04);
+  border-radius: 12px;
+  overflow: auto;
+}
+
+.contifico-invoice-raw summary {
+  margin-bottom: 0.25rem;
+}
+
 .public-order-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));


### PR DESCRIPTION
## Summary
- extend the Contífico client with invoice listing and lookup helpers and expose temporary endpoints for them
- add Contífico invoice schemas plus unit tests covering the new helpers and HTTP handlers
- expand the Contífico preview UI with invoice search forms and related styling for administrators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e15ee34c5483329677669b5e9e3fc3