### PR TITLE
Optimize Contifico invoice lookup to avoid timeouts

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -43,6 +43,11 @@ class ContificoClient:
     INVOICE_LOOKUP_MAX_PAGES = 50
     INVOICE_LOOKUP_SERVER_RETRIES = 2
     INVOICE_LOOKUP_RETRY_BACKOFF_BASE = 0.5
+    INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES = {
+        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.NOT_FOUND,
+        HTTPStatus.METHOD_NOT_ALLOWED,
+    }
 
     def __init__(
         self,
@@ -298,6 +303,11 @@ class ContificoClient:
 
         trimmed_input = document_number.strip()
         canonical_input = " ".join(trimmed_input.split())
+
+        direct_invoice = self._lookup_invoice_direct(normalized_target)
+        if direct_invoice is not None:
+            return direct_invoice
+
         search_candidates = []
         if canonical_input:
             search_candidates.append(canonical_input)
@@ -379,4 +389,57 @@ class ContificoClient:
             raise last_server_error
 
         return None
+
+    def _lookup_invoice_direct(self, normalized_target: str) -> Optional[Dict[str, Any]]:
+        """Try to retrieve an invoice directly using the document number."""
+
+        if not normalized_target:
+            return None
+
+        compact_target = normalized_target.replace("-", "") if "-" in normalized_target else None
+
+        try:
+            payload = self._request(
+                "GET", f"registro/documento/{normalized_target}/"
+            )
+        except ContificoAPIError as exc:
+            if exc.status_code in self.INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES:
+                return None
+            raise
+
+        if payload is None:
+            return None
+
+        if isinstance(payload, dict):
+            candidate = self._extract_invoice_number(payload)
+            if not candidate:
+                return payload
+            normalized_candidate = self._normalize_invoice_number(candidate)
+            if normalized_candidate == normalized_target:
+                return payload
+            if compact_target and normalized_candidate == compact_target:
+                return payload
+            return None
+
+        if isinstance(payload, list):
+            match = self._match_invoice_by_number(payload, normalized_target)
+            if match is not None:
+                return match
+            if compact_target:
+                for invoice in payload:
+                    candidate = self._extract_invoice_number(invoice)
+                    if not candidate:
+                        continue
+                    normalized_candidate = self._normalize_invoice_number(candidate)
+                    if normalized_candidate == compact_target:
+                        return invoice
+            if len(payload) == 1 and isinstance(payload[0], dict):
+                return payload[0]
+            return None
+
+        raise ContificoAPIError(
+            status_code=200,
+            detail="El formato de respuesta para facturas no es el esperado.",
+            payload=payload,
+        )
 

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -166,17 +166,9 @@ def test_list_invoices_by_customer_document_validates_input() -> None:
 
 def test_find_invoice_by_document_number_returns_matching_invoice() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        params = dict(request.url.params)
-        assert params.get("documento") == "001-001-0000001"
-        assert params.get("numero") == "001-001-0000001"
-        assert params.get("result_size") == str(ContificoClient.INVOICE_LOOKUP_PAGE_SIZE)
-        return httpx.Response(
-            200,
-            json=[
-                {"id": 99, "numero": "001-001-0000009"},
-                {"id": 1, "numero": "001-001-0000001"},
-            ],
-        )
+        if request.url.path.endswith("/registro/documento/001-001-0000001/"):
+            return httpx.Response(200, json={"id": 1, "numero": "001-001-0000001"})
+        raise AssertionError("Unexpected request")
 
     transport = httpx.MockTransport(handler)
     client = ContificoClient(
@@ -192,17 +184,13 @@ def test_find_invoice_by_document_number_returns_matching_invoice() -> None:
 
 
 def test_find_invoice_by_document_number_strips_prefix_and_spaces() -> None:
-    requests: list[dict[str, str]] = []
+    seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        params = dict(request.url.params)
-        requests.append(params)
-        return httpx.Response(
-            200,
-            json=[
-                {"id": 7, "numero": "001-001-0000001"},
-            ],
-        )
+        seen.append(request.url.path)
+        if request.url.path.endswith("/registro/documento/001-001-0000001/"):
+            return httpx.Response(200, json={"id": 7, "numero_documento": "FAC0010010000001"})
+        raise AssertionError("Unexpected request")
 
     transport = httpx.MockTransport(handler)
     client = ContificoClient(
@@ -214,26 +202,27 @@ def test_find_invoice_by_document_number_strips_prefix_and_spaces() -> None:
 
     invoice = client.find_invoice_by_document_number("  FAC  001-001-0000001  ")
 
-    assert invoice == {"id": 7, "numero": "001-001-0000001"}
-    assert len(requests) == 1
-    assert requests[0]["documento"] == "FAC 001-001-0000001"
-    assert requests[0]["numero"] == "001-001-0000001"
+    assert invoice == {"id": 7, "numero_documento": "FAC0010010000001"}
+    assert seen == ["/registro/documento/001-001-0000001/"]
 
 
 def test_find_invoice_by_document_number_retries_with_original_value() -> None:
-    seen: list[str] = []
+    captured: list[tuple[str, dict[str, str]]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        params = dict(request.url.params)
-        seen.append(params.get("documento", ""))
-        if len(seen) == 1:
+        if request.url.path.endswith("/registro/documento/001-001-0000001/"):
+            captured.append(("direct", {}))
             return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No"})
-        return httpx.Response(
-            200,
-            json=[
-                {"id": 5, "numero": "FAC 001-001-0000001"},
-            ],
-        )
+        params = dict(request.url.params)
+        captured.append(("paged", params))
+        if params.get("documento") == "FAC 001-001-0000001":
+            return httpx.Response(
+                200,
+                json=[
+                    {"id": 5, "numero": "FAC 001-001-0000001"},
+                ],
+            )
+        raise AssertionError("Unexpected parameters")
 
     transport = httpx.MockTransport(handler)
     client = ContificoClient(
@@ -246,13 +235,17 @@ def test_find_invoice_by_document_number_retries_with_original_value() -> None:
     invoice = client.find_invoice_by_document_number("FAC 001-001-0000001")
 
     assert invoice == {"id": 5, "numero": "FAC 001-001-0000001"}
-    assert seen == ["FAC 001-001-0000001", "001-001-0000001"]
+    assert captured[0][0] == "direct"
+    assert captured[1][1]["documento"] == "FAC 001-001-0000001"
+    assert captured[1][1]["numero"] == "001-001-0000001"
 
 
 def test_find_invoice_by_document_number_fetches_multiple_pages() -> None:
     pages: list[int] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000005/"):
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No"})
         params = dict(request.url.params)
         page = int(params.get("result_page", 1))
         pages.append(page)
@@ -295,6 +288,9 @@ def test_find_invoice_by_document_number_falls_back_to_smaller_page_size(monkeyp
     monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
 
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000001/"):
+            requests.append({"direct": True})
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No"})
         params = dict(request.url.params)
         requests.append(params)
         if params.get("result_size") == str(ContificoClient.INVOICE_LOOKUP_PAGE_SIZE):
@@ -315,7 +311,8 @@ def test_find_invoice_by_document_number_falls_back_to_smaller_page_size(monkeyp
     assert invoice == {"id": 3, "numero": "001-001-0000001"}
     default_size = str(ContificoClient.INVOICE_LOOKUP_PAGE_SIZE)
     fallback_size = str(ContificoClient.INVOICE_LOOKUP_FALLBACK_PAGE_SIZES[0])
-    assert [params["result_size"] for params in requests] == [
+    assert [params.get("result_size") for params in requests] == [
+        None,
         default_size,
         default_size,
         default_size,
@@ -330,6 +327,7 @@ def test_find_invoice_by_document_number_falls_back_to_smaller_page_size(monkeyp
 def test_find_invoice_by_document_number_retries_before_returning(monkeypatch: pytest.MonkeyPatch) -> None:
     requests: list[dict[str, str]] = []
     sleeps: list[float] = []
+    fallback_calls = 0
 
     def fake_sleep(seconds: float) -> None:
         sleeps.append(seconds)
@@ -337,9 +335,14 @@ def test_find_invoice_by_document_number_retries_before_returning(monkeypatch: p
     monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
 
     def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal fallback_calls
+        if request.url.path.endswith("/registro/documento/001-001-0000001/"):
+            requests.append({"direct": True})
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "Timeout"})
         params = dict(request.url.params)
         requests.append(params)
-        if len(requests) < 3:
+        fallback_calls += 1
+        if fallback_calls < 3:
             return httpx.Response(status.HTTP_504_GATEWAY_TIMEOUT, json={"mensaje": "Timeout"})
         return httpx.Response(200, json=[{"id": 11, "numero": "001-001-0000001"}])
 
@@ -355,7 +358,8 @@ def test_find_invoice_by_document_number_retries_before_returning(monkeypatch: p
 
     assert invoice == {"id": 11, "numero": "001-001-0000001"}
     default_size = str(ContificoClient.INVOICE_LOOKUP_PAGE_SIZE)
-    assert [params["result_size"] for params in requests] == [
+    assert [params.get("result_size") for params in requests] == [
+        None,
         default_size,
         default_size,
         default_size,
@@ -367,7 +371,9 @@ def test_find_invoice_by_document_number_retries_before_returning(monkeypatch: p
 
 
 def test_find_invoice_by_document_number_handles_missing() -> None:
-    def handler(_: httpx.Request) -> httpx.Response:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000002/"):
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No"})
         return httpx.Response(200, json=[])
 
     transport = httpx.MockTransport(handler)
@@ -384,7 +390,9 @@ def test_find_invoice_by_document_number_handles_missing() -> None:
 
 
 def test_find_invoice_by_document_number_returns_none_when_no_match() -> None:
-    def handler(_: httpx.Request) -> httpx.Response:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000005/"):
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No"})
         return httpx.Response(
             200,
             json=[
@@ -407,7 +415,9 @@ def test_find_invoice_by_document_number_returns_none_when_no_match() -> None:
 
 
 def test_find_invoice_by_document_number_handles_404_error() -> None:
-    def handler(_: httpx.Request) -> httpx.Response:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000005/"):
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No existe"})
         return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No existe"})
 
     transport = httpx.MockTransport(handler)


### PR DESCRIPTION
## Summary
- add a direct lookup step for Contifico invoices to avoid long paging sequences and gateway timeouts
- broaden invoice number normalization so compact numbers returned by the API still match the requested document
- update Contifico client tests to cover the new direct lookup behaviour and adjusted retry flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e1b833d60c8332a1bb49bb1d2d632a