### PR TITLE
Propagate Contifico invoice 404 errors

### DIFF
--- a/backend/app/temp_contifico.py
+++ b/backend/app/temp_contifico.py
@@ -70,10 +70,7 @@ def build_invoice_page(
             detail=exc.detail,
         ) from exc
     except ContificoAPIError as exc:
-        if exc.status_code == status.HTTP_404_NOT_FOUND:
-            invoices = []
-        else:
-            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
     items = [schemas.ContificoInvoice.from_api(invoice) for invoice in invoices]
     return schemas.ContificoInvoicePage(page=page, page_size=page_size, items=items)

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -286,16 +286,16 @@ def test_build_invoice_page_handles_errors() -> None:
     assert "timeout" in exc_info.value.detail
 
 
-def test_build_invoice_page_returns_empty_on_not_found() -> None:
+def test_build_invoice_page_raises_http_exception_on_not_found() -> None:
     class StubClient:
         def list_invoices_by_customer_document(self, document_id: str, *, page: int, page_size: int):
             raise ContificoAPIError(status.HTTP_404_NOT_FOUND, "Sin resultados")
 
-    result = build_invoice_page(StubClient(), page=1, page_size=25, document_id="0912345678")
+    with pytest.raises(HTTPException) as exc_info:
+        build_invoice_page(StubClient(), page=1, page_size=25, document_id="0912345678")
 
-    assert result.page == 1
-    assert result.page_size == 25
-    assert result.items == []
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert "Sin resultados" in exc_info.value.detail
 
 
 def test_fetch_invoice_by_document_number_success() -> None:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5323,7 +5323,18 @@ function renderContificoPreviewCustomerInvoices() {
       ? state.contificoPreviewCustomerInvoices
       : [];
 
-    if (invoices.length) {
+    if (
+      state.contificoPreviewCustomerInvoicesError &&
+      !state.contificoPreviewCustomerInvoicesLoading
+    ) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 7;
+      cell.className = 'error';
+      cell.textContent = state.contificoPreviewCustomerInvoicesError;
+      row.appendChild(cell);
+      contificoCustomerInvoicesTableBody.appendChild(row);
+    } else if (invoices.length) {
       invoices.forEach((invoice) => {
         const row = document.createElement('tr');
 


### PR DESCRIPTION
## Summary
- propagate Contifico API 404 errors from the temporary invoice endpoint instead of treating them as empty results
- update the Contifico client tests to expect HTTP exceptions for 404 responses
- surface backend failures in the Contifico customer invoices preview by rendering the captured error message in the table

## Testing
- pytest backend/tests/test_contifico_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1661d6adc83329efd516ffa5c6db1