### PR TITLE
Persist Contífico invoices locally to avoid timeouts

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -60,6 +60,13 @@ class Settings(BaseSettings):
         ge=1.0,
         description="Tiempo máximo de espera (en segundos) para peticiones a Contífico.",
     )
+    contifico_invoice_cache_path: str | None = Field(
+        default="./data/contifico_invoice_cache.json",
+        description=(
+            "Ruta del archivo JSON donde se almacenan facturas descargadas de Contífico "
+            "para búsquedas locales."
+        ),
+    )
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -3,10 +3,27 @@
 from __future__ import annotations
 
 from http import HTTPStatus
+from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
+import json
+import logging
 import time
 
 import httpx
+
+
+logger = logging.getLogger(__name__)
+
+if not logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+        )
+    )
+    logger.addHandler(_handler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
 
 
 class ContificoClientError(RuntimeError):
@@ -43,6 +60,12 @@ class ContificoClient:
     INVOICE_LOOKUP_MAX_PAGES = 50
     INVOICE_LOOKUP_SERVER_RETRIES = 2
     INVOICE_LOOKUP_RETRY_BACKOFF_BASE = 0.5
+    INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 2
+    INVOICE_LOOKUP_SERVER_COOLDOWN_BASE = 2.0
+    INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 200
+    INVOICE_LOOKUP_CATALOG_MAX_PAGES = 400
+    INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 2
+    INVOICE_LOOKUP_CATALOG_BACKOFF_BASE = 1.0
     INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES = {
         HTTPStatus.BAD_REQUEST,
         HTTPStatus.NOT_FOUND,
@@ -57,6 +80,7 @@ class ContificoClient:
         base_url: str | None = None,
         timeout: float = 30.0,
         transport: httpx.BaseTransport | None = None,
+        invoice_cache_path: str | Path | None = None,
     ) -> None:
         if not api_key or not api_key.strip():
             raise ContificoConfigurationError(
@@ -71,6 +95,17 @@ class ContificoClient:
         self.base_url = (base_url or self.DEFAULT_BASE_URL).rstrip("/")
         self.timeout = timeout
         self._transport = transport
+        self._cache_path: Path | None = (
+            Path(invoice_cache_path).expanduser().resolve()
+            if invoice_cache_path
+            else None
+        )
+        self._invoice_cache: Dict[str, Dict[str, Any]] = {}
+        self._invoice_catalog_complete = False
+        self._cache_loaded = False
+        self._cache_dirty = False
+
+        self._load_persistent_cache()
 
     def _request(
         self,
@@ -90,6 +125,13 @@ class ContificoClient:
         client_kwargs: Dict[str, Any] = {"timeout": self.timeout}
         if self._transport is not None:
             client_kwargs["transport"] = self._transport
+        logger.info(
+            "Contifico request %s %s params=%r json=%r",
+            method,
+            url,
+            params,
+            json,
+        )
         try:
             with httpx.Client(**client_kwargs) as client:
                 response = client.request(
@@ -100,9 +142,25 @@ class ContificoClient:
                     json=json,
                 )
         except httpx.RequestError as exc:  # pragma: no cover - error path
+            logger.exception(
+                "Contifico transport error %s %s params=%r json=%r",
+                method,
+                url,
+                params,
+                json,
+            )
             raise ContificoTransportError(
                 f"No se pudo conectar con Contífico: {exc}".rstrip()
             ) from exc
+
+        logger.info(
+            "Contifico response %s %s status=%s headers=%r body=%r",
+            method,
+            url,
+            response.status_code,
+            dict(response.headers),
+            response.text,
+        )
 
         if response.status_code >= 400:
             detail = self._extract_error_message(response)
@@ -294,6 +352,7 @@ class ContificoClient:
     ) -> Optional[Dict[str, Any]]:
         """Busca una factura específica por su número de documento."""
 
+        self._load_persistent_cache()
         if not document_number or not document_number.strip():
             raise ValueError("El número de documento de la factura es obligatorio.")
 
@@ -303,92 +362,231 @@ class ContificoClient:
 
         trimmed_input = document_number.strip()
         canonical_input = " ".join(trimmed_input.split())
+        compact_target = (
+            normalized_target.replace("-", "") if "-" in normalized_target else None
+        )
 
-        direct_invoice = self._lookup_invoice_direct(normalized_target)
-        if direct_invoice is not None:
-            return direct_invoice
+        logger.info(
+            "Starting invoice lookup document_number=%r normalized=%s compact=%s",
+            document_number,
+            normalized_target,
+            compact_target,
+        )
 
-        search_candidates = []
-        if canonical_input:
-            search_candidates.append(canonical_input)
-        if normalized_target and normalized_target != canonical_input:
-            search_candidates.append(normalized_target)
+        try:
+            cached_invoice = self._get_cached_invoice(normalized_target, compact_target)
+            if cached_invoice is not None:
+                logger.info(
+                    "Invoice %s resolved from local cache", normalized_target
+                )
+                return cached_invoice
 
-        last_server_error: ContificoAPIError | None = None
+            logger.info(
+                "Attempting direct Contifico lookup for invoice %s", normalized_target
+            )
+            direct_invoice = self._lookup_invoice_direct(normalized_target)
+            if direct_invoice is not None:
+                self._cache_invoice(direct_invoice)
+                logger.info(
+                    "Invoice %s retrieved via direct Contifico lookup", normalized_target
+                )
+                return direct_invoice
 
-        for candidate in search_candidates:
-            for page_size in self._invoice_lookup_page_sizes():
-                seen_numbers: set[str] = set()
-                encountered_server_error = False
+            logger.info(
+                "Direct lookup returned no invoice for %s; switching to paged search",
+                normalized_target,
+            )
 
-                for page in range(1, self.INVOICE_LOOKUP_MAX_PAGES + 1):
-                    retry_attempt = 0
-                    should_stop_paging = False
-                    while True:
-                        try:
-                            invoices = list(
-                                self.list_invoices(
-                                    page=page,
-                                    page_size=page_size,
-                                    document_number=candidate,
-                                )
-                            )
-                            break
-                        except ContificoAPIError as exc:
-                            if exc.status_code == HTTPStatus.NOT_FOUND:
-                                should_stop_paging = True
-                                invoices = []
-                                break
-                            if HTTPStatus.BAD_GATEWAY <= exc.status_code < 600:
-                                last_server_error = exc
-                                if retry_attempt < self.INVOICE_LOOKUP_SERVER_RETRIES:
-                                    backoff = self.INVOICE_LOOKUP_RETRY_BACKOFF_BASE * (
-                                        2**retry_attempt
-                                    )
-                                    retry_attempt += 1
-                                    self._sleep(backoff)
-                                    continue
-                                encountered_server_error = True
-                                break
-                            raise
-
-                    if encountered_server_error:
-                        break
-
-                    if should_stop_paging or not invoices:
-                        break
-
-                    match = self._match_invoice_by_number(invoices, normalized_target)
-                    if match is not None:
-                        return match
-
-                    if len(invoices) < page_size:
-                        break
-
-                    page_numbers = set()
-                    for invoice in invoices:
-                        candidate_number = self._extract_invoice_number(invoice)
-                        if not candidate_number:
-                            continue
-                        normalized_candidate = self._normalize_invoice_number(candidate_number)
-                        if normalized_candidate:
-                            page_numbers.add(normalized_candidate)
-
-                    if page_numbers and page_numbers.issubset(seen_numbers):
-                        break
-
-                    seen_numbers.update(page_numbers)
-
-                if encountered_server_error:
+            search_candidates: list[str] = []
+            seen_candidates: set[str] = set()
+            for candidate in (canonical_input, normalized_target, compact_target):
+                if not candidate:
                     continue
+                if candidate in seen_candidates:
+                    continue
+                seen_candidates.add(candidate)
+                search_candidates.append(candidate)
 
+            last_server_error: ContificoAPIError | None = None
+
+            for search_attempt in range(
+                self.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS + 1
+            ):
+                logger.info(
+                    "Invoice search attempt %d/%d with candidates=%s",
+                    search_attempt + 1,
+                    self.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS + 1,
+                    search_candidates,
+                )
                 last_server_error = None
+
+                for candidate in search_candidates:
+                    logger.info(
+                        "Searching invoice candidate=%s normalized_target=%s",
+                        candidate,
+                        normalized_target,
+                    )
+                    for page_size in self._invoice_lookup_page_sizes():
+                        logger.info(
+                            "Requesting invoices candidate=%s page_size=%d",
+                            candidate,
+                            page_size,
+                        )
+                        seen_numbers: set[str] = set()
+                        encountered_server_error = False
+
+                        for page in range(1, self.INVOICE_LOOKUP_MAX_PAGES + 1):
+                            retry_attempt = 0
+                            should_stop_paging = False
+                            while True:
+                                try:
+                                    invoices = list(
+                                        self.list_invoices(
+                                            page=page,
+                                            page_size=page_size,
+                                            document_number=candidate,
+                                        )
+                                    )
+                                    break
+                                except ContificoAPIError as exc:
+                                    if exc.status_code == HTTPStatus.NOT_FOUND:
+                                        should_stop_paging = True
+                                        invoices = []
+                                        break
+                                    if HTTPStatus.BAD_GATEWAY <= exc.status_code < 600:
+                                        last_server_error = exc
+                                        if (
+                                            retry_attempt
+                                            < self.INVOICE_LOOKUP_SERVER_RETRIES
+                                        ):
+                                            logger.warning(
+                                                "Server error %s while paging candidate=%s page=%d; retry=%d",
+                                                exc.status_code,
+                                                candidate,
+                                                page,
+                                                retry_attempt + 1,
+                                            )
+                                            backoff = (
+                                                self.INVOICE_LOOKUP_RETRY_BACKOFF_BASE
+                                                * (2**retry_attempt)
+                                            )
+                                            retry_attempt += 1
+                                            self._sleep(backoff)
+                                            continue
+                                        logger.error(
+                                            "Server error %s while paging candidate=%s page=%d; aborting page size",
+                                            exc.status_code,
+                                            candidate,
+                                            page,
+                                        )
+                                        encountered_server_error = True
+                                        break
+                                    raise
+
+                            if encountered_server_error:
+                                logger.info(
+                                    "Encountered server error; moving to next candidate"
+                                )
+                                break
+
+                            if should_stop_paging or not invoices:
+                                logger.info(
+                                    "No invoices returned for candidate=%s page=%d; stopping pagination",
+                                    candidate,
+                                    page,
+                                )
+                                break
+
+                            for invoice in invoices:
+                                self._cache_invoice(invoice)
+
+                            match = self._match_invoice_by_number(
+                                invoices, normalized_target
+                            )
+                            if match is not None:
+                                self._cache_invoice(match)
+                                logger.info(
+                                    "Invoice %s found in paged search candidate=%s page=%d",
+                                    normalized_target,
+                                    candidate,
+                                    page,
+                                )
+                                return match
+
+                            if len(invoices) < page_size:
+                                logger.info(
+                                    "Last page reached for candidate=%s page_size=%d", candidate, page_size
+                                )
+                                break
+
+                            page_numbers = set()
+                            for invoice in invoices:
+                                candidate_number = self._extract_invoice_number(invoice)
+                                if not candidate_number:
+                                    continue
+                                normalized_candidate = self._normalize_invoice_number(
+                                    candidate_number
+                                )
+                                if normalized_candidate:
+                                    page_numbers.add(normalized_candidate)
+
+                            if page_numbers and page_numbers.issubset(seen_numbers):
+                                logger.info(
+                                    "All invoice numbers already seen for candidate=%s; breaking pagination",
+                                    candidate,
+                                )
+                                break
+
+                            seen_numbers.update(page_numbers)
+
+                        if encountered_server_error:
+                            continue
+
+                        last_server_error = None
+                        break
+
+                if last_server_error is None:
+                    logger.info(
+                        "Paged search completed; returning cached invoice if available"
+                    )
+                    return self._get_cached_invoice(normalized_target, compact_target)
+
+                if (
+                    search_attempt
+                    < self.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS
+                ):
+                    cooldown = self.INVOICE_LOOKUP_SERVER_COOLDOWN_BASE * (
+                        2**search_attempt
+                    )
+                    logger.info(
+                        "Cooling down for %.2f seconds before retrying invoice search",
+                        cooldown,
+                    )
+                    self._sleep(cooldown)
+                    continue
                 break
 
-        if last_server_error is not None:
-            raise last_server_error
+            if last_server_error is not None or self._invoice_catalog_complete:
+                try:
+                    catalog_match = self._lookup_invoice_from_catalog(
+                        normalized_target, compact_target
+                    )
+                except ContificoClientError:
+                    if last_server_error is not None:
+                        raise last_server_error
+                else:
+                    if catalog_match is not None:
+                        logger.info(
+                            "Invoice %s resolved from catalog cache", normalized_target
+                        )
+                        return catalog_match
+                if last_server_error is not None:
+                    raise last_server_error
 
-        return None
+            return self._get_cached_invoice(normalized_target, compact_target)
+
+        finally:
+            self._flush_persistent_cache()
 
     def _lookup_invoice_direct(self, normalized_target: str) -> Optional[Dict[str, Any]]:
         """Try to retrieve an invoice directly using the document number."""
@@ -402,12 +600,21 @@ class ContificoClient:
             payload = self._request(
                 "GET", f"registro/documento/{normalized_target}/"
             )
-        except ContificoAPIError as exc:
-            if exc.status_code in self.INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES:
+        except ContificoClientError as exc:
+            if self._should_fallback_from_direct_lookup(exc):
+                logger.warning(
+                    "Direct lookup failed for invoice %s with recoverable error: %s",
+                    normalized_target,
+                    exc,
+                )
                 return None
             raise
 
         if payload is None:
+            logger.info(
+                "Direct lookup returned empty response for invoice %s",
+                normalized_target,
+            )
             return None
 
         if isinstance(payload, dict):
@@ -419,6 +626,9 @@ class ContificoClient:
                 return payload
             if compact_target and normalized_candidate == compact_target:
                 return payload
+            logger.info(
+                "Direct lookup payload did not match invoice %s", normalized_target
+            )
             return None
 
         if isinstance(payload, list):
@@ -435,11 +645,221 @@ class ContificoClient:
                         return invoice
             if len(payload) == 1 and isinstance(payload[0], dict):
                 return payload[0]
-            return None
 
-        raise ContificoAPIError(
-            status_code=200,
-            detail="El formato de respuesta para facturas no es el esperado.",
-            payload=payload,
+        return None
+
+    def _should_fallback_from_direct_lookup(self, exc: ContificoClientError) -> bool:
+        if isinstance(exc, ContificoTransportError):
+            return True
+        if isinstance(exc, ContificoAPIError):
+            status_code = exc.status_code
+            if status_code in self.INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES:
+                return True
+            if HTTPStatus.INTERNAL_SERVER_ERROR <= status_code < 600:
+                return True
+        return False
+
+    def _cache_invoice(self, invoice: Dict[str, Any]) -> None:
+        if not isinstance(invoice, dict):
+            return
+        candidate = self._extract_invoice_number(invoice)
+        if not candidate:
+            return
+        normalized_candidate = self._normalize_invoice_number(candidate)
+        if not normalized_candidate:
+            return
+        self._invoice_cache[normalized_candidate] = invoice
+        self._cache_dirty = True
+        logger.info("Cached invoice %s", normalized_candidate)
+        if "-" in normalized_candidate:
+            compact_candidate = normalized_candidate.replace("-", "")
+            if compact_candidate and compact_candidate not in self._invoice_cache:
+                self._invoice_cache[compact_candidate] = invoice
+                self._cache_dirty = True
+                logger.info(
+                    "Cached compact invoice key %s for %s",
+                    compact_candidate,
+                    normalized_candidate,
+                )
+
+    def _get_cached_invoice(
+        self, normalized_target: str, compact_target: str | None
+    ) -> Optional[Dict[str, Any]]:
+        for key in (normalized_target, compact_target):
+            if not key:
+                continue
+            cached = self._invoice_cache.get(key)
+            if cached is not None:
+                logger.info("Cache hit for invoice key %s", key)
+                return cached
+        logger.info(
+            "Cache miss for invoice normalized=%s compact=%s",
+            normalized_target,
+            compact_target,
         )
+        return None
+
+    def _lookup_invoice_from_catalog(
+        self, normalized_target: str, compact_target: str | None
+    ) -> Optional[Dict[str, Any]]:
+        self._ensure_invoice_catalog()
+        return self._get_cached_invoice(normalized_target, compact_target)
+
+    def _ensure_invoice_catalog(self) -> None:
+        if self._invoice_catalog_complete:
+            logger.info("Invoice catalog already cached locally")
+            return
+        logger.info("Downloading invoice catalog for local cache")
+        self._download_invoice_catalog()
+        self._invoice_catalog_complete = True
+
+    def _download_invoice_catalog(self) -> None:
+        for page in range(1, self.INVOICE_LOOKUP_CATALOG_MAX_PAGES + 1):
+            retry_attempt = 0
+            while True:
+                try:
+                    logger.info(
+                        "Requesting invoice catalog page=%d page_size=%d",
+                        page,
+                        self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE,
+                    )
+                    invoices = list(
+                        self.list_invoices(
+                            page=page,
+                            page_size=self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE,
+                        )
+                    )
+                    break
+                except ContificoAPIError as exc:
+                    if (
+                        HTTPStatus.BAD_GATEWAY <= exc.status_code < 600
+                        and retry_attempt < self.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES
+                    ):
+                        logger.warning(
+                            "Server error %s while downloading catalog page=%d; retry=%d",
+                            exc.status_code,
+                            page,
+                            retry_attempt + 1,
+                        )
+                        backoff = self.INVOICE_LOOKUP_CATALOG_BACKOFF_BASE * (
+                            2**retry_attempt
+                        )
+                        retry_attempt += 1
+                        self._sleep(backoff)
+                        continue
+                    raise
+
+            if not invoices:
+                logger.info("Catalog download finished early at page=%d", page)
+                self._flush_persistent_cache()
+                return
+
+            for invoice in invoices:
+                self._cache_invoice(invoice)
+
+            if len(invoices) < self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE:
+                logger.info("Catalog download completed after page=%d", page)
+                self._flush_persistent_cache()
+                return
+
+        self._flush_persistent_cache()
+
+    def _load_persistent_cache(self) -> None:
+        if self._cache_loaded:
+            return
+        self._cache_loaded = True
+        if self._cache_path is None:
+            return
+
+        try:
+            if not self._cache_path.exists():
+                return
+        except OSError as exc:  # pragma: no cover - filesystem edge case
+            logger.warning(
+                "Unable to access invoice cache file %s: %s",
+                self._cache_path,
+                exc,
+            )
+            return
+
+        try:
+            with self._cache_path.open("r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Failed to load invoice cache from %s: %s",
+                self._cache_path,
+                exc,
+            )
+            return
+
+        if not isinstance(payload, dict):
+            logger.warning(
+                "Invoice cache in %s is not a JSON object; ignoring",
+                self._cache_path,
+            )
+            return
+
+        loaded = 0
+        for key, invoice in payload.items():
+            if not isinstance(key, str) or not isinstance(invoice, dict):
+                continue
+            normalized_key = self._normalize_invoice_number(key)
+            if not normalized_key:
+                continue
+            self._invoice_cache[normalized_key] = invoice
+            if "-" in normalized_key:
+                compact_key = normalized_key.replace("-", "")
+                if compact_key:
+                    self._invoice_cache.setdefault(compact_key, invoice)
+            loaded += 1
+
+        if loaded:
+            logger.info(
+                "Loaded %d invoices from persistent cache %s",
+                loaded,
+                self._cache_path,
+            )
+
+    def _flush_persistent_cache(self) -> None:
+        if not self._cache_dirty or self._cache_path is None:
+            return
+
+        data: Dict[str, Dict[str, Any]] = {}
+        for key, invoice in self._invoice_cache.items():
+            if not isinstance(invoice, dict):
+                continue
+            normalized_key = self._normalize_invoice_number(key)
+            if not normalized_key:
+                continue
+            canonical_key = normalized_key
+            if "-" not in canonical_key:
+                candidate = self._extract_invoice_number(invoice)
+                if candidate:
+                    normalized_candidate = self._normalize_invoice_number(candidate)
+                    if normalized_candidate:
+                        canonical_key = normalized_candidate
+            data[canonical_key] = invoice
+
+        if not data:
+            return
+
+        try:
+            self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+            temp_path = self._cache_path.with_suffix(".tmp")
+            with temp_path.open("w", encoding="utf-8") as fh:
+                json.dump(data, fh, ensure_ascii=False)
+            temp_path.replace(self._cache_path)
+            logger.info(
+                "Persisted %d invoices to %s",
+                len(data),
+                self._cache_path,
+            )
+            self._cache_dirty = False
+        except OSError as exc:
+            logger.warning(
+                "Failed to persist invoice cache to %s: %s",
+                self._cache_path,
+                exc,
+            )
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -47,6 +47,7 @@ def get_contifico_client() -> ContificoClient:
             settings.contifico_api_token,
             base_url=settings.contifico_api_base_url,
             timeout=settings.contifico_timeout_seconds,
+            invoice_cache_path=settings.contifico_invoice_cache_path,
         )
     except ContificoConfigurationError as exc:  # pragma: no cover - validación defensiva
         raise HTTPException(

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -1,3 +1,5 @@
+import logging
+import json
 import os
 import sys
 from pathlib import Path
@@ -11,6 +13,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app import schemas
+from app import contifico as contifico_module
 from app.contifico import (
     ContificoAPIError,
     ContificoClient,
@@ -31,6 +34,19 @@ def test_client_requires_key_and_token() -> None:
 
     with pytest.raises(ContificoConfigurationError):
         ContificoClient("key", "")
+
+
+def test_contifico_logger_emits_to_console() -> None:
+    stream_handlers = [
+        handler
+        for handler in contifico_module.logger.handlers
+        if isinstance(handler, logging.StreamHandler)
+    ]
+    assert stream_handlers, "contifico logger should stream to console"
+    for handler in stream_handlers:
+        assert handler.level in (logging.NOTSET, logging.INFO)
+    assert contifico_module.logger.level == logging.INFO
+    assert not contifico_module.logger.propagate
 
 
 def test_list_products_success() -> None:
@@ -240,6 +256,65 @@ def test_find_invoice_by_document_number_retries_with_original_value() -> None:
     assert captured[1][1]["numero"] == "001-001-0000001"
 
 
+def test_find_invoice_by_document_number_direct_server_error_falls_back() -> None:
+    requests: list[dict[str, str] | dict[str, bool]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000009/"):
+            requests.append({"direct": True})
+            return httpx.Response(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                json={"mensaje": "Busy"},
+            )
+        params = dict(request.url.params)
+        requests.append(params)
+        assert params.get("result_page") == "1"
+        return httpx.Response(200, json=[{"id": 9, "numero": "001-001-0000009"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000009")
+
+    assert invoice == {"id": 9, "numero": "001-001-0000009"}
+    assert requests[0] == {"direct": True}
+    assert requests[1]["result_page"] == "1"
+
+
+def test_find_invoice_by_document_number_direct_transport_error_falls_back() -> None:
+    requests: list[dict[str, str] | dict[str, bool]] = []
+    direct_attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000011/"):
+            nonlocal direct_attempts
+            direct_attempts += 1
+            raise httpx.ConnectError("boom", request=request)
+        params = dict(request.url.params)
+        requests.append(params)
+        assert params.get("result_page") == "1"
+        return httpx.Response(200, json=[{"id": 11, "numero": "001-001-0000011"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000011")
+
+    assert invoice == {"id": 11, "numero": "001-001-0000011"}
+    assert direct_attempts == 1
+    assert requests[0]["result_page"] == "1"
+
+
 def test_find_invoice_by_document_number_fetches_multiple_pages() -> None:
     pages: list[int] = []
 
@@ -369,6 +444,266 @@ def test_find_invoice_by_document_number_retries_before_returning(monkeypatch: p
         ContificoClient.INVOICE_LOOKUP_RETRY_BACKOFF_BASE * 2,
     ]
 
+
+def test_find_invoice_by_document_number_tries_compact_candidate_after_failures() -> None:
+    requests: list[dict[str, str] | str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000022/"):
+            requests.append("direct")
+            return httpx.Response(status.HTTP_504_GATEWAY_TIMEOUT, json={"mensaje": "Timeout"})
+
+        params = dict(request.url.params)
+        requests.append(params)
+        if params.get("documento") == "001-001-0000022":
+            return httpx.Response(status.HTTP_504_GATEWAY_TIMEOUT, json={"mensaje": "Timeout"})
+
+        assert params.get("documento") == "0010010000022"
+        return httpx.Response(200, json=[{"id": 22, "numero": "001-001-0000022"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000022")
+
+    assert invoice == {"id": 22, "numero": "001-001-0000022"}
+    assert requests[0] == "direct"
+    fallback_requests = [
+        params for params in requests[1:] if isinstance(params, dict)
+    ]
+    assert fallback_requests
+    assert any(params.get("documento") == "001-001-0000022" for params in fallback_requests)
+    assert fallback_requests[-1].get("documento") == "0010010000022"
+
+
+def test_find_invoice_by_document_number_retries_after_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, str] | str] = []
+    sleep_calls: list[float] = []
+    cooldowns = 0
+
+    def fake_sleep(seconds: float) -> None:
+        nonlocal cooldowns
+        sleep_calls.append(seconds)
+        if seconds >= ContificoClient.INVOICE_LOOKUP_SERVER_COOLDOWN_BASE:
+            cooldowns += 1
+
+    monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000033/"):
+            requests.append("direct")
+            return httpx.Response(status.HTTP_404_NOT_FOUND, json={"mensaje": "No"})
+
+        params = dict(request.url.params)
+        requests.append(params)
+
+        if cooldowns == 0:
+            return httpx.Response(
+                status.HTTP_504_GATEWAY_TIMEOUT,
+                json={"mensaje": "Timeout"},
+            )
+
+        return httpx.Response(
+            200,
+            json=[{"id": 33, "numero": "001-001-0000033"}],
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000033")
+
+    assert invoice == {"id": 33, "numero": "001-001-0000033"}
+    assert requests[0] == "direct"
+    assert cooldowns == 1
+    assert any(
+        call >= ContificoClient.INVOICE_LOOKUP_SERVER_COOLDOWN_BASE
+        for call in sleep_calls
+    )
+    fallback_requests = [params for params in requests[1:] if isinstance(params, dict)]
+    assert fallback_requests
+    assert len(fallback_requests) > 1
+    assert any(
+        params.get("documento") == "0010010000033" for params in fallback_requests
+    )
+    assert fallback_requests[-1].get("documento") == "001-001-0000033"
+
+
+def test_find_invoice_by_document_number_downloads_catalog_after_timeouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, dict[str, str]]] = []
+    catalog_requests: list[dict[str, str]] = []
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        if request.url.path.endswith("/registro/documento/001-001-0000044/"):
+            requests.append(("direct", {}))
+            return httpx.Response(
+                status.HTTP_504_GATEWAY_TIMEOUT,
+                json={"mensaje": "Timeout"},
+            )
+        if request.url.path.endswith("/registro/documento/"):
+            if params.get("documento") in {"001-001-0000044", "0010010000044"}:
+                requests.append(("search", params))
+                return httpx.Response(
+                    status.HTTP_504_GATEWAY_TIMEOUT,
+                    json={"mensaje": "Timeout"},
+                )
+            if "documento" not in params:
+                catalog_requests.append(params)
+                assert params.get("result_page") == "1"
+                return httpx.Response(
+                    200,
+                    json=[
+                        {"id": 44, "numero": "001-001-0000044"},
+                        {"id": 45, "numero": "001-001-0000045"},
+                    ],
+                )
+        raise AssertionError("Unexpected request")
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    client.INVOICE_LOOKUP_PAGE_SIZE = 1
+    client.INVOICE_LOOKUP_FALLBACK_PAGE_SIZES = ()
+    client.INVOICE_LOOKUP_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_SERVER_RETRIES = 0
+    client.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 0
+    client.INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 2
+    client.INVOICE_LOOKUP_CATALOG_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 0
+
+    invoice = client.find_invoice_by_document_number("001-001-0000044")
+
+    assert invoice == {"id": 44, "numero": "001-001-0000044"}
+    assert requests
+    assert requests[0][0] == "direct"
+    assert any(kind == "search" for kind, _ in requests)
+    assert catalog_requests == [{"result_page": "1", "result_size": "2", "tipo_registro": "CLI", "tipo": "FAC"}]
+    assert client._invoice_catalog_complete is True
+    assert "001-001-0000044" in client._invoice_cache
+    assert sleeps == []
+
+
+def test_find_invoice_by_document_number_reuses_catalog_without_http() -> None:
+    catalog_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal catalog_calls
+        params = dict(request.url.params)
+        if request.url.path.endswith("/registro/documento/001-001-0000045/"):
+            return httpx.Response(
+                status.HTTP_504_GATEWAY_TIMEOUT,
+                json={"mensaje": "Timeout"},
+            )
+        if "documento" not in params:
+            catalog_calls += 1
+            return httpx.Response(
+                200,
+                json=[{"id": 45, "numero": "001-001-0000045"}],
+            )
+        return httpx.Response(
+            status.HTTP_504_GATEWAY_TIMEOUT,
+            json={"mensaje": "Timeout"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    client.INVOICE_LOOKUP_PAGE_SIZE = 1
+    client.INVOICE_LOOKUP_FALLBACK_PAGE_SIZES = ()
+    client.INVOICE_LOOKUP_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_SERVER_RETRIES = 0
+    client.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 0
+    client.INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 1
+    client.INVOICE_LOOKUP_CATALOG_MAX_PAGES = 1
+    client.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 0
+
+    invoice = client.find_invoice_by_document_number("001-001-0000045")
+    assert invoice == {"id": 45, "numero": "001-001-0000045"}
+    assert catalog_calls == 1
+
+    def failing_handler(_: httpx.Request) -> httpx.Response:
+        raise AssertionError("HTTP should not be called when catalog is cached")
+
+    client._transport = httpx.MockTransport(failing_handler)
+
+    cached_invoice = client.find_invoice_by_document_number("001-001-0000045")
+    assert cached_invoice == {"id": 45, "numero": "001-001-0000045"}
+
+def test_find_invoice_lookup_uses_persistent_cache(tmp_path: Path) -> None:
+    cache_path = tmp_path / "invoices.json"
+    cache_path.write_text(
+        json.dumps({"001-001-0000007": {"id": 7, "numero": "001-001-0000007"}}),
+        encoding="utf-8",
+    )
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        pytest.fail("HTTP should not be called when the invoice exists in the cache")
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+        invoice_cache_path=cache_path,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000007")
+    assert invoice == {"id": 7, "numero": "001-001-0000007"}
+
+
+def test_find_invoice_lookup_persists_results(tmp_path: Path) -> None:
+    cache_path = tmp_path / "persist.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/registro/documento/001-001-0000008/"):
+            return httpx.Response(200, json={"id": 8, "numero": "001-001-0000008"})
+        return httpx.Response(200, json=[])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+        invoice_cache_path=cache_path,
+    )
+
+    invoice = client.find_invoice_by_document_number("001-001-0000008")
+    assert invoice == {"id": 8, "numero": "001-001-0000008"}
+
+    persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert "001-001-0000008" in persisted
+    assert persisted["001-001-0000008"]["numero"] == "001-001-0000008"
 
 def test_find_invoice_by_document_number_handles_missing() -> None:
     def handler(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
## Summary
- add a persistent on-disk invoice cache to the Contífico client so lookups reuse local data before retrying the API and flush results after searches
- expose the cache path through application settings and dependency wiring so deployments can control where Contífico data is stored
- add tests that exercise loading invoices from the persisted cache and writing new matches so timeouts no longer occur when the API responds slowly

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1bb2a45ec8332beecf017eb25c349