### PR TITLE
Fix public order search by customer document

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -412,9 +412,20 @@ def search_orders(
 ) -> List[models.Order]:
     query = db.query(models.Order).options(joinedload(models.Order.customer))
     if order_number:
-        query = query.filter(models.Order.order_number == order_number)
+        trimmed_number = order_number.strip()
+        if trimmed_number:
+            query = query.filter(models.Order.order_number == trimmed_number)
     if customer_document:
-        query = query.filter(models.Order.customer_document == customer_document)
+        trimmed_document = customer_document.strip()
+        if trimmed_document:
+            query = query.filter(
+                or_(
+                    models.Order.customer_document == trimmed_document,
+                    models.Order.customer.has(
+                        models.Customer.document_id == trimmed_document
+                    ),
+                )
+            )
     return query.order_by(models.Order.updated_at.desc()).all()
 
 


### PR DESCRIPTION
## Summary
- trim public order search parameters before querying
- match customer document against both stored order field and linked customer to include legacy orders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e1818c56c483329cd1fb83712c71d7