### PR TITLE
Improve order detail loading resilience and feedback (catalog fallback fix)

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -575,6 +575,7 @@ class ContificoClient:
                     if last_server_error is not None:
                         raise last_server_error
                 else:
+                    last_server_error = None
                     if catalog_match is not None:
                         logger.info(
                             "Invoice %s resolved from catalog cache", normalized_target


### PR DESCRIPTION
## Summary
- add retry with backoff to the order detail data fetch so gateway timeouts keep the loading state instead of surfacing a 504 error
- enhance the checklist loader with retry-aware messaging and spinner styling to keep the user informed during long API calls
- reset stale server errors after a successful catalog fallback to avoid propagating false 5xx responses when no invoice is found

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e2ae162a9c8332bbad54633320664b