### PR TITLE
Update Contifico invoice integration to use registro/documento endpoint

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -162,13 +162,18 @@ class ContificoClient:
     ) -> Iterable[Dict[str, Any]]:
         """Obtiene facturas desde Contífico con los filtros disponibles."""
 
-        params: Dict[str, Any] = {"result_page": page, "result_size": page_size}
+        params: Dict[str, Any] = {
+            "result_page": page,
+            "result_size": page_size,
+            "tipo_registro": "CLI",
+            "tipo": "FAC",
+        }
         if customer_document:
-            params["cliente_identificacion"] = customer_document.strip()
+            params["persona_identificacion"] = customer_document.strip()
         if document_number:
-            params["numero_documento"] = document_number.strip()
+            params["documento"] = document_number.strip()
 
-        data = self._request("GET", "factura/", params=params)
+        data = self._request("GET", "registro/documento/", params=params)
         if data is None:
             return []
         if isinstance(data, list):

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -107,7 +107,7 @@ def test_list_invoices_success() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["params"] = dict(request.url.params)
-        assert request.url.path.endswith("/factura/")
+        assert request.url.path.endswith("/registro/documento/")
         return httpx.Response(200, json=[{"id": "inv-1", "numero": "001-001-0000001"}])
 
     transport = httpx.MockTransport(handler)
@@ -132,8 +132,10 @@ def test_list_invoices_success() -> None:
     assert isinstance(params, dict)
     assert params["result_page"] == "3"
     assert params["result_size"] == "25"
-    assert params["cliente_identificacion"] == "0912345678"
-    assert params["numero_documento"] == "001-001-0000001"
+    assert params["tipo_registro"] == "CLI"
+    assert params["tipo"] == "FAC"
+    assert params["persona_identificacion"] == "0912345678"
+    assert params["documento"] == "001-001-0000001"
 
 
 def test_list_invoices_requires_list_response() -> None:
@@ -163,7 +165,7 @@ def test_list_invoices_by_customer_document_validates_input() -> None:
 
 def test_find_invoice_by_document_number_returns_first() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.params.get("numero_documento") == "001-001-0000001"
+        assert request.url.params.get("documento") == "001-001-0000001"
         return httpx.Response(
             200,
             json=[


### PR DESCRIPTION
## Summary
- switch invoice queries to the `/registro/documento/` endpoint and send the required `tipo_registro` and `tipo` filters so Contífico returns invoices again
- adjust document and customer filters to use the new parameter names exposed by Contífico
- update the Contífico client tests to assert the new path and query parameters

## Testing
- pytest backend/tests/test_contifico_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e1679dfc0c8332a0098399cd5877b1