### PR TITLE
Ensure Contífico modals reset hides UI

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5129,8 +5129,6 @@ function resetContificoPreviewState() {
   state.contificoPreviewInvoiceLookupError = null;
   state.contificoPreviewInvoiceLookupFetched = false;
   state.contificoPreviewInvoiceLookupNumber = '';
-  state.contificoCustomerInvoicesModalVisible = false;
-  state.contificoInvoiceLookupModalVisible = false;
   setContificoCustomerInvoicesVisible(false);
   setContificoInvoiceLookupVisible(false);
   renderContificoPreview();


### PR DESCRIPTION
## Summary
- rely on Contífico modal visibility setters during preview reset so the DOM state is updated when hiding the dialogs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17293eaa88332b80e3ac685a0903c