### PR TITLE
Handle 5xx responses from direct Contifico invoice lookup fallback

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -403,7 +403,10 @@ class ContificoClient:
                 "GET", f"registro/documento/{normalized_target}/"
             )
         except ContificoAPIError as exc:
-            if exc.status_code in self.INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES:
+            if (
+                exc.status_code in self.INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES
+                or HTTPStatus.INTERNAL_SERVER_ERROR <= exc.status_code < 600
+            ):
                 return None
             raise
 

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -240,6 +240,36 @@ def test_find_invoice_by_document_number_retries_with_original_value() -> None:
     assert captured[1][1]["numero"] == "001-001-0000001"
 
 
+def test_find_invoice_by_document_number_direct_server_error_falls_back() -> None:
+    requests: list[dict[str, str] | dict[str, bool]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000009/"):
+            requests.append({"direct": True})
+            return httpx.Response(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                json={"mensaje": "Busy"},
+            )
+        params = dict(request.url.params)
+        requests.append(params)
+        assert params.get("result_page") == "1"
+        return httpx.Response(200, json=[{"id": 9, "numero": "001-001-0000009"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000009")
+
+    assert invoice == {"id": 9, "numero": "001-001-0000009"}
+    assert requests[0] == {"direct": True}
+    assert requests[1]["result_page"] == "1"
+
+
 def test_find_invoice_by_document_number_fetches_multiple_pages() -> None:
     pages: list[int] = []
 


### PR DESCRIPTION
## Summary
- return None on 5xx errors from the direct Contifico invoice lookup so the paged search retry flow still runs
- add regression test covering fallback to the paged search when the direct lookup returns HTTP 503

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1bb2a45ec8332beecf017eb25c349