### PR TITLE
Handle 404 responses when looking up Contifico invoices

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import Any, Dict, Iterable, Optional
 
 import httpx
@@ -203,13 +204,18 @@ class ContificoClient:
         if not document_number or not document_number.strip():
             raise ValueError("El número de documento de la factura es obligatorio.")
 
-        invoices = list(
-            self.list_invoices(
-                page=1,
-                page_size=1,
-                document_number=document_number.strip(),
+        try:
+            invoices = list(
+                self.list_invoices(
+                    page=1,
+                    page_size=1,
+                    document_number=document_number.strip(),
+                )
             )
-        )
+        except ContificoAPIError as exc:
+            if exc.status_code == HTTPStatus.NOT_FOUND:
+                return None
+            raise
         if not invoices:
             return None
         return invoices[0]

--- a/backend/app/temp_contifico.py
+++ b/backend/app/temp_contifico.py
@@ -82,6 +82,7 @@ def build_invoice_page(
 def fetch_invoice_by_document_number(
     contifico_client: ContificoClient, *, document_number: str
 ) -> schemas.ContificoInvoice:
+    invoice = None
     try:
         invoice = contifico_client.find_invoice_by_document_number(document_number)
     except ValueError as exc:
@@ -92,7 +93,10 @@ def fetch_invoice_by_document_number(
             detail=exc.detail,
         ) from exc
     except ContificoAPIError as exc:
-        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        if exc.status_code == status.HTTP_404_NOT_FOUND:
+            invoice = None
+        else:
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
     if invoice is None:
         raise HTTPException(

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -202,6 +202,23 @@ def test_find_invoice_by_document_number_handles_missing() -> None:
     assert invoice is None
 
 
+def test_find_invoice_by_document_number_handles_404_error() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No existe"})
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000005")
+
+    assert invoice is None
+
+
 def test_build_product_page_success() -> None:
     class StubClient:
         def list_products(self, *, page: int, page_size: int):
@@ -318,6 +335,19 @@ def test_fetch_invoice_by_document_number_not_found() -> None:
 
     with pytest.raises(HTTPException) as exc_info:
         fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000004")
+
+    assert exc_info.value.status_code == 404
+    assert "No se encontró" in exc_info.value.detail
+
+
+def test_fetch_invoice_by_document_number_handles_api_404() -> None:
+    class StubClient:
+        def find_invoice_by_document_number(self, document_number: str):
+            assert document_number == "001-001-0000005"
+            raise ContificoAPIError(status.HTTP_404_NOT_FOUND, "Sin resultados")
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000005")
 
     assert exc_info.value.status_code == 404
     assert "No se encontró" in exc_info.value.detail


### PR DESCRIPTION
## Summary
- treat Contifico API 404 responses as missing invoices in the Contifico client and temporary endpoints
- extend Contifico client tests to cover the new 404 handling for invoice lookups

## Testing
- pytest backend/tests/test_contifico_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e166236ab0833289f08bcf715853f5