### PR TITLE
Reset server error after successful fallback invoice search

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -347,6 +347,7 @@ class ContificoClient:
                 if encountered_server_error:
                     continue
 
+                last_server_error = None
                 break
 
         if last_server_error is not None:


### PR DESCRIPTION
## Summary
- clear the stored Contífico server error after a page-size fallback succeeds without incidents
- ensure successful invoice searches no longer raise a stale timeout from a prior attempt

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e1b323da44833290a4f88606f9b438