### PR TITLE
Cache Contifico invoice catalog for resilient lookups

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -43,6 +43,12 @@ class ContificoClient:
     INVOICE_LOOKUP_MAX_PAGES = 50
     INVOICE_LOOKUP_SERVER_RETRIES = 2
     INVOICE_LOOKUP_RETRY_BACKOFF_BASE = 0.5
+    INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 2
+    INVOICE_LOOKUP_SERVER_COOLDOWN_BASE = 2.0
+    INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 200
+    INVOICE_LOOKUP_CATALOG_MAX_PAGES = 400
+    INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 2
+    INVOICE_LOOKUP_CATALOG_BACKOFF_BASE = 1.0
     INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES = {
         HTTPStatus.BAD_REQUEST,
         HTTPStatus.NOT_FOUND,
@@ -71,6 +77,8 @@ class ContificoClient:
         self.base_url = (base_url or self.DEFAULT_BASE_URL).rstrip("/")
         self.timeout = timeout
         self._transport = transport
+        self._invoice_cache: Dict[str, Dict[str, Any]] = {}
+        self._invoice_catalog_complete = False
 
     def _request(
         self,
@@ -303,92 +311,146 @@ class ContificoClient:
 
         trimmed_input = document_number.strip()
         canonical_input = " ".join(trimmed_input.split())
+        compact_target = (
+            normalized_target.replace("-", "") if "-" in normalized_target else None
+        )
+
+        cached_invoice = self._get_cached_invoice(normalized_target, compact_target)
+        if cached_invoice is not None:
+            return cached_invoice
 
         direct_invoice = self._lookup_invoice_direct(normalized_target)
         if direct_invoice is not None:
+            self._cache_invoice(direct_invoice)
             return direct_invoice
 
-        search_candidates = []
-        if canonical_input:
-            search_candidates.append(canonical_input)
-        if normalized_target and normalized_target != canonical_input:
-            search_candidates.append(normalized_target)
+        search_candidates: list[str] = []
+        seen_candidates: set[str] = set()
+        for candidate in (canonical_input, normalized_target, compact_target):
+            if not candidate:
+                continue
+            if candidate in seen_candidates:
+                continue
+            seen_candidates.add(candidate)
+            search_candidates.append(candidate)
 
         last_server_error: ContificoAPIError | None = None
 
-        for candidate in search_candidates:
-            for page_size in self._invoice_lookup_page_sizes():
-                seen_numbers: set[str] = set()
-                encountered_server_error = False
+        for search_attempt in range(
+            self.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS + 1
+        ):
+            last_server_error = None
 
-                for page in range(1, self.INVOICE_LOOKUP_MAX_PAGES + 1):
-                    retry_attempt = 0
-                    should_stop_paging = False
-                    while True:
-                        try:
-                            invoices = list(
-                                self.list_invoices(
-                                    page=page,
-                                    page_size=page_size,
-                                    document_number=candidate,
-                                )
-                            )
-                            break
-                        except ContificoAPIError as exc:
-                            if exc.status_code == HTTPStatus.NOT_FOUND:
-                                should_stop_paging = True
-                                invoices = []
-                                break
-                            if HTTPStatus.BAD_GATEWAY <= exc.status_code < 600:
-                                last_server_error = exc
-                                if retry_attempt < self.INVOICE_LOOKUP_SERVER_RETRIES:
-                                    backoff = self.INVOICE_LOOKUP_RETRY_BACKOFF_BASE * (
-                                        2**retry_attempt
+            for candidate in search_candidates:
+                for page_size in self._invoice_lookup_page_sizes():
+                    seen_numbers: set[str] = set()
+                    encountered_server_error = False
+
+                    for page in range(1, self.INVOICE_LOOKUP_MAX_PAGES + 1):
+                        retry_attempt = 0
+                        should_stop_paging = False
+                        while True:
+                            try:
+                                invoices = list(
+                                    self.list_invoices(
+                                        page=page,
+                                        page_size=page_size,
+                                        document_number=candidate,
                                     )
-                                    retry_attempt += 1
-                                    self._sleep(backoff)
-                                    continue
-                                encountered_server_error = True
+                                )
                                 break
-                            raise
+                            except ContificoAPIError as exc:
+                                if exc.status_code == HTTPStatus.NOT_FOUND:
+                                    should_stop_paging = True
+                                    invoices = []
+                                    break
+                                if HTTPStatus.BAD_GATEWAY <= exc.status_code < 600:
+                                    last_server_error = exc
+                                    if (
+                                        retry_attempt
+                                        < self.INVOICE_LOOKUP_SERVER_RETRIES
+                                    ):
+                                        backoff = (
+                                            self.INVOICE_LOOKUP_RETRY_BACKOFF_BASE
+                                            * (2**retry_attempt)
+                                        )
+                                        retry_attempt += 1
+                                        self._sleep(backoff)
+                                        continue
+                                    encountered_server_error = True
+                                    break
+                                raise
+
+                        if encountered_server_error:
+                            break
+
+                        if should_stop_paging or not invoices:
+                            break
+
+                        for invoice in invoices:
+                            self._cache_invoice(invoice)
+
+                        match = self._match_invoice_by_number(
+                            invoices, normalized_target
+                        )
+                        if match is not None:
+                            self._cache_invoice(match)
+                            return match
+
+                        if len(invoices) < page_size:
+                            break
+
+                        page_numbers = set()
+                        for invoice in invoices:
+                            candidate_number = self._extract_invoice_number(invoice)
+                            if not candidate_number:
+                                continue
+                            normalized_candidate = self._normalize_invoice_number(
+                                candidate_number
+                            )
+                            if normalized_candidate:
+                                page_numbers.add(normalized_candidate)
+
+                        if page_numbers and page_numbers.issubset(seen_numbers):
+                            break
+
+                        seen_numbers.update(page_numbers)
 
                     if encountered_server_error:
-                        break
+                        continue
 
-                    if should_stop_paging or not invoices:
-                        break
+                    last_server_error = None
+                    break
 
-                    match = self._match_invoice_by_number(invoices, normalized_target)
-                    if match is not None:
-                        return match
+            if last_server_error is None:
+                return self._get_cached_invoice(normalized_target, compact_target)
 
-                    if len(invoices) < page_size:
-                        break
+            if (
+                search_attempt
+                < self.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS
+            ):
+                cooldown = self.INVOICE_LOOKUP_SERVER_COOLDOWN_BASE * (
+                    2**search_attempt
+                )
+                self._sleep(cooldown)
+                continue
+            break
 
-                    page_numbers = set()
-                    for invoice in invoices:
-                        candidate_number = self._extract_invoice_number(invoice)
-                        if not candidate_number:
-                            continue
-                        normalized_candidate = self._normalize_invoice_number(candidate_number)
-                        if normalized_candidate:
-                            page_numbers.add(normalized_candidate)
+        if last_server_error is not None or self._invoice_catalog_complete:
+            try:
+                catalog_match = self._lookup_invoice_from_catalog(
+                    normalized_target, compact_target
+                )
+            except ContificoClientError:
+                if last_server_error is not None:
+                    raise last_server_error
+            else:
+                if catalog_match is not None:
+                    return catalog_match
+            if last_server_error is not None:
+                raise last_server_error
 
-                    if page_numbers and page_numbers.issubset(seen_numbers):
-                        break
-
-                    seen_numbers.update(page_numbers)
-
-                if encountered_server_error:
-                    continue
-
-                last_server_error = None
-                break
-
-        if last_server_error is not None:
-            raise last_server_error
-
-        return None
+        return self._get_cached_invoice(normalized_target, compact_target)
 
     def _lookup_invoice_direct(self, normalized_target: str) -> Optional[Dict[str, Any]]:
         """Try to retrieve an invoice directly using the document number."""
@@ -402,8 +464,8 @@ class ContificoClient:
             payload = self._request(
                 "GET", f"registro/documento/{normalized_target}/"
             )
-        except ContificoAPIError as exc:
-            if exc.status_code in self.INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES:
+        except ContificoClientError as exc:
+            if self._should_fallback_from_direct_lookup(exc):
                 return None
             raise
 
@@ -435,11 +497,89 @@ class ContificoClient:
                         return invoice
             if len(payload) == 1 and isinstance(payload[0], dict):
                 return payload[0]
-            return None
 
-        raise ContificoAPIError(
-            status_code=200,
-            detail="El formato de respuesta para facturas no es el esperado.",
-            payload=payload,
-        )
+        return None
+
+    def _should_fallback_from_direct_lookup(self, exc: ContificoClientError) -> bool:
+        if isinstance(exc, ContificoTransportError):
+            return True
+        if isinstance(exc, ContificoAPIError):
+            status_code = exc.status_code
+            if status_code in self.INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES:
+                return True
+            if HTTPStatus.INTERNAL_SERVER_ERROR <= status_code < 600:
+                return True
+        return False
+
+    def _cache_invoice(self, invoice: Dict[str, Any]) -> None:
+        if not isinstance(invoice, dict):
+            return
+        candidate = self._extract_invoice_number(invoice)
+        if not candidate:
+            return
+        normalized_candidate = self._normalize_invoice_number(candidate)
+        if not normalized_candidate:
+            return
+        self._invoice_cache[normalized_candidate] = invoice
+        if "-" in normalized_candidate:
+            compact_candidate = normalized_candidate.replace("-", "")
+            if compact_candidate and compact_candidate not in self._invoice_cache:
+                self._invoice_cache[compact_candidate] = invoice
+
+    def _get_cached_invoice(
+        self, normalized_target: str, compact_target: str | None
+    ) -> Optional[Dict[str, Any]]:
+        for key in (normalized_target, compact_target):
+            if not key:
+                continue
+            cached = self._invoice_cache.get(key)
+            if cached is not None:
+                return cached
+        return None
+
+    def _lookup_invoice_from_catalog(
+        self, normalized_target: str, compact_target: str | None
+    ) -> Optional[Dict[str, Any]]:
+        self._ensure_invoice_catalog()
+        return self._get_cached_invoice(normalized_target, compact_target)
+
+    def _ensure_invoice_catalog(self) -> None:
+        if self._invoice_catalog_complete:
+            return
+        self._download_invoice_catalog()
+        self._invoice_catalog_complete = True
+
+    def _download_invoice_catalog(self) -> None:
+        for page in range(1, self.INVOICE_LOOKUP_CATALOG_MAX_PAGES + 1):
+            retry_attempt = 0
+            while True:
+                try:
+                    invoices = list(
+                        self.list_invoices(
+                            page=page,
+                            page_size=self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE,
+                        )
+                    )
+                    break
+                except ContificoAPIError as exc:
+                    if (
+                        HTTPStatus.BAD_GATEWAY <= exc.status_code < 600
+                        and retry_attempt < self.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES
+                    ):
+                        backoff = self.INVOICE_LOOKUP_CATALOG_BACKOFF_BASE * (
+                            2**retry_attempt
+                        )
+                        retry_attempt += 1
+                        self._sleep(backoff)
+                        continue
+                    raise
+
+            if not invoices:
+                return
+
+            for invoice in invoices:
+                self._cache_invoice(invoice)
+
+            if len(invoices) < self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE:
+                return
 

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -240,6 +240,65 @@ def test_find_invoice_by_document_number_retries_with_original_value() -> None:
     assert captured[1][1]["numero"] == "001-001-0000001"
 
 
+def test_find_invoice_by_document_number_direct_server_error_falls_back() -> None:
+    requests: list[dict[str, str] | dict[str, bool]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000009/"):
+            requests.append({"direct": True})
+            return httpx.Response(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                json={"mensaje": "Busy"},
+            )
+        params = dict(request.url.params)
+        requests.append(params)
+        assert params.get("result_page") == "1"
+        return httpx.Response(200, json=[{"id": 9, "numero": "001-001-0000009"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000009")
+
+    assert invoice == {"id": 9, "numero": "001-001-0000009"}
+    assert requests[0] == {"direct": True}
+    assert requests[1]["result_page"] == "1"
+
+
+def test_find_invoice_by_document_number_direct_transport_error_falls_back() -> None:
+    requests: list[dict[str, str] | dict[str, bool]] = []
+    direct_attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000011/"):
+            nonlocal direct_attempts
+            direct_attempts += 1
+            raise httpx.ConnectError("boom", request=request)
+        params = dict(request.url.params)
+        requests.append(params)
+        assert params.get("result_page") == "1"
+        return httpx.Response(200, json=[{"id": 11, "numero": "001-001-0000011"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000011")
+
+    assert invoice == {"id": 11, "numero": "001-001-0000011"}
+    assert direct_attempts == 1
+    assert requests[0]["result_page"] == "1"
+
+
 def test_find_invoice_by_document_number_fetches_multiple_pages() -> None:
     pages: list[int] = []
 
@@ -370,6 +429,218 @@ def test_find_invoice_by_document_number_retries_before_returning(monkeypatch: p
     ]
 
 
+def test_find_invoice_by_document_number_tries_compact_candidate_after_failures() -> None:
+    requests: list[dict[str, str] | str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000022/"):
+            requests.append("direct")
+            return httpx.Response(status.HTTP_504_GATEWAY_TIMEOUT, json={"mensaje": "Timeout"})
+
+        params = dict(request.url.params)
+        requests.append(params)
+        if params.get("documento") == "001-001-0000022":
+            return httpx.Response(status.HTTP_504_GATEWAY_TIMEOUT, json={"mensaje": "Timeout"})
+
+        assert params.get("documento") == "0010010000022"
+        return httpx.Response(200, json=[{"id": 22, "numero": "001-001-0000022"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000022")
+
+    assert invoice == {"id": 22, "numero": "001-001-0000022"}
+    assert requests[0] == "direct"
+    fallback_requests = [
+        params for params in requests[1:] if isinstance(params, dict)
+    ]
+    assert fallback_requests
+    assert any(params.get("documento") == "001-001-0000022" for params in fallback_requests)
+    assert fallback_requests[-1].get("documento") == "0010010000022"
+
+
+def test_find_invoice_by_document_number_retries_after_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, str] | str] = []
+    sleep_calls: list[float] = []
+    cooldowns = 0
+
+    def fake_sleep(seconds: float) -> None:
+        nonlocal cooldowns
+        sleep_calls.append(seconds)
+        if seconds >= ContificoClient.INVOICE_LOOKUP_SERVER_COOLDOWN_BASE:
+            cooldowns += 1
+
+    monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000033/"):
+            requests.append("direct")
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No"})
+
+        params = dict(request.url.params)
+        requests.append(params)
+
+        if cooldowns == 0:
+            return httpx.Response(
+                status.HTTP_504_GATEWAY_TIMEOUT,
+                json={"mensaje": "Timeout"},
+            )
+
+        return httpx.Response(
+            200,
+            json=[{"id": 33, "numero": "001-001-0000033"}],
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000033")
+
+    assert invoice == {"id": 33, "numero": "001-001-0000033"}
+    assert requests[0] == "direct"
+    assert cooldowns == 1
+    assert any(
+        call >= ContificoClient.INVOICE_LOOKUP_SERVER_COOLDOWN_BASE
+        for call in sleep_calls
+    )
+    fallback_requests = [params for params in requests[1:] if isinstance(params, dict)]
+    assert fallback_requests
+    assert len(fallback_requests) > 1
+    assert any(
+        params.get("documento") == "0010010000033" for params in fallback_requests
+    )
+    assert fallback_requests[-1].get("documento") == "001-001-0000033"
+
+
+def test_find_invoice_by_document_number_downloads_catalog_after_timeouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, dict[str, str]]] = []
+    catalog_requests: list[dict[str, str]] = []
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        if request.url.path.endswith("/registro/documento/001-001-0000044/"):
+            requests.append(("direct", {}))
+            return httpx.Response(
+                status.HTTP_504_GATEWAY_TIMEOUT,
+                json={"mensaje": "Timeout"},
+            )
+        if request.url.path.endswith("/registro/documento/"):
+            if params.get("documento") in {"001-001-0000044", "0010010000044"}:
+                requests.append(("search", params))
+                return httpx.Response(
+                    status.HTTP_504_GATEWAY_TIMEOUT,
+                    json={"mensaje": "Timeout"},
+                )
+            if "documento" not in params:
+                catalog_requests.append(params)
+                assert params.get("result_page") == "1"
+                return httpx.Response(
+                    200,
+                    json=[
+                        {"id": 44, "numero": "001-001-0000044"},
+                        {"id": 45, "numero": "001-001-0000045"},
+                    ],
+                )
+        raise AssertionError("Unexpected request")
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    client.INVOICE_LOOKUP_PAGE_SIZE = 1
+    client.INVOICE_LOOKUP_FALLBACK_PAGE_SIZES = ()
+    client.INVOICE_LOOKUP_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_SERVER_RETRIES = 0
+    client.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 0
+    client.INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 2
+    client.INVOICE_LOOKUP_CATALOG_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 0
+
+    invoice = client.find_invoice_by_document_number("001-001-0000044")
+
+    assert invoice == {"id": 44, "numero": "001-001-0000044"}
+    assert requests
+    assert requests[0][0] == "direct"
+    assert any(kind == "search" for kind, _ in requests)
+    assert catalog_requests == [{"result_page": "1", "result_size": "2", "tipo_registro": "CLI", "tipo": "FAC"}]
+    assert client._invoice_catalog_complete is True
+    assert "001-001-0000044" in client._invoice_cache
+    assert sleeps == []
+
+
+def test_find_invoice_by_document_number_reuses_catalog_without_http() -> None:
+    catalog_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal catalog_calls
+        params = dict(request.url.params)
+        if request.url.path.endswith("/registro/documento/001-001-0000045/"):
+            return httpx.Response(
+                status.HTTP_504_GATEWAY_TIMEOUT,
+                json={"mensaje": "Timeout"},
+            )
+        if "documento" not in params:
+            catalog_calls += 1
+            return httpx.Response(
+                200,
+                json=[{"id": 45, "numero": "001-001-0000045"}],
+            )
+        return httpx.Response(
+            status.HTTP_504_GATEWAY_TIMEOUT,
+            json={"mensaje": "Timeout"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    client.INVOICE_LOOKUP_PAGE_SIZE = 1
+    client.INVOICE_LOOKUP_FALLBACK_PAGE_SIZES = ()
+    client.INVOICE_LOOKUP_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_SERVER_RETRIES = 0
+    client.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 0
+    client.INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 1
+    client.INVOICE_LOOKUP_CATALOG_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 0
+
+    invoice = client.find_invoice_by_document_number("001-001-0000045")
+    assert invoice == {"id": 45, "numero": "001-001-0000045"}
+    assert catalog_calls == 1
+
+    def failing_handler(_: httpx.Request) -> httpx.Response:
+        raise AssertionError("HTTP should not be called when catalog is cached")
+
+    client._transport = httpx.MockTransport(failing_handler)
+
+    cached_invoice = client.find_invoice_by_document_number("001-001-0000045")
+    assert cached_invoice == {"id": 45, "numero": "001-001-0000045"}
 def test_find_invoice_by_document_number_handles_missing() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.endswith("/registro/documento/001-001-0000002/"):


### PR DESCRIPTION
## Summary
- introduce a local invoice cache populated from configurable catalog downloads when Contífico lookups keep timing out
- reuse cached batches for subsequent lookups before hitting the API and persist matches retrieved from direct and paged searches
- add regression tests covering the catalog download fallback and cache reuse without further HTTP calls

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1bb2a45ec8332beecf017eb25c349