### PR TITLE
Codex/address feedback in contifico.py 9uymiq

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -575,8 +575,8 @@ class ContificoClient:
                     if last_server_error is not None:
                         raise last_server_error
                 else:
-                    last_server_error = None
                     if catalog_match is not None:
+                        last_server_error = None
                         logger.info(
                             "Invoice %s resolved from catalog cache", normalized_target
                         )


### PR DESCRIPTION
## Summary
- ensure the server error state is preserved when the catalog lookup returns no match

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b0b6d82883329deffe47d8cc1da4