### PR TITLE
Add customer filtered invoice lookup preview

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -237,6 +237,97 @@ class ContificoClient:
         return None
 
     @classmethod
+    def _extract_invoice_customer_document(
+        cls, payload: Dict[str, Any]
+    ) -> Optional[str]:
+        if not isinstance(payload, dict):
+            return None
+        keys = (
+            "identificacion",
+            "persona_identificacion",
+            "identification",
+            "personaIdentificacion",
+            "IDENTIFICACION",
+            "PERSONA_IDENTIFICACION",
+            "IDENTIFICATION",
+        )
+        for key in keys:
+            value = payload.get(key)
+            if value is None:
+                continue
+            if isinstance(value, (int, float)):
+                candidate = str(value)
+            elif isinstance(value, str):
+                candidate = value.strip()
+            else:
+                continue
+            if candidate:
+                return candidate
+        # Algunos payloads anidan los datos del cliente bajo "cliente" u otras llaves.
+        for key in ("cliente", "CLIENTE"):
+            nested = payload.get(key)
+            if isinstance(nested, dict):
+                nested_value = nested.get("identificacion") or nested.get("IDENTIFICACION")
+                if isinstance(nested_value, str) and nested_value.strip():
+                    return nested_value.strip()
+        return None
+
+    @classmethod
+    def _invoice_matches_customer(
+        cls, invoice: Dict[str, Any], customer_document: str
+    ) -> bool:
+        normalized_customer = customer_document.strip()
+        if not normalized_customer:
+            return True
+        candidate = cls._extract_invoice_customer_document(invoice)
+        if not candidate:
+            return True
+        return candidate.strip() == normalized_customer
+
+    def _lookup_invoice_for_customer(
+        self,
+        customer_document: str,
+        normalized_target: str,
+        canonical_input: str,
+        compact_target: str | None,
+    ) -> Optional[Dict[str, Any]]:
+        """Busca rápidamente la factura filtrando por el cliente indicado."""
+
+        search_candidates: list[str] = []
+        seen: set[str] = set()
+        for candidate in (canonical_input, normalized_target, compact_target):
+            if not candidate:
+                continue
+            normalized_candidate = str(candidate)
+            if normalized_candidate in seen:
+                continue
+            seen.add(normalized_candidate)
+            search_candidates.append(normalized_candidate)
+
+        for candidate in search_candidates:
+            invoices = list(
+                self.list_invoices(
+                    page=1,
+                    page_size=self.INVOICE_LOOKUP_PAGE_SIZE,
+                    customer_document=customer_document,
+                    document_number=candidate,
+                )
+            )
+            if not invoices:
+                continue
+            for invoice in invoices:
+                self._cache_invoice(invoice)
+            for target in (normalized_target, compact_target):
+                if not target:
+                    continue
+                match = self._match_invoice_by_number(invoices, target)
+                if match is not None and self._invoice_matches_customer(
+                    match, customer_document
+                ):
+                    return match
+        return None
+
+    @classmethod
     def _match_invoice_by_number(
         cls, invoices: Iterable[Dict[str, Any]], normalized_target: str
     ) -> Optional[Dict[str, Any]]:
@@ -469,6 +560,7 @@ class ContificoClient:
         self,
         document_number: str,
         *,
+        customer_document: str | None = None,
         progress_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None,
     ) -> Optional[Dict[str, Any]]:
         """Busca una factura específica por su número de documento."""
@@ -486,73 +578,123 @@ class ContificoClient:
         compact_target = (
             normalized_target.replace("-", "") if "-" in normalized_target else None
         )
+        normalized_customer_document = None
+        if customer_document is not None:
+            normalized_customer_document = customer_document.strip()
+            if not normalized_customer_document:
+                raise ValueError("El número de documento del cliente es obligatorio.")
+
+        base_progress: Dict[str, Any] = {"document_number": normalized_target}
+        if normalized_customer_document:
+            base_progress["customer_document"] = normalized_customer_document
+
+        def emit(stage: str, *, progress: int | None = None, **extras: Any) -> None:
+            payload = dict(base_progress)
+            payload.update(extras)
+            if progress is None:
+                self._emit_progress(progress_callback, stage, **payload)
+            else:
+                self._emit_progress(
+                    progress_callback,
+                    stage,
+                    progress=progress,
+                    **payload,
+                )
 
         logger.info(
-            "Starting invoice lookup document_number=%r normalized=%s compact=%s",
+            "Starting invoice lookup document_number=%r normalized=%s compact=%s customer=%s",
             document_number,
             normalized_target,
             compact_target,
+            normalized_customer_document,
         )
-        self._emit_progress(
-            progress_callback,
-            "start",
-            progress=5,
-            document_number=normalized_target,
-        )
+        emit("start", progress=5)
 
         try:
             cached_invoice = self._get_cached_invoice(normalized_target, compact_target)
+            if (
+                cached_invoice is not None
+                and normalized_customer_document
+                and not self._invoice_matches_customer(
+                    cached_invoice, normalized_customer_document
+                )
+            ):
+                cached_invoice = None
             if cached_invoice is not None:
                 logger.info(
                     "Invoice %s resolved from local cache", normalized_target
                 )
-                self._emit_progress(
-                    progress_callback,
-                    "cache_hit",
-                    progress=100,
-                    document_number=normalized_target,
-                )
+                emit("cache_hit", progress=100)
                 return cached_invoice
 
-            self._emit_progress(
-                progress_callback,
-                "cache_miss",
-                progress=10,
-                document_number=normalized_target,
-            )
+            emit("cache_miss", progress=10)
+
+            if normalized_customer_document:
+                logger.info(
+                    "Attempting invoice lookup filtered by customer %s",
+                    normalized_customer_document,
+                )
+                emit("customer_lookup_start", progress=15)
+                try:
+                    customer_invoice = self._lookup_invoice_for_customer(
+                        normalized_customer_document,
+                        normalized_target,
+                        canonical_input,
+                        compact_target,
+                    )
+                except ContificoClientError as exc:
+                    if self._should_fallback_from_direct_lookup(exc):
+                        logger.warning(
+                            "Customer-filtered lookup failed for invoice %s with %s",
+                            normalized_target,
+                            exc,
+                        )
+                        emit(
+                            "customer_lookup_error",
+                            progress=18,
+                            error=str(exc),
+                        )
+                    else:
+                        raise
+                else:
+                    if customer_invoice is not None:
+                        self._cache_invoice(customer_invoice)
+                        logger.info(
+                            "Invoice %s retrieved while filtering by customer %s",
+                            normalized_target,
+                            normalized_customer_document,
+                        )
+                        emit("customer_lookup_success", progress=100)
+                        return customer_invoice
+                    emit("customer_lookup_miss", progress=20)
+
             logger.info(
                 "Attempting direct Contifico lookup for invoice %s", normalized_target
             )
-            self._emit_progress(
-                progress_callback,
-                "direct_lookup_start",
-                progress=20,
-                document_number=normalized_target,
-            )
+            emit("direct_lookup_start", progress=30)
             direct_invoice = self._lookup_invoice_direct(normalized_target)
             if direct_invoice is not None:
-                self._cache_invoice(direct_invoice)
-                logger.info(
-                    "Invoice %s retrieved via direct Contifico lookup", normalized_target
-                )
-                self._emit_progress(
-                    progress_callback,
-                    "direct_lookup_success",
-                    progress=100,
-                    document_number=normalized_target,
-                )
-                return direct_invoice
+                if normalized_customer_document and not self._invoice_matches_customer(
+                    direct_invoice, normalized_customer_document
+                ):
+                    logger.info(
+                        "Direct lookup invoice %s does not belong to customer %s",
+                        normalized_target,
+                        normalized_customer_document,
+                    )
+                else:
+                    self._cache_invoice(direct_invoice)
+                    logger.info(
+                        "Invoice %s retrieved via direct Contifico lookup", normalized_target
+                    )
+                    emit("direct_lookup_success", progress=100)
+                    return direct_invoice
 
             logger.info(
                 "Direct lookup returned no invoice for %s; switching to paged search",
                 normalized_target,
             )
-            self._emit_progress(
-                progress_callback,
-                "direct_lookup_fallback",
-                progress=35,
-                document_number=normalized_target,
-            )
+            emit("direct_lookup_fallback", progress=35)
 
             search_candidates: list[str] = []
             seen_candidates: set[str] = set()
@@ -583,11 +725,9 @@ class ContificoClient:
                         candidate,
                         normalized_target,
                     )
-                    self._emit_progress(
-                        progress_callback,
+                    emit(
                         "paged_search_candidate",
                         progress=min(60, 40 + candidate_index * 5),
-                        document_number=normalized_target,
                         candidate=candidate,
                     )
                     for page_size in self._invoice_lookup_page_sizes():
@@ -676,11 +816,9 @@ class ContificoClient:
                                 )
                                 break
 
-                            self._emit_progress(
-                                progress_callback,
+                            emit(
                                 "paged_search_page",
                                 progress=min(85, 45 + (page - 1) * 5),
-                                document_number=normalized_target,
                                 candidate=candidate,
                                 page=page,
                                 page_size=page_size,
@@ -692,7 +830,12 @@ class ContificoClient:
                             match = self._match_invoice_by_number(
                                 invoices, normalized_target
                             )
-                            if match is not None:
+                            if match is not None and (
+                                not normalized_customer_document
+                                or self._invoice_matches_customer(
+                                    match, normalized_customer_document
+                                )
+                            ):
                                 self._cache_invoice(match)
                                 logger.info(
                                     "Invoice %s found in paged search candidate=%s page=%d",
@@ -700,11 +843,9 @@ class ContificoClient:
                                     candidate,
                                     page,
                                 )
-                                self._emit_progress(
-                                    progress_callback,
+                                emit(
                                     "paged_search_success",
                                     progress=100,
-                                    document_number=normalized_target,
                                     candidate=candidate,
                                     page=page,
                                 )
@@ -753,13 +894,19 @@ class ContificoClient:
                     logger.info(
                         "Paged search completed; returning cached invoice if available"
                     )
-                    self._emit_progress(
-                        progress_callback,
-                        "paged_search_exhausted",
-                        progress=90,
-                        document_number=normalized_target,
+                    emit("paged_search_exhausted", progress=90)
+                    cached_result = self._get_cached_invoice(
+                        normalized_target, compact_target
                     )
-                    return self._get_cached_invoice(normalized_target, compact_target)
+                    if (
+                        cached_result is not None
+                        and normalized_customer_document
+                        and not self._invoice_matches_customer(
+                            cached_result, normalized_customer_document
+                        )
+                    ):
+                        return None
+                    return cached_result
 
                 if (
                     search_attempt
@@ -778,12 +925,7 @@ class ContificoClient:
 
             if last_server_error is not None or self._invoice_catalog_complete:
                 try:
-                    self._emit_progress(
-                        progress_callback,
-                        "catalog_lookup_start",
-                        progress=92,
-                        document_number=normalized_target,
-                    )
+                    emit("catalog_lookup_start", progress=92)
                     catalog_match = self._lookup_invoice_from_catalog(
                         normalized_target, compact_target
                     )
@@ -791,21 +933,30 @@ class ContificoClient:
                     if last_server_error is not None:
                         raise last_server_error
                 else:
-                    if catalog_match is not None:
+                    if catalog_match is not None and (
+                        not normalized_customer_document
+                        or self._invoice_matches_customer(
+                            catalog_match, normalized_customer_document
+                        )
+                    ):
                         logger.info(
                             "Invoice %s resolved from catalog cache", normalized_target
                         )
-                        self._emit_progress(
-                            progress_callback,
-                            "catalog_lookup_success",
-                            progress=100,
-                            document_number=normalized_target,
-                        )
+                        emit("catalog_lookup_success", progress=100)
                         return catalog_match
                 if last_server_error is not None:
                     raise last_server_error
 
-            return self._get_cached_invoice(normalized_target, compact_target)
+            cached_result = self._get_cached_invoice(normalized_target, compact_target)
+            if (
+                cached_result is not None
+                and normalized_customer_document
+                and not self._invoice_matches_customer(
+                    cached_result, normalized_customer_document
+                )
+            ):
+                return None
+            return cached_result
 
         finally:
             self._flush_persistent_cache()

--- a/backend/app/temp_contifico.py
+++ b/backend/app/temp_contifico.py
@@ -105,6 +105,39 @@ def fetch_invoice_by_document_number(
     return schemas.ContificoInvoice.from_api(invoice)
 
 
+def fetch_invoice_by_customer_and_document(
+    contifico_client: ContificoClient,
+    *,
+    customer_document: str,
+    document_number: str,
+) -> schemas.ContificoInvoice:
+    invoice = None
+    try:
+        invoice = contifico_client.find_invoice_by_document_number(
+            document_number,
+            customer_document=customer_document,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except ContificoTransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.detail,
+        ) from exc
+    except ContificoAPIError as exc:
+        if exc.status_code == status.HTTP_404_NOT_FOUND:
+            invoice = None
+        else:
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    if invoice is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No se encontró una factura con ese número de documento.",
+        )
+    return schemas.ContificoInvoice.from_api(invoice)
+
+
 def serialize_invoice_lookup_job(job) -> schemas.ContificoInvoiceLookupJob:
     invoice = job.result
     invoice_schema = (
@@ -183,6 +216,29 @@ async def preview_contifico_invoice_by_number(
     return await run_in_threadpool(
         fetch_invoice_by_document_number,
         contifico_client,
+        document_number=normalized_number,
+    )
+
+
+@router.get(
+    "/invoices/by-customer-and-number",
+    response_model=schemas.ContificoInvoice,
+)
+async def preview_contifico_invoice_by_customer_and_number(
+    customer_document: str = Query(..., min_length=3, max_length=30),
+    document_number: str = Query(..., min_length=3, max_length=40),
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user=Depends(admin_required()),
+):
+    """Busca una factura específica combinando cliente y número de documento."""
+
+    _ = current_user
+    normalized_customer = customer_document.strip()
+    normalized_number = document_number.strip()
+    return await run_in_threadpool(
+        fetch_invoice_by_customer_and_document,
+        contifico_client,
+        customer_document=normalized_customer,
         document_number=normalized_number,
     )
 

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -25,6 +25,7 @@ from app.temp_contifico import (
     build_invoice_page,
     build_product_page,
     build_warehouse_list,
+    fetch_invoice_by_customer_and_document,
     fetch_invoice_by_document_number,
 )
 
@@ -336,6 +337,100 @@ def test_find_invoice_by_document_number_returns_matching_invoice() -> None:
     invoice = client.find_invoice_by_document_number("001-001-0000001")
 
     assert invoice == {"id": 1, "numero": "001-001-0000001"}
+
+
+def test_find_invoice_by_document_number_prefers_customer_lookup() -> None:
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append((request.url.path, dict(request.url.params)))
+        if request.url.path.endswith("/registro/documento/"):
+            params = dict(request.url.params)
+            assert params.get("persona_identificacion") == "0912345678"
+            assert params.get("documento") == "001-001-0000001"
+            assert params.get("numero") == "001-001-0000001"
+            payload = [
+                {
+                    "id": 77,
+                    "numero": "001-001-0000001",
+                    "identificacion": "0912345678",
+                }
+            ]
+            return httpx.Response(200, json=payload)
+        raise AssertionError("Unexpected request")
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number(
+        "001-001-0000001", customer_document="0912345678"
+    )
+
+    assert invoice is not None
+    assert invoice.get("id") == 77
+    assert captured and captured[0][0].endswith("/registro/documento/")
+    assert len(captured) == 1
+
+
+def test_find_invoice_by_document_number_ignores_mismatched_customer() -> None:
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        captured.append((request.url.path, params))
+        if request.url.path.endswith("/registro/documento/") and params.get(
+            "persona_identificacion"
+        ) == "0912345678":
+            payload = [
+                {
+                    "id": 88,
+                    "numero": "001-001-0000001",
+                    "identificacion": "0000000000",
+                }
+            ]
+            return httpx.Response(200, json=payload)
+        if request.url.path.endswith("/registro/documento/001-001-0000001/"):
+            payload = {
+                "id": 101,
+                "numero": "001-001-0000001",
+                "identificacion": "0912345678",
+            }
+            return httpx.Response(200, json=payload)
+        raise AssertionError("Unexpected request")
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    invoice = client.find_invoice_by_document_number(
+        "001-001-0000001", customer_document="0912345678"
+    )
+
+    assert invoice == {
+        "id": 101,
+        "numero": "001-001-0000001",
+        "identificacion": "0912345678",
+    }
+    assert any(path.endswith("/registro/documento/") for path, _ in captured)
+    assert any(path.endswith("/registro/documento/001-001-0000001/") for path, _ in captured)
+
+
+def test_find_invoice_by_document_number_validates_customer_document() -> None:
+    client = ContificoClient("key", "token")
+
+    with pytest.raises(ValueError):
+        client.find_invoice_by_document_number(
+            "001-001-0000001", customer_document="   "
+        )
 
 
 def test_find_invoice_by_document_number_strips_prefix_and_spaces() -> None:
@@ -1084,8 +1179,15 @@ def test_build_invoice_page_raises_http_exception_on_not_found() -> None:
 
 def test_fetch_invoice_by_document_number_success() -> None:
     class StubClient:
-        def find_invoice_by_document_number(self, document_number: str):
+        def find_invoice_by_document_number(
+            self,
+            document_number: str,
+            *,
+            customer_document: str | None = None,
+            progress_callback=None,
+        ):
             assert document_number == "001-001-0000003"
+            assert customer_document is None
             return {"id": 3, "numero": "001-001-0000003", "cliente": "Lucía"}
 
     result = fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000003")
@@ -1096,8 +1198,15 @@ def test_fetch_invoice_by_document_number_success() -> None:
 
 def test_fetch_invoice_by_document_number_not_found() -> None:
     class StubClient:
-        def find_invoice_by_document_number(self, document_number: str):
+        def find_invoice_by_document_number(
+            self,
+            document_number: str,
+            *,
+            customer_document: str | None = None,
+            progress_callback=None,
+        ):
             assert document_number == "001-001-0000004"
+            assert customer_document is None
             return None
 
     with pytest.raises(HTTPException) as exc_info:
@@ -1109,12 +1218,70 @@ def test_fetch_invoice_by_document_number_not_found() -> None:
 
 def test_fetch_invoice_by_document_number_handles_api_404() -> None:
     class StubClient:
-        def find_invoice_by_document_number(self, document_number: str):
+        def find_invoice_by_document_number(
+            self,
+            document_number: str,
+            *,
+            customer_document: str | None = None,
+            progress_callback=None,
+        ):
             assert document_number == "001-001-0000005"
+            assert customer_document is None
             raise ContificoAPIError(status.HTTP_404_NOT_FOUND, "Sin resultados")
 
     with pytest.raises(HTTPException) as exc_info:
         fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000005")
+
+    assert exc_info.value.status_code == 404
+    assert "No se encontró" in exc_info.value.detail
+
+
+def test_fetch_invoice_by_customer_and_document_success() -> None:
+    class StubClient:
+        def find_invoice_by_document_number(
+            self,
+            document_number: str,
+            *,
+            customer_document: str | None = None,
+            progress_callback=None,
+        ):
+            assert document_number == "001-001-0000006"
+            assert customer_document == "0912345678"
+            return {
+                "id": 6,
+                "numero": "001-001-0000006",
+                "identificacion": "0912345678",
+            }
+
+    result = fetch_invoice_by_customer_and_document(
+        StubClient(),
+        customer_document="0912345678",
+        document_number="001-001-0000006",
+    )
+
+    assert result.numero == "001-001-0000006"
+    assert result.identificacion == "0912345678"
+
+
+def test_fetch_invoice_by_customer_and_document_handles_missing() -> None:
+    class StubClient:
+        def find_invoice_by_document_number(
+            self,
+            document_number: str,
+            *,
+            customer_document: str | None = None,
+            progress_callback=None,
+        ):
+            assert document_number == "001-001-0000007"
+            assert customer_document == "0912345678"
+            return None
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_invoice_by_customer_and_document(
+            StubClient(),
+            customer_document="0912345678",
+            document_number="001-001-0000007",
+        )
 
     assert exc_info.value.status_code == 404
     assert "No se encontró" in exc_info.value.detail

--- a/backend/tests/test_invoice_jobs.py
+++ b/backend/tests/test_invoice_jobs.py
@@ -19,7 +19,13 @@ class FakeClient:
         self._invoice = invoice
         self._exception_factory = exception_factory
 
-    def find_invoice_by_document_number(self, document_number: str, *, progress_callback=None):
+    def find_invoice_by_document_number(
+        self,
+        document_number: str,
+        *,
+        customer_document: str | None = None,
+        progress_callback=None,
+    ):
         if progress_callback:
             progress_callback("start", {"progress": 5, "document_number": document_number})
         if self._exception_factory is not None:
@@ -100,7 +106,13 @@ def test_invoice_lookup_job_manager_reports_transport_error() -> None:
 
 def test_invoice_lookup_job_manager_times_out_long_running_job() -> None:
     class SlowClient:
-        def find_invoice_by_document_number(self, document_number: str, *, progress_callback=None):
+        def find_invoice_by_document_number(
+            self,
+            document_number: str,
+            *,
+            customer_document: str | None = None,
+            progress_callback=None,
+        ):
             if progress_callback:
                 progress_callback("start", {"progress": 5, "document_number": document_number})
             time.sleep(0.05)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -71,6 +71,12 @@ const state = {
   contificoPreviewCustomerInvoicesError: null,
   contificoPreviewCustomerInvoicesFetched: false,
   contificoPreviewCustomerInvoicesDocument: '',
+  contificoPreviewCustomerInvoiceLookup: null,
+  contificoPreviewCustomerInvoiceLookupLoading: false,
+  contificoPreviewCustomerInvoiceLookupError: null,
+  contificoPreviewCustomerInvoiceLookupFetched: false,
+  contificoPreviewCustomerInvoiceLookupDocument: '',
+  contificoPreviewCustomerInvoiceLookupNumber: '',
   contificoPreviewInvoiceLookup: null,
   contificoPreviewInvoiceLookupLoading: false,
   contificoPreviewInvoiceLookupError: null,
@@ -121,6 +127,12 @@ const INVOICE_LOOKUP_STAGE_MESSAGES = {
   starting: 'Preparando búsqueda en Contífico...',
   cache_hit: 'Factura encontrada en la caché local.',
   cache_miss: 'Factura no encontrada en la caché. Consultando Contífico...',
+  customer_lookup_start: 'Filtrando facturas por cliente en Contífico...',
+  customer_lookup_success: 'Factura encontrada entre las facturas del cliente.',
+  customer_lookup_miss:
+    'No se halló la factura dentro del historial del cliente. Reintentando con otras estrategias...',
+  customer_lookup_error:
+    'No se pudo consultar las facturas del cliente. Probando con otra estrategia...',
   direct_lookup_start: 'Consultando la factura directamente en Contífico...',
   direct_lookup_success: 'Factura obtenida exitosamente mediante consulta directa.',
   direct_lookup_fallback: 'Reintentando mediante búsqueda paginada...',
@@ -345,6 +357,19 @@ const contificoCustomerInvoicesDocumentInput = document.getElementById('contific
 const contificoCustomerInvoicesPageInput = document.getElementById('contificoCustomerInvoicesPage');
 const contificoCustomerInvoicesPageSizeInput = document.getElementById('contificoCustomerInvoicesPageSize');
 const contificoCustomerInvoicesStatus = document.getElementById('contificoCustomerInvoicesStatus');
+const contificoCustomerInvoiceLookupForm = document.getElementById('contificoCustomerInvoiceLookupForm');
+const contificoCustomerInvoiceLookupDocumentInput = document.getElementById(
+  'contificoCustomerInvoiceLookupDocument'
+);
+const contificoCustomerInvoiceLookupNumberInput = document.getElementById(
+  'contificoCustomerInvoiceLookupNumber'
+);
+const contificoCustomerInvoiceLookupStatus = document.getElementById(
+  'contificoCustomerInvoiceLookupStatus'
+);
+const contificoCustomerInvoiceLookupResult = document.getElementById(
+  'contificoCustomerInvoiceLookupResult'
+);
 const contificoInvoiceLookupForm = document.getElementById('contificoInvoiceLookupForm');
 const contificoInvoiceLookupNumberInput = document.getElementById('contificoInvoiceLookupNumber');
 const contificoInvoiceLookupStatus = document.getElementById('contificoInvoiceLookupStatus');
@@ -2748,6 +2773,13 @@ if (contificoPreviewWarehousesButton) {
 
 if (contificoCustomerInvoicesForm) {
   contificoCustomerInvoicesForm.addEventListener('submit', handleContificoCustomerInvoicesFetch);
+}
+
+if (contificoCustomerInvoiceLookupForm) {
+  contificoCustomerInvoiceLookupForm.addEventListener(
+    'submit',
+    handleContificoCustomerInvoiceLookup
+  );
 }
 
 if (contificoInvoiceLookupForm) {
@@ -5220,6 +5252,12 @@ function resetContificoPreviewState() {
   state.contificoPreviewCustomerInvoicesError = null;
   state.contificoPreviewCustomerInvoicesFetched = false;
   state.contificoPreviewCustomerInvoicesDocument = '';
+  state.contificoPreviewCustomerInvoiceLookup = null;
+  state.contificoPreviewCustomerInvoiceLookupLoading = false;
+  state.contificoPreviewCustomerInvoiceLookupError = null;
+  state.contificoPreviewCustomerInvoiceLookupFetched = false;
+  state.contificoPreviewCustomerInvoiceLookupDocument = '';
+  state.contificoPreviewCustomerInvoiceLookupNumber = '';
   state.contificoPreviewInvoiceLookup = null;
   state.contificoPreviewInvoiceLookupLoading = false;
   state.contificoPreviewInvoiceLookupError = null;
@@ -5671,6 +5709,133 @@ function renderContificoPreviewCustomerInvoices() {
   });
 }
 
+function renderContificoPreviewCustomerInvoiceLookup() {
+  const isAdmin = state.token && state.user?.role === 'administrador';
+  if (contificoCustomerInvoiceLookupForm) {
+    const elements = contificoCustomerInvoiceLookupForm.querySelectorAll('input, button');
+    elements.forEach((element) => {
+      element.disabled = !isAdmin || state.contificoPreviewCustomerInvoiceLookupLoading;
+    });
+  }
+
+  if (!isAdmin) {
+    if (contificoCustomerInvoiceLookupDocumentInput) {
+      contificoCustomerInvoiceLookupDocumentInput.value = '';
+    }
+    if (contificoCustomerInvoiceLookupNumberInput) {
+      contificoCustomerInvoiceLookupNumberInput.value = '';
+    }
+    if (contificoCustomerInvoiceLookupResult) {
+      contificoCustomerInvoiceLookupResult.innerHTML = '';
+      contificoCustomerInvoiceLookupResult.classList.add('empty');
+    }
+    updateContificoStatus(contificoCustomerInvoiceLookupStatus, {
+      text: 'Autentícate como administrador para consultar facturas puntuales por cliente.',
+      tone: 'info',
+    });
+    return;
+  }
+
+  if (contificoCustomerInvoiceLookupDocumentInput) {
+    contificoCustomerInvoiceLookupDocumentInput.value =
+      state.contificoPreviewCustomerInvoiceLookupDocument || '';
+  }
+  if (contificoCustomerInvoiceLookupNumberInput) {
+    contificoCustomerInvoiceLookupNumberInput.value =
+      state.contificoPreviewCustomerInvoiceLookupNumber || '';
+  }
+
+  const invoice = state.contificoPreviewCustomerInvoiceLookup;
+  const loading = state.contificoPreviewCustomerInvoiceLookupLoading;
+  const error = state.contificoPreviewCustomerInvoiceLookupError;
+  const fetched = state.contificoPreviewCustomerInvoiceLookupFetched;
+
+  let statusMessage = '';
+  let tone = 'info';
+  if (loading) {
+    statusMessage = 'Buscando factura para el cliente en Contífico...';
+    tone = 'loading';
+  } else if (error) {
+    statusMessage = error;
+    tone = 'error';
+  } else if (fetched) {
+    if (invoice) {
+      statusMessage = 'Factura encontrada. Revisa el detalle debajo.';
+      tone = 'success';
+    } else if (
+      state.contificoPreviewCustomerInvoiceLookupDocument ||
+      state.contificoPreviewCustomerInvoiceLookupNumber
+    ) {
+      statusMessage = 'No se encontraron resultados con los datos proporcionados.';
+    } else {
+      statusMessage = 'No se encontraron resultados con los datos proporcionados.';
+    }
+  } else {
+    statusMessage =
+      'Ingresa el documento del cliente y el número de factura para validar los datos en Contífico.';
+  }
+  updateContificoStatus(contificoCustomerInvoiceLookupStatus, { text: statusMessage, tone });
+
+  if (contificoCustomerInvoiceLookupResult) {
+    contificoCustomerInvoiceLookupResult.innerHTML = '';
+    let hasContent = false;
+
+    if (!loading && !error && invoice) {
+      const list = document.createElement('dl');
+      list.className = 'contifico-invoice-detail-list';
+
+      const appendItem = (label, value) => {
+        const term = document.createElement('dt');
+        term.textContent = label;
+        const description = document.createElement('dd');
+        description.textContent = value ?? '—';
+        list.appendChild(term);
+        list.appendChild(description);
+      };
+
+      appendItem('Documento', invoice.numero ? String(invoice.numero) : '—');
+      appendItem('Cliente', invoice.cliente ? String(invoice.cliente) : '—');
+      appendItem(
+        'Identificación',
+        invoice.identificacion ? String(invoice.identificacion) : '—'
+      );
+      appendItem(
+        'Fecha de emisión',
+        invoice.fecha_emision ? String(invoice.fecha_emision) : '—'
+      );
+      appendItem('Estado', invoice.estado ? String(invoice.estado) : '—');
+      appendItem(
+        'Total',
+        typeof invoice.total === 'number' && Number.isFinite(invoice.total)
+          ? invoice.total.toFixed(2)
+          : '—'
+      );
+
+      const rawDetails = document.createElement('details');
+      rawDetails.className = 'contifico-invoice-raw';
+      const summary = document.createElement('summary');
+      summary.textContent = 'Ver respuesta completa';
+      const pre = document.createElement('pre');
+      pre.textContent = JSON.stringify(invoice.raw ?? invoice, null, 2);
+      rawDetails.appendChild(summary);
+      rawDetails.appendChild(pre);
+
+      contificoCustomerInvoiceLookupResult.appendChild(list);
+      contificoCustomerInvoiceLookupResult.appendChild(rawDetails);
+      hasContent = true;
+    } else if (!loading && !error && fetched) {
+      const emptyParagraph = document.createElement('p');
+      emptyParagraph.className = 'muted';
+      emptyParagraph.textContent =
+        'No se encontró una factura que coincida con el cliente y número proporcionados.';
+      contificoCustomerInvoiceLookupResult.appendChild(emptyParagraph);
+      hasContent = true;
+    }
+
+    contificoCustomerInvoiceLookupResult.classList.toggle('empty', !hasContent);
+  }
+}
+
 function renderContificoPreviewInvoiceLookup() {
   const isAdmin = state.token && state.user?.role === 'administrador';
   if (!isAdmin) {
@@ -5879,6 +6044,7 @@ function renderContificoPreview() {
   renderContificoPreviewProducts();
   renderContificoPreviewWarehouses();
   renderContificoPreviewCustomerInvoices();
+  renderContificoPreviewCustomerInvoiceLookup();
   renderContificoPreviewInvoiceLookup();
 }
 
@@ -6040,6 +6206,85 @@ async function handleContificoCustomerInvoicesFetch(event) {
   } finally {
     state.contificoPreviewCustomerInvoicesLoading = false;
     renderContificoPreviewCustomerInvoices();
+  }
+}
+
+async function handleContificoCustomerInvoiceLookup(event) {
+  if (event) {
+    event.preventDefault();
+  }
+  if (!state.token || !state.user || state.user.role !== 'administrador') {
+    showToast('Solo los administradores pueden consultar Contífico.', 'error');
+    return;
+  }
+  if (state.contificoPreviewCustomerInvoiceLookupLoading) {
+    return;
+  }
+
+  const rawDocument =
+    contificoCustomerInvoiceLookupDocumentInput?.value ??
+    state.contificoPreviewCustomerInvoiceLookupDocument ??
+    '';
+  const normalizedDocument = String(rawDocument).trim();
+
+  if (!normalizedDocument) {
+    state.contificoPreviewCustomerInvoiceLookupError =
+      'Ingresa un número de documento válido.';
+    state.contificoPreviewCustomerInvoiceLookup = null;
+    state.contificoPreviewCustomerInvoiceLookupFetched = true;
+    renderContificoPreviewCustomerInvoiceLookup();
+    showToast(state.contificoPreviewCustomerInvoiceLookupError, 'error');
+    return;
+  }
+
+  const rawNumber =
+    contificoCustomerInvoiceLookupNumberInput?.value ??
+    state.contificoPreviewCustomerInvoiceLookupNumber ??
+    '';
+  const normalizedNumber = String(rawNumber).trim();
+
+  if (!normalizedNumber) {
+    state.contificoPreviewCustomerInvoiceLookupError =
+      'Ingresa un número de factura válido.';
+    state.contificoPreviewCustomerInvoiceLookup = null;
+    state.contificoPreviewCustomerInvoiceLookupFetched = true;
+    renderContificoPreviewCustomerInvoiceLookup();
+    showToast(state.contificoPreviewCustomerInvoiceLookupError, 'error');
+    return;
+  }
+
+  state.contificoPreviewCustomerInvoiceLookupDocument = normalizedDocument;
+  state.contificoPreviewCustomerInvoiceLookupNumber = normalizedNumber;
+  state.contificoPreviewCustomerInvoiceLookupLoading = true;
+  state.contificoPreviewCustomerInvoiceLookupError = null;
+  state.contificoPreviewCustomerInvoiceLookupFetched = false;
+  state.contificoPreviewCustomerInvoiceLookup = null;
+  renderContificoPreviewCustomerInvoiceLookup();
+
+  try {
+    const response = await apiFetch(
+      `/temp/contifico/invoices/by-customer-and-number?customer_document=${encodeURIComponent(
+        normalizedDocument
+      )}&document_number=${encodeURIComponent(normalizedNumber)}`
+    );
+    state.contificoPreviewCustomerInvoiceLookup = response || null;
+    state.contificoPreviewCustomerInvoiceLookupFetched = true;
+    renderContificoPreviewCustomerInvoiceLookup();
+    if (state.contificoPreviewCustomerInvoiceLookup) {
+      showToast('Factura encontrada correctamente.', 'success');
+    } else {
+      showToast('No se encontraron resultados.', 'info');
+    }
+  } catch (error) {
+    state.contificoPreviewCustomerInvoiceLookupError =
+      error?.message || 'No se pudo consultar la factura solicitada.';
+    state.contificoPreviewCustomerInvoiceLookup = null;
+    state.contificoPreviewCustomerInvoiceLookupFetched = true;
+    renderContificoPreviewCustomerInvoiceLookup();
+    showToast(state.contificoPreviewCustomerInvoiceLookupError, 'error');
+  } finally {
+    state.contificoPreviewCustomerInvoiceLookupLoading = false;
+    renderContificoPreviewCustomerInvoiceLookup();
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -957,6 +957,50 @@
               <article class="contifico-preview-card">
                 <header class="contifico-preview-card-header">
                   <div>
+                    <h4>Factura por cliente y número</h4>
+                    <p class="muted small">
+                      Ingresa la cédula o RUC y el número de documento para obtener el detalle puntual.
+                    </p>
+                  </div>
+                </header>
+                <form id="contificoCustomerInvoiceLookupForm" class="form-grid contifico-preview-form">
+                  <div class="form-row">
+                    <label for="contificoCustomerInvoiceLookupDocument">Documento del cliente</label>
+                    <input
+                      type="text"
+                      id="contificoCustomerInvoiceLookupDocument"
+                      inputmode="numeric"
+                      autocomplete="off"
+                      placeholder="Ej. 0912345678"
+                      required
+                    />
+                  </div>
+                  <div class="form-row">
+                    <label for="contificoCustomerInvoiceLookupNumber">Número de documento</label>
+                    <input
+                      type="text"
+                      id="contificoCustomerInvoiceLookupNumber"
+                      autocomplete="off"
+                      placeholder="Ej. 001-001-0000001"
+                      required
+                    />
+                  </div>
+                  <div class="form-row contifico-preview-submit">
+                    <button type="submit" class="primary">Buscar detalle</button>
+                  </div>
+                </form>
+                <p
+                  id="contificoCustomerInvoiceLookupStatus"
+                  class="contifico-preview-status muted small"
+                  role="status"
+                  aria-live="polite"
+                ></p>
+                <div id="contificoCustomerInvoiceLookupResult" class="contifico-invoice-preview-result"></div>
+              </article>
+
+              <article class="contifico-preview-card">
+                <header class="contifico-preview-card-header">
+                  <div>
                     <h4>Buscar factura puntual</h4>
                     <p class="muted small">
                       Introduce el número completo del documento para validar una factura específica.

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2200,6 +2200,19 @@ th {
   color: var(--text-primary);
 }
 
+.contifico-invoice-preview-result {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(7, 10, 12, 0.04);
+  transition: background 0.2s ease;
+}
+
+.contifico-invoice-preview-result.empty {
+  background: none;
+  padding: 0;
+}
+
 .contifico-preview-card details {
   font-size: 0.85rem;
 }


### PR DESCRIPTION
## Summary
- extend the Contifico client to filter invoice lookups by customer before falling back to broader searches
- expose a new temporary API endpoint and tests to fetch invoices by customer ID and document number
- add a Contífico preview card and styling to query invoice details by client and document from the UI

## Testing
- pytest backend/tests/test_contifico_client.py backend/tests/test_invoice_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f4cb6f348332b0ddb35c5a25c12c