### PR TITLE
Handle Contifico 5xx errors when listing invoices

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -306,7 +306,6 @@ class ContificoClient:
 
         params: Dict[str, Any] = {
             "result_page": page,
-            "result_size": page_size,
             "tipo_registro": "CLI",
             "tipo": "FAC",
         }
@@ -319,7 +318,78 @@ class ContificoClient:
             if normalized_number:
                 params["numero"] = normalized_number
 
-        data = self._request("GET", "registro/documento/", params=params)
+        try:
+            normalized_page_size = int(page_size)
+        except (TypeError, ValueError):  # pragma: no cover - defensive guard
+            normalized_page_size = self.INVOICE_LOOKUP_PAGE_SIZE
+        if normalized_page_size <= 0:
+            normalized_page_size = self.INVOICE_LOOKUP_PAGE_SIZE
+
+        sizes_to_try: list[int] = []
+        seen_sizes: set[int] = set()
+        for candidate in (normalized_page_size, *self._invoice_lookup_page_sizes()):
+            if not isinstance(candidate, int):
+                try:
+                    candidate = int(candidate)
+                except (TypeError, ValueError):  # pragma: no cover - defensive guard
+                    continue
+            if candidate <= 0 or candidate in seen_sizes:
+                continue
+            if candidate > normalized_page_size and candidate != normalized_page_size:
+                continue
+            seen_sizes.add(candidate)
+            sizes_to_try.append(candidate)
+
+        last_server_error: ContificoAPIError | None = None
+        data: Any | None = None
+
+        for candidate_size in sizes_to_try:
+            params["result_size"] = candidate_size
+            retry_attempt = 0
+            while True:
+                try:
+                    data = self._request(
+                        "GET", "registro/documento/", params=dict(params)
+                    )
+                    last_server_error = None
+                    break
+                except ContificoAPIError as exc:
+                    if (
+                        HTTPStatus.BAD_GATEWAY <= exc.status_code < 600
+                        and retry_attempt < self.INVOICE_LOOKUP_SERVER_RETRIES
+                    ):
+                        backoff = self.INVOICE_LOOKUP_RETRY_BACKOFF_BASE * (
+                            2**retry_attempt
+                        )
+                        retry_attempt += 1
+                        logger.warning(
+                            "Server error %s while listing invoices page_size=%d; retry=%d",
+                            exc.status_code,
+                            candidate_size,
+                            retry_attempt,
+                        )
+                        self._sleep(backoff)
+                        continue
+                    last_server_error = exc
+                    break
+
+            if last_server_error is None:
+                if candidate_size != normalized_page_size:
+                    logger.info(
+                        "Recovered invoice list using fallback page_size=%d (requested=%d)",
+                        candidate_size,
+                        normalized_page_size,
+                    )
+                break
+
+            logger.warning(
+                "Falling back to smaller invoice page size after server error (attempted=%d)",
+                candidate_size,
+            )
+
+        if last_server_error is not None:
+            raise last_server_error
+
         if data is None:
             return []
         if isinstance(data, list):

--- a/backend/app/invoice_jobs.py
+++ b/backend/app/invoice_jobs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
+import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -13,6 +14,9 @@ from uuid import uuid4
 
 from .config import get_settings
 from .contifico import ContificoClient, ContificoClientError, ContificoConfigurationError
+
+
+logger = logging.getLogger(__name__)
 
 
 class InvoiceLookupJobStatus(str, Enum):
@@ -143,72 +147,37 @@ class InvoiceLookupJobManager:
                 progress_callback,
             )
         )
+        finalize_task = asyncio.create_task(
+            self._finalize_lookup(job_id, lookup_task)
+        )
 
         try:
             if self._max_job_duration is not None and self._max_job_duration > 0:
-                result = await asyncio.wait_for(
-                    lookup_task, timeout=self._max_job_duration
+                await asyncio.wait_for(
+                    asyncio.shield(finalize_task), timeout=self._max_job_duration
                 )
             else:
-                result = await lookup_task
+                await finalize_task
         except asyncio.TimeoutError:
-            if not lookup_task.done():
-                lookup_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await lookup_task
             await self._update_job(
                 job_id,
-                status=InvoiceLookupJobStatus.FAILED,
-                stage="timeout",
-                progress=100,
-                error=(
-                    "La búsqueda de la factura superó el tiempo límite. "
-                    "Inténtalo nuevamente más tarde."
-                ),
+                stage="waiting",
+                metadata={
+                    "timeout_exceeded": True,
+                    "message": (
+                        "La búsqueda está tardando más de lo esperado. "
+                        "Seguiremos intentando en segundo plano."
+                    ),
+                },
             )
-            return
         except asyncio.CancelledError:
             if not lookup_task.done():
                 lookup_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await lookup_task
+                self._detach_lookup_task(lookup_task)
+            if not finalize_task.done():
+                finalize_task.cancel()
+                self._detach_lookup_task(finalize_task)
             raise
-        except InvoiceNotFoundError as exc:
-            await self._update_job(
-                job_id,
-                status=InvoiceLookupJobStatus.FAILED,
-                stage="not_found",
-                progress=100,
-                error=str(exc),
-            )
-        except ContificoClientError as exc:
-            await self._update_job(
-                job_id,
-                status=InvoiceLookupJobStatus.FAILED,
-                stage="error",
-                progress=100,
-                error=exc.detail,
-            )
-        except Exception as exc:  # pragma: no cover - defensivo
-            if not lookup_task.done():
-                lookup_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await lookup_task
-            await self._update_job(
-                job_id,
-                status=InvoiceLookupJobStatus.FAILED,
-                stage="error",
-                progress=100,
-                error=str(exc) or "Error desconocido al consultar Contífico.",
-            )
-        else:
-            await self._update_job(
-                job_id,
-                status=InvoiceLookupJobStatus.COMPLETED,
-                stage="completed",
-                progress=100,
-                result=result,
-            )
 
     def _execute_lookup(
         self,
@@ -254,6 +223,61 @@ class InvoiceLookupJobManager:
             asyncio.run_coroutine_threadsafe(_update(), loop)
 
         return callback
+
+    async def _finalize_lookup(
+        self, job_id: str, lookup_task: asyncio.Task[Any]
+    ) -> None:
+        try:
+            result = await lookup_task
+        except asyncio.CancelledError:
+            raise
+        except InvoiceNotFoundError as exc:
+            await self._update_job(
+                job_id,
+                status=InvoiceLookupJobStatus.FAILED,
+                stage="not_found",
+                progress=100,
+                error=str(exc),
+            )
+        except ContificoClientError as exc:
+            await self._update_job(
+                job_id,
+                status=InvoiceLookupJobStatus.FAILED,
+                stage="error",
+                progress=100,
+                error=exc.detail,
+            )
+        except Exception as exc:  # pragma: no cover - defensivo
+            await self._update_job(
+                job_id,
+                status=InvoiceLookupJobStatus.FAILED,
+                stage="error",
+                progress=100,
+                error=str(exc) or "Error desconocido al consultar Contífico.",
+            )
+            logger.exception(
+                "La tarea de búsqueda de Contífico falló mientras se esperaba su finalización.",
+            )
+        else:
+            await self._update_job(
+                job_id,
+                status=InvoiceLookupJobStatus.COMPLETED,
+                stage="completed",
+                progress=100,
+                result=result,
+            )
+
+    def _detach_lookup_task(self, task: asyncio.Task[Any]) -> None:
+        async def _await_task() -> None:
+            with contextlib.suppress(asyncio.CancelledError):
+                try:
+                    await task
+                except Exception:  # pragma: no cover - defensivo
+                    logger.exception(
+                        "La tarea de búsqueda de Contífico falló tras la cancelación.",
+                    )
+
+        asyncio.create_task(_await_task())
 
     async def _update_job(self, job_id: str, **changes: Any) -> None:
         async with self._lock:

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -2,6 +2,7 @@ import logging
 import json
 import os
 import sys
+from http import HTTPStatus
 from pathlib import Path
 
 import httpx
@@ -153,6 +154,78 @@ def test_list_invoices_success() -> None:
     assert params["tipo"] == "FAC"
     assert params["persona_identificacion"] == "0912345678"
     assert params["documento"] == "001-001-0000001"
+
+
+def test_list_invoices_recovers_from_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, str]] = []
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
+
+    attempts_by_size: dict[int, int] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        requests.append(params)
+        size = int(params["result_size"])
+        attempts_by_size[size] = attempts_by_size.get(size, 0) + 1
+        if size == 25:
+            return httpx.Response(HTTPStatus.BAD_GATEWAY, json={"mensaje": "Bad"})
+        assert size == 10, f"Unexpected fallback size: {size}"
+        return httpx.Response(200, json=[{"id": "inv-1", "numero": "001-001-0000001"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoices = list(client.list_invoices(page_size=25))
+
+    assert invoices == [{"id": "inv-1", "numero": "001-001-0000001"}]
+    assert [params["result_size"] for params in requests] == ["25", "25", "25", "10"]
+    assert attempts_by_size[25] == ContificoClient.INVOICE_LOOKUP_SERVER_RETRIES + 1
+    assert attempts_by_size[10] == 1
+    assert sleeps == [
+        ContificoClient.INVOICE_LOOKUP_RETRY_BACKOFF_BASE,
+        ContificoClient.INVOICE_LOOKUP_RETRY_BACKOFF_BASE * 2,
+    ]
+
+
+def test_list_invoices_raises_last_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(ContificoClient, "_sleep", staticmethod(fake_sleep))
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(HTTPStatus.BAD_GATEWAY, json={"mensaje": "Bad"})
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    with pytest.raises(ContificoAPIError) as exc_info:
+        list(client.list_invoices(page_size=5))
+
+    assert exc_info.value.status_code == HTTPStatus.BAD_GATEWAY
+    assert sleeps == [
+        ContificoClient.INVOICE_LOOKUP_RETRY_BACKOFF_BASE,
+        ContificoClient.INVOICE_LOOKUP_RETRY_BACKOFF_BASE * 2,
+        ContificoClient.INVOICE_LOOKUP_RETRY_BACKOFF_BASE,
+        ContificoClient.INVOICE_LOOKUP_RETRY_BACKOFF_BASE * 2,
+    ]
 
 
 def test_list_invoices_requires_list_response() -> None:

--- a/backend/tests/test_invoice_jobs.py
+++ b/backend/tests/test_invoice_jobs.py
@@ -113,12 +113,21 @@ def test_invoice_lookup_job_manager_times_out_long_running_job() -> None:
         max_job_duration=0.01,
     )
 
-    async def scenario() -> object:
+    async def scenario() -> tuple[object, object]:
         job = await manager.start_job("001-001-0000001")
-        return await wait_for_completion(manager, job.id)
+        # Espera suficiente para que se registre el timeout sin bloquear el hilo.
+        await asyncio.sleep(0.02)
+        interim_job = await manager.get_job(job.id)
+        final_job = await wait_for_completion(manager, job.id)
+        return interim_job, final_job
 
-    final_job = asyncio.run(scenario())
+    interim_job, final_job = asyncio.run(scenario())
 
-    assert final_job.status == InvoiceLookupJobStatus.FAILED
-    assert final_job.stage == "timeout"
-    assert "tiempo" in (final_job.error or "").lower()
+    assert interim_job is not None
+    assert interim_job.status == InvoiceLookupJobStatus.RUNNING
+    assert interim_job.stage == "waiting"
+    assert interim_job.metadata.get("timeout_exceeded") is True
+    assert "segundo plano" in (interim_job.metadata.get("message") or "")
+
+    assert final_job.status == InvoiceLookupJobStatus.COMPLETED
+    assert final_job.stage == "completed"


### PR DESCRIPTION
## Summary
- keep Contífico lookup tasks running after exceeding the configured timeout so jobs remain active
- finalize lookup completion in a dedicated coroutine that updates job status when the Contífico call finishes
- adjust the timeout unit test to assert the job reports a waiting stage and eventually completes successfully
- retry Contífico invoice listing requests on server errors, falling back to smaller page sizes before surfacing failures
- add regression tests covering the new retry logic for invoice listings

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e2c262647c8332a958b9fe93318090