### PR TITLE
Require customer document for Contífico invoice lookups

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,7 +1,7 @@
-from typing import Iterable, List, Optional, Dict, Any, Tuple
+from typing import Iterable, List, Optional, Dict, Any, Tuple, Set
 
 from sqlalchemy import func, or_
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, load_only
 
 from . import auth, models, schemas
 
@@ -23,6 +23,17 @@ def _normalize_document_column(column):
     normalized = func.lower(column)
     for char in DOCUMENT_SANITIZE_CHARS:
         normalized = func.replace(normalized, char, "")
+    return normalized
+
+
+def _normalize_invoice_number(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    normalized = value.strip()
+    if normalized.upper().startswith("FAC"):
+        normalized = normalized[3:]
+    normalized = normalized.strip().lstrip("-:")
+    normalized = normalized.replace(" ", "")
     return normalized
 
 
@@ -418,6 +429,46 @@ def get_orders(
         items_query = items_query.limit(limit)
     orders = items_query.all()
     return orders, total
+
+
+def get_orders_for_customer_by_invoice_numbers(
+    db: Session, customer_id: int, invoice_numbers: Iterable[str]
+) -> Dict[str, List[models.Order]]:
+    normalized_targets: Set[str] = set()
+    for number in invoice_numbers:
+        if number is None:
+            continue
+        normalized = _normalize_invoice_number(str(number))
+        if normalized:
+            normalized_targets.add(normalized)
+    if not normalized_targets:
+        return {}
+
+    orders = (
+        db.query(models.Order)
+        .options(
+            load_only(
+                models.Order.id,
+                models.Order.order_number,
+                models.Order.status,
+                models.Order.invoice_number,
+                models.Order.created_at,
+                models.Order.delivery_date,
+            )
+        )
+        .filter(
+            models.Order.customer_id == customer_id,
+            models.Order.invoice_number.isnot(None),
+        )
+        .all()
+    )
+
+    mapping: Dict[str, List[models.Order]] = {}
+    for order in orders:
+        normalized = _normalize_invoice_number(order.invoice_number or "")
+        if normalized and normalized in normalized_targets:
+            mapping.setdefault(normalized, []).append(order)
+    return mapping
 
 
 def search_orders(

--- a/backend/app/invoice_jobs.py
+++ b/backend/app/invoice_jobs.py
@@ -34,6 +34,7 @@ class InvoiceLookupJob:
 
     id: str
     document_number: str
+    customer_document: Optional[str] = None
     status: InvoiceLookupJobStatus = InvoiceLookupJobStatus.PENDING
     progress: int = 0
     stage: str = "pending"
@@ -109,16 +110,25 @@ class InvoiceLookupJobManager:
             else:
                 self._max_job_duration = float(default_timeout)
 
-    async def start_job(self, document_number: str) -> InvoiceLookupJob:
+    async def start_job(
+        self, document_number: str, *, customer_document: str
+    ) -> InvoiceLookupJob:
         """Inicia un trabajo en segundo plano para buscar la factura."""
 
         normalized_number = document_number.strip()
-        job = InvoiceLookupJob(id=uuid4().hex, document_number=normalized_number)
+        normalized_customer = customer_document.strip()
+        if not normalized_customer:
+            raise ValueError("El documento del cliente es obligatorio para la búsqueda.")
+        job = InvoiceLookupJob(
+            id=uuid4().hex,
+            document_number=normalized_number,
+            customer_document=normalized_customer,
+        )
         async with self._lock:
             self._jobs[job.id] = job
         loop = asyncio.get_running_loop()
         self._loop = loop
-        loop.create_task(self._run_job(job.id, normalized_number))
+        loop.create_task(self._run_job(job.id, normalized_number, normalized_customer))
         return dataclasses.replace(job)
 
     async def get_job(self, job_id: str) -> Optional[InvoiceLookupJob]:
@@ -130,7 +140,9 @@ class InvoiceLookupJobManager:
                 return None
             return dataclasses.replace(job)
 
-    async def _run_job(self, job_id: str, document_number: str) -> None:
+    async def _run_job(
+        self, job_id: str, document_number: str, customer_document: str
+    ) -> None:
         await self._update_job(
             job_id,
             status=InvoiceLookupJobStatus.RUNNING,
@@ -144,6 +156,7 @@ class InvoiceLookupJobManager:
             asyncio.to_thread(
                 self._execute_lookup,
                 document_number,
+                customer_document,
                 progress_callback,
             )
         )
@@ -182,11 +195,13 @@ class InvoiceLookupJobManager:
     def _execute_lookup(
         self,
         document_number: str,
+        customer_document: str,
         progress_callback: Callable[[str, Dict[str, Any]], None],
     ) -> Dict[str, Any]:
         client = self._client_factory()
         invoice = client.find_invoice_by_document_number(
             document_number,
+            customer_document=customer_document,
             progress_callback=progress_callback,
         )
         if invoice is None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from typing import List, Optional, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Query, status
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
@@ -18,8 +19,10 @@ from .dependencies import (
     vendor_or_admin_required,
 )
 from .temp_contifico import (
+    build_invoice_page,
     build_product_page,
     build_warehouse_list,
+    fetch_invoice_by_customer_and_document,
     router as contifico_preview_router,
 )
 from .migrations import apply_schema_upgrades
@@ -162,6 +165,48 @@ def list_contifico_warehouses(
 
     _ = current_user
     return build_warehouse_list(contifico_client)
+
+
+@app.get(
+    "/integrations/contifico/invoices/by-customer",
+    response_model=schemas.ContificoInvoicePage,
+)
+def list_contifico_invoices_by_customer(
+    document_id: str = Query(..., min_length=3, max_length=30),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user: models.User = Depends(staff_required()),
+):
+    _ = current_user
+    normalized_document = document_id.strip()
+    return build_invoice_page(
+        contifico_client,
+        page=page,
+        page_size=page_size,
+        document_id=normalized_document,
+    )
+
+
+@app.get(
+    "/integrations/contifico/invoices/by-customer-and-number",
+    response_model=schemas.ContificoInvoice,
+)
+async def get_contifico_invoice_by_customer_and_number(
+    customer_document: str = Query(..., min_length=3, max_length=30),
+    document_number: str = Query(..., min_length=3, max_length=40),
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user: models.User = Depends(staff_required()),
+):
+    _ = current_user
+    normalized_customer = customer_document.strip()
+    normalized_number = document_number.strip()
+    return await run_in_threadpool(
+        fetch_invoice_by_customer_and_document,
+        contifico_client,
+        customer_document=normalized_customer,
+        document_number=normalized_number,
+    )
 
 
 @app.post(
@@ -332,6 +377,71 @@ def get_customer_endpoint(
     if not customer:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
     return customer
+
+
+@app.get(
+    "/customers/{customer_id}/contifico/invoices",
+    response_model=schemas.CustomerContificoInvoicePage,
+)
+def get_customer_contifico_invoices(
+    customer_id: int,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    db: Session = Depends(get_db),
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user: models.User = Depends(staff_required()),
+):
+    _ = current_user
+    customer = crud.get_customer(db, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cliente no encontrado")
+
+    document_id = (customer.document_id or "").strip()
+    if not document_id:
+        return schemas.CustomerContificoInvoicePage(
+            document_id="",
+            page=page,
+            page_size=page_size,
+            items=[],
+        )
+
+    invoice_page = build_invoice_page(
+        contifico_client,
+        page=page,
+        page_size=page_size,
+        document_id=document_id,
+    )
+
+    mapping = crud.get_orders_for_customer_by_invoice_numbers(
+        db,
+        customer.id,
+        [invoice.numero for invoice in invoice_page.items],
+    )
+
+    enriched_items: list[schemas.CustomerContificoInvoice] = []
+    for invoice in invoice_page.items:
+        normalized_number = ContificoClient._normalize_invoice_number(invoice.numero or "")
+        linked_orders = mapping.get(normalized_number, [])
+        linked_summaries = [
+            schemas.CustomerInvoiceOrderLink(
+                order_id=order.id,
+                order_number=order.order_number,
+                status=order.status,
+                created_at=order.created_at,
+                delivery_date=order.delivery_date,
+            )
+            for order in linked_orders
+        ]
+        enriched_items.append(
+            schemas.CustomerContificoInvoice(invoice=invoice, linked_orders=linked_summaries)
+        )
+
+    return schemas.CustomerContificoInvoicePage(
+        document_id=document_id,
+        page=invoice_page.page,
+        page_size=invoice_page.page_size,
+        items=enriched_items,
+    )
 
 
 @app.patch("/customers/{customer_id}", response_model=schemas.CustomerRead)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -465,8 +465,31 @@ class ContificoInvoicePage(BaseModel):
     page_size: int
 
 
+class CustomerInvoiceOrderLink(BaseModel):
+    order_id: int
+    order_number: str
+    status: OrderStatus
+    created_at: datetime
+    delivery_date: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustomerContificoInvoice(BaseModel):
+    invoice: ContificoInvoice
+    linked_orders: List[CustomerInvoiceOrderLink] = Field(default_factory=list)
+
+
+class CustomerContificoInvoicePage(BaseModel):
+    document_id: str
+    page: int
+    page_size: int
+    items: List[CustomerContificoInvoice] = Field(default_factory=list)
+
+
 class ContificoInvoiceLookupRequest(BaseModel):
     document_number: str = Field(min_length=3, max_length=40)
+    customer_document: str = Field(min_length=3, max_length=30)
 
 
 class ContificoInvoiceLookupJobStatus(str, Enum):
@@ -479,6 +502,7 @@ class ContificoInvoiceLookupJobStatus(str, Enum):
 class ContificoInvoiceLookupJob(BaseModel):
     id: str
     document_number: str
+    customer_document: Optional[str] = None
     status: ContificoInvoiceLookupJobStatus
     progress: int = Field(ge=0, le=100)
     stage: str

--- a/backend/app/temp_contifico.py
+++ b/backend/app/temp_contifico.py
@@ -79,11 +79,23 @@ def build_invoice_page(
 
 
 def fetch_invoice_by_document_number(
-    contifico_client: ContificoClient, *, document_number: str
+    contifico_client: ContificoClient,
+    *,
+    document_number: str,
+    customer_document: str,
 ) -> schemas.ContificoInvoice:
     invoice = None
+    normalized_customer = customer_document.strip()
+    if not normalized_customer:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="El número de documento del cliente es obligatorio.",
+        )
     try:
-        invoice = contifico_client.find_invoice_by_document_number(document_number)
+        invoice = contifico_client.find_invoice_by_document_number(
+            document_number,
+            customer_document=normalized_customer,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     except ContificoTransportError as exc:
@@ -148,6 +160,7 @@ def serialize_invoice_lookup_job(job) -> schemas.ContificoInvoiceLookupJob:
     return schemas.ContificoInvoiceLookupJob(
         id=job.id,
         document_number=job.document_number,
+        customer_document=job.customer_document,
         status=schemas.ContificoInvoiceLookupJobStatus(job.status.value),
         progress=job.progress,
         stage=job.stage,
@@ -206,17 +219,20 @@ def preview_contifico_invoices_by_customer(
 @router.get("/invoices/by-number", response_model=schemas.ContificoInvoice)
 async def preview_contifico_invoice_by_number(
     document_number: str = Query(..., min_length=3, max_length=40),
+    customer_document: str = Query(..., min_length=3, max_length=30),
     contifico_client: ContificoClient = Depends(get_contifico_client),
     current_user=Depends(admin_required()),
 ):
-    """Busca una factura por su número de documento."""
+    """Busca una factura por su número de documento validando el cliente."""
 
     _ = current_user
     normalized_number = document_number.strip()
+    normalized_customer = customer_document.strip()
     return await run_in_threadpool(
         fetch_invoice_by_document_number,
         contifico_client,
         document_number=normalized_number,
+        customer_document=normalized_customer,
     )
 
 
@@ -256,7 +272,15 @@ async def start_contifico_invoice_lookup_job(
     """Inicia una búsqueda asíncrona de factura en Contífico."""
 
     _ = current_user
-    job = await job_manager.start_job(payload.document_number)
+    try:
+        job = await job_manager.start_job(
+            payload.document_number, customer_document=payload.customer_document
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     return serialize_invoice_lookup_job(job)
 
 
@@ -287,4 +311,5 @@ __all__ = [
     "build_warehouse_list",
     "build_invoice_page",
     "fetch_invoice_by_document_number",
+    "fetch_invoice_by_customer_and_document",
 ]

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -1187,10 +1187,12 @@ def test_fetch_invoice_by_document_number_success() -> None:
             progress_callback=None,
         ):
             assert document_number == "001-001-0000003"
-            assert customer_document is None
+            assert customer_document == "0912345678"
             return {"id": 3, "numero": "001-001-0000003", "cliente": "Lucía"}
 
-    result = fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000003")
+    result = fetch_invoice_by_document_number(
+        StubClient(), document_number="001-001-0000003", customer_document="0912345678"
+    )
 
     assert result.numero == "001-001-0000003"
     assert result.cliente == "Lucía"
@@ -1206,11 +1208,13 @@ def test_fetch_invoice_by_document_number_not_found() -> None:
             progress_callback=None,
         ):
             assert document_number == "001-001-0000004"
-            assert customer_document is None
+            assert customer_document == "0912345678"
             return None
 
     with pytest.raises(HTTPException) as exc_info:
-        fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000004")
+        fetch_invoice_by_document_number(
+            StubClient(), document_number="001-001-0000004", customer_document="0912345678"
+        )
 
     assert exc_info.value.status_code == 404
     assert "No se encontró" in exc_info.value.detail
@@ -1226,11 +1230,13 @@ def test_fetch_invoice_by_document_number_handles_api_404() -> None:
             progress_callback=None,
         ):
             assert document_number == "001-001-0000005"
-            assert customer_document is None
+            assert customer_document == "0912345678"
             raise ContificoAPIError(status.HTTP_404_NOT_FOUND, "Sin resultados")
 
     with pytest.raises(HTTPException) as exc_info:
-        fetch_invoice_by_document_number(StubClient(), document_number="001-001-0000005")
+        fetch_invoice_by_document_number(
+            StubClient(), document_number="001-001-0000005", customer_document="0912345678"
+        )
 
     assert exc_info.value.status_code == 404
     assert "No se encontró" in exc_info.value.detail

--- a/backend/tests/test_customer_contifico_invoices.py
+++ b/backend/tests/test_customer_contifico_invoices.py
@@ -1,0 +1,196 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-value-32-chars!!")
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import auth, crud, main, models, schemas
+from app.database import Base
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def create_staff_user(
+    session,
+    username: str = "staff",
+    *,
+    role: models.UserRole = models.UserRole.SASTRE,
+) -> models.User:
+    user = models.User(
+        username=username,
+        full_name=f"{username.title()} User",
+        role=role,
+        password_hash=auth.get_password_hash("secret"),
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def create_customer(session, *, document_id: str = "0912345678") -> models.Customer:
+    customer = models.Customer(
+        full_name="Cliente de Prueba",
+        document_id=document_id,
+        phone="0990000000",
+    )
+    session.add(customer)
+    session.commit()
+    session.refresh(customer)
+    return customer
+
+
+def create_order(
+    session,
+    customer: models.Customer,
+    *,
+    order_number: str,
+    invoice_number: str,
+) -> models.Order:
+    order = models.Order(
+        order_number=order_number,
+        customer_id=customer.id,
+        customer_name=customer.full_name,
+        customer_document=customer.document_id,
+        customer_contact=customer.phone,
+        status=models.OrderStatus.EN_TIENDA_BATAN,
+        measurements=[],
+        origin_branch=models.Establishment.BATAN,
+        invoice_number=invoice_number,
+    )
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return order
+
+
+def test_get_orders_for_customer_by_invoice_numbers_matches_variants(db_session):
+    customer = create_customer(db_session, document_id="0999999999")
+    first_order = create_order(
+        db_session,
+        customer,
+        order_number="ORD-100",
+        invoice_number="FAC 001-001-000123",
+    )
+    second_order = create_order(
+        db_session,
+        customer,
+        order_number="ORD-101",
+        invoice_number="001-001-000124",
+    )
+    third_order = create_order(
+        db_session,
+        customer,
+        order_number="ORD-102",
+        invoice_number="FAC: 001-001-000125",
+    )
+
+    mapping = crud.get_orders_for_customer_by_invoice_numbers(
+        db_session,
+        customer.id,
+        [
+            " 001-001-000123  ",
+            "fac001-001-000124",
+            "fac:001-001-000125",
+            None,
+            "",
+        ],
+    )
+
+    assert set(mapping.keys()) == {"001-001-000123", "001-001-000124", "001-001-000125"}
+    assert [order.id for order in mapping["001-001-000123"]] == [first_order.id]
+    assert [order.id for order in mapping["001-001-000124"]] == [second_order.id]
+    assert [order.id for order in mapping["001-001-000125"]] == [third_order.id]
+
+
+def test_get_customer_contifico_invoices_links_orders(monkeypatch, db_session):
+    staff_user = create_staff_user(db_session)
+    customer = create_customer(db_session, document_id="0911223344")
+    linked_order = create_order(
+        db_session,
+        customer,
+        order_number="ORD-200",
+        invoice_number="FAC 001-002-000999",
+    )
+    _ = create_order(
+        db_session,
+        customer,
+        order_number="ORD-201",
+        invoice_number="999-999-999999",
+    )
+
+    invoice_match = schemas.ContificoInvoice(
+        id=1,
+        numero="001-002-000999",
+        cliente="Cliente de Prueba",
+        identificacion=customer.document_id,
+        fecha_emision="2024-01-01",
+        estado="AUTORIZADO",
+        total=150.5,
+    )
+    invoice_other = schemas.ContificoInvoice(
+        id=2,
+        numero="000-123-456789",
+        cliente="Otro Cliente",
+        identificacion="0000000000",
+        fecha_emision="2024-02-01",
+        estado="AUTORIZADO",
+        total=50.0,
+    )
+
+    def fake_build_invoice_page(contifico_client, *, page, page_size, document_id):
+        assert document_id == customer.document_id
+        return schemas.ContificoInvoicePage(
+            items=[invoice_match, invoice_other],
+            page=page,
+            page_size=page_size,
+        )
+
+    monkeypatch.setattr(main, "build_invoice_page", fake_build_invoice_page)
+
+    result = main.get_customer_contifico_invoices(
+        customer.id,
+        page=2,
+        page_size=10,
+        db=db_session,
+        contifico_client=object(),
+        current_user=staff_user,
+    )
+
+    assert result.document_id == customer.document_id
+    assert result.page == 2
+    assert result.page_size == 10
+    assert [item.invoice.numero for item in result.items] == [
+        "001-002-000999",
+        "000-123-456789",
+    ]
+    linked_numbers = {
+        item.invoice.numero: [link.order_id for link in item.linked_orders]
+        for item in result.items
+    }
+    assert linked_numbers["001-002-000999"] == [linked_order.id]
+    assert linked_numbers["000-123-456789"] == []

--- a/backend/tests/test_invoice_jobs.py
+++ b/backend/tests/test_invoice_jobs.py
@@ -15,9 +15,11 @@ class FakeClient:
         *,
         invoice: dict | None = None,
         exception_factory: Callable[[], Exception] | None = None,
+        expected_customer_document: str = "0912345678",
     ) -> None:
         self._invoice = invoice
         self._exception_factory = exception_factory
+        self._expected_customer_document = expected_customer_document
 
     def find_invoice_by_document_number(
         self,
@@ -26,6 +28,7 @@ class FakeClient:
         customer_document: str | None = None,
         progress_callback=None,
     ):
+        assert customer_document == self._expected_customer_document
         if progress_callback:
             progress_callback("start", {"progress": 5, "document_number": document_number})
         if self._exception_factory is not None:
@@ -59,7 +62,9 @@ def test_invoice_lookup_job_manager_completes_successfully() -> None:
     )
 
     async def scenario() -> object:
-        job = await manager.start_job("001-001-0000009")
+        job = await manager.start_job(
+            "001-001-0000009", customer_document="0912345678"
+        )
         return await wait_for_completion(manager, job.id)
 
     final_job = asyncio.run(scenario())
@@ -69,13 +74,16 @@ def test_invoice_lookup_job_manager_completes_successfully() -> None:
     assert final_job.stage == "completed"
     assert final_job.result == {"id": 1, "numero": "001-001-0000009"}
     assert final_job.metadata.get("document_number") == "001-001-0000009"
+    assert final_job.customer_document == "0912345678"
 
 
 def test_invoice_lookup_job_manager_marks_not_found() -> None:
     manager = InvoiceLookupJobManager(client_factory=lambda: FakeClient(invoice=None))
 
     async def scenario() -> object:
-        job = await manager.start_job("001-001-0000999")
+        job = await manager.start_job(
+            "001-001-0000999", customer_document="0912345678"
+        )
         return await wait_for_completion(manager, job.id)
 
     final_job = asyncio.run(scenario())
@@ -94,7 +102,9 @@ def test_invoice_lookup_job_manager_reports_transport_error() -> None:
     )
 
     async def scenario() -> object:
-        job = await manager.start_job("001-001-0000123")
+        job = await manager.start_job(
+            "001-001-0000123", customer_document="0912345678"
+        )
         return await wait_for_completion(manager, job.id)
 
     final_job = asyncio.run(scenario())
@@ -126,7 +136,9 @@ def test_invoice_lookup_job_manager_times_out_long_running_job() -> None:
     )
 
     async def scenario() -> tuple[object, object]:
-        job = await manager.start_job("001-001-0000001")
+        job = await manager.start_job(
+            "001-001-0000001", customer_document="0912345678"
+        )
         # Espera suficiente para que se registre el timeout sin bloquear el hilo.
         await asyncio.sleep(0.02)
         interim_job = await manager.get_job(job.id)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,6 +9,7 @@ const ORDER_TASK_STATUS_COMPLETED = 'completado';
 const KANBAN_FETCH_PAGE_SIZE = 100;
 const KANBAN_FALLBACK_STATUS = 'Sin estado';
 const INVOICE_LOOKUP_LOG_PREFIX = '[Contífico][Factura puntual]';
+const CUSTOMER_INVOICE_PAGE_SIZE = 50;
 
 
 const state = {
@@ -54,6 +55,20 @@ const state = {
   customerRequestId: 0,
   orderRequestId: 0,
   customerOptionsRequestId: 0,
+  customerInvoicesCache: {},
+  customerInvoicesRequestId: 0,
+  orderInvoiceSuggestions: [],
+  orderInvoiceSuggestionsCustomerId: null,
+  orderInvoiceSuggestionRequestId: 0,
+  orderInvoiceSuggestionsLoading: false,
+  orderInvoiceSuggestionsError: null,
+  orderInvoiceLookup: null,
+  orderInvoiceLookupLoading: false,
+  orderInvoiceLookupError: null,
+  orderInvoiceLookupCustomerId: null,
+  orderInvoiceLookupNumber: '',
+  orderInvoiceLookupRequestId: 0,
+  pendingOrderCustomerSelection: null,
   contificoPreviewProducts: [],
   contificoPreviewProductsPage: 1,
   contificoPreviewProductsPageSize: CONTIFICO_DEFAULT_PAGE_SIZE,
@@ -82,6 +97,7 @@ const state = {
   contificoPreviewInvoiceLookupError: null,
   contificoPreviewInvoiceLookupFetched: false,
   contificoPreviewInvoiceLookupNumber: '',
+  contificoPreviewInvoiceLookupCustomerDocument: '',
   contificoPreviewInvoiceLookupRequestId: 0,
   contificoPreviewInvoiceLookupProgress: 0,
   contificoPreviewInvoiceLookupStage: '',
@@ -286,6 +302,10 @@ const customerDetailDialog = document.getElementById('customerDetailDialog');
 const customerDetailTitle = document.getElementById('customerDetailTitle');
 const customerDetailSummaryElement = document.getElementById('customerDetailSummary');
 const customerOrderHistoryContainer = document.getElementById('customerOrderHistory');
+const customerInvoicesSection = document.getElementById('customerInvoicesSection');
+const customerInvoicesStatus = document.getElementById('customerInvoicesStatus');
+const customerInvoicesTableBody = document.getElementById('customerInvoicesTableBody');
+const customerInvoicesRefreshButton = document.getElementById('customerInvoicesRefreshButton');
 const customerMeasurementsContainer = document.getElementById('customerMeasurementsContainer');
 const updateCustomerMeasurementsContainer = document.getElementById('updateCustomerMeasurementsContainer');
 const updateCustomerNameInput = document.getElementById('updateCustomerName');
@@ -295,6 +315,7 @@ const addCustomerMeasurementSetButton = document.getElementById('addCustomerMeas
 const addUpdateCustomerMeasurementSetButton = document.getElementById('addUpdateCustomerMeasurementSet');
 const deleteCustomerButton = document.getElementById('deleteCustomerButton');
 const orderCustomerSelect = document.getElementById('orderCustomerSelect');
+const orderCreateCustomerButton = document.getElementById('orderCreateCustomerButton');
 const customerMeasurementOptions = document.getElementById('customerMeasurementOptions');
 const ordersTableBody = document.getElementById('ordersTableBody');
 const orderPageSizeSelect = document.getElementById('orderPageSize');
@@ -310,6 +331,10 @@ const statusSelect = document.getElementById('newOrderStatus');
 const assignTailorSelect = document.getElementById('assignTailor');
 const assignVendorSelect = document.getElementById('assignVendor');
 const newOrderInvoiceInput = document.getElementById('newOrderInvoice');
+const orderInvoiceSuggestionsStatus = document.getElementById('orderInvoiceSuggestionsStatus');
+const orderInvoiceSuggestionsList = document.getElementById('orderInvoiceSuggestions');
+const orderInvoiceLookupButton = document.getElementById('orderInvoiceLookupButton');
+const orderInvoiceLookupDetails = document.getElementById('orderInvoiceLookupDetails');
 const newOrderOriginSelect = document.getElementById('newOrderOrigin');
 const newOrderDeliveryDateInput = document.getElementById('newOrderDeliveryDate');
 const orderDetail = document.getElementById('orderDetail');
@@ -371,6 +396,9 @@ const contificoCustomerInvoiceLookupResult = document.getElementById(
   'contificoCustomerInvoiceLookupResult'
 );
 const contificoInvoiceLookupForm = document.getElementById('contificoInvoiceLookupForm');
+const contificoInvoiceLookupDocumentInput = document.getElementById(
+  'contificoInvoiceLookupDocument'
+);
 const contificoInvoiceLookupNumberInput = document.getElementById('contificoInvoiceLookupNumber');
 const contificoInvoiceLookupStatus = document.getElementById('contificoInvoiceLookupStatus');
 const contificoCustomerInvoicesModalButton = document.getElementById('contificoCustomerInvoicesModalButton');
@@ -438,6 +466,7 @@ let currentOrderDetailHost = null;
 let lastKanbanFocusedElement = null;
 let lastKanbanFocusedOrderId = null;
 let lastCustomerDetailTrigger = null;
+let lastCreateCustomerTrigger = null;
 let lastContificoCustomerInvoicesTrigger = null;
 let lastContificoInvoiceLookupTrigger = null;
 
@@ -1870,6 +1899,7 @@ function resetCreateOrderForm() {
     addNewOrderTaskRow();
   }
   renderCustomerMeasurementOptions(null);
+  clearOrderInvoiceSuggestions();
 }
 
 function resetCreateCustomerForm() {
@@ -1898,6 +1928,7 @@ function setCreateCustomerVisible(visible) {
     showCreateCustomerButton.classList.toggle('hidden', visible);
   }
   if (visible) {
+    lastCreateCustomerTrigger = document.activeElement;
     if (customerMeasurementsContainer && !customerMeasurementsContainer.children.length) {
       createMeasurementSetBlock(customerMeasurementsContainer);
     }
@@ -1909,8 +1940,18 @@ function setCreateCustomerVisible(visible) {
       firstField?.focus();
     });
   } else {
+    if (
+      state.pendingOrderCustomerSelection?.source === 'order' &&
+      !state.pendingOrderCustomerSelection?.customerId
+    ) {
+      state.pendingOrderCustomerSelection = null;
+    }
     resetCreateCustomerForm();
-    if (showCreateCustomerButton?.isConnected) {
+    const trigger = lastCreateCustomerTrigger;
+    lastCreateCustomerTrigger = null;
+    if (trigger?.isConnected) {
+      trigger.focus();
+    } else if (showCreateCustomerButton?.isConnected) {
       showCreateCustomerButton.focus();
     }
   }
@@ -2141,6 +2182,7 @@ function updateNavigationForAuth() {
     }
   }
   updateDashboardShortcutVisibility();
+  updateOrderInvoiceLookupButtonState();
 }
 
 async function bootstrapAuthenticatedSession({ showWelcomeToast = false } = {}) {
@@ -2512,8 +2554,24 @@ async function refreshCustomerOptions() {
     }
     state.customerOptions = collected;
     if (orderCustomerSelect) {
-      populateCustomerSelect(orderCustomerSelect, orderCustomerSelect.value || '');
+      let desiredValue = orderCustomerSelect.value || '';
+      if (
+        state.pendingOrderCustomerSelection?.source === 'order' &&
+        state.pendingOrderCustomerSelection?.customerId
+      ) {
+        desiredValue = String(state.pendingOrderCustomerSelection.customerId);
+      }
+      populateCustomerSelect(orderCustomerSelect, desiredValue);
+      if (desiredValue) {
+        orderCustomerSelect.value = desiredValue;
+      }
       handleOrderCustomerChange();
+      if (
+        state.pendingOrderCustomerSelection?.source === 'order' &&
+        state.pendingOrderCustomerSelection?.customerId
+      ) {
+        state.pendingOrderCustomerSelection = null;
+      }
     }
   } catch (error) {
     if (state.customerOptionsRequestId === requestId) {
@@ -2572,6 +2630,516 @@ async function loadAuditLogs() {
     renderAuditLogs();
   } catch (error) {
     showToast(error.message, 'error');
+  }
+}
+
+function getCachedCustomerInvoices(customerId) {
+  const numericId = Number(customerId);
+  if (!Number.isFinite(numericId) || numericId <= 0) {
+    return null;
+  }
+  const cacheKey = String(numericId);
+  const cached = state.customerInvoicesCache[cacheKey];
+  if (!cached || !Array.isArray(cached.items)) {
+    return null;
+  }
+  return cached;
+}
+
+function updateOrderInvoiceLookupButtonState() {
+  if (!orderInvoiceLookupButton) return;
+  const hasToken = Boolean(state.token);
+  const hasCustomer = Number(orderCustomerSelect?.value) > 0;
+  const invoiceValue = newOrderInvoiceInput?.value?.trim() || '';
+  orderInvoiceLookupButton.disabled =
+    !hasToken || state.orderInvoiceLookupLoading || !hasCustomer || !invoiceValue;
+}
+
+function renderOrderInvoiceLookupDetails() {
+  if (!orderInvoiceLookupDetails) {
+    updateOrderInvoiceLookupButtonState();
+    return;
+  }
+  orderInvoiceLookupDetails.innerHTML = '';
+  orderInvoiceLookupDetails.classList.remove('status-error', 'status-success');
+  const { orderInvoiceLookupLoading, orderInvoiceLookupError, orderInvoiceLookup } = state;
+  if (orderInvoiceLookupLoading) {
+    orderInvoiceLookupDetails.textContent = 'Consultando factura en Contífico...';
+    orderInvoiceLookupDetails.classList.remove('hidden');
+  } else if (orderInvoiceLookupError) {
+    orderInvoiceLookupDetails.textContent = orderInvoiceLookupError;
+    orderInvoiceLookupDetails.classList.remove('hidden');
+    orderInvoiceLookupDetails.classList.add('status-error');
+  } else if (orderInvoiceLookup) {
+    const summary = document.createElement('div');
+    summary.className = 'invoice-lookup-summary';
+    const number = document.createElement('span');
+    number.className = 'invoice-lookup-number';
+    number.textContent =
+      orderInvoiceLookup.numero || state.orderInvoiceLookupNumber || 'Factura confirmada';
+    summary.append('Factura confirmada: ', number);
+    orderInvoiceLookupDetails.appendChild(summary);
+
+    const metaValues = [];
+    if (orderInvoiceLookup.cliente) {
+      metaValues.push(`Cliente: ${orderInvoiceLookup.cliente}`);
+    }
+    if (orderInvoiceLookup.fecha_emision) {
+      metaValues.push(`Emisión: ${formatDate(orderInvoiceLookup.fecha_emision)}`);
+    }
+    if (orderInvoiceLookup.estado) {
+      metaValues.push(`Estado: ${orderInvoiceLookup.estado}`);
+    }
+    if (
+      typeof orderInvoiceLookup.total === 'number' &&
+      Number.isFinite(orderInvoiceLookup.total)
+    ) {
+      metaValues.push(`Total: ${formatCurrencyUSD(orderInvoiceLookup.total)}`);
+    }
+    if (metaValues.length) {
+      const metaList = document.createElement('ul');
+      metaList.className = 'invoice-lookup-meta';
+      metaValues.forEach((value) => {
+        const item = document.createElement('li');
+        item.textContent = value;
+        metaList.appendChild(item);
+      });
+      orderInvoiceLookupDetails.appendChild(metaList);
+    }
+    orderInvoiceLookupDetails.classList.remove('hidden');
+    orderInvoiceLookupDetails.classList.add('status-success');
+  } else {
+    orderInvoiceLookupDetails.classList.add('hidden');
+  }
+  updateOrderInvoiceLookupButtonState();
+}
+
+function clearOrderInvoiceLookup() {
+  state.orderInvoiceLookup = null;
+  state.orderInvoiceLookupError = null;
+  state.orderInvoiceLookupLoading = false;
+  state.orderInvoiceLookupCustomerId = null;
+  state.orderInvoiceLookupNumber = '';
+  state.orderInvoiceLookupRequestId = 0;
+  renderOrderInvoiceLookupDetails();
+}
+
+function setOrderInvoiceSuggestionsStatus(message, { isError = false } = {}) {
+  if (!orderInvoiceSuggestionsStatus) return;
+  orderInvoiceSuggestionsStatus.textContent = message || '';
+  orderInvoiceSuggestionsStatus.classList.toggle('status-error', Boolean(isError));
+}
+
+function renderOrderInvoiceSuggestions() {
+  updateOrderInvoiceLookupButtonState();
+  if (orderInvoiceSuggestionsList) {
+    orderInvoiceSuggestionsList.innerHTML = '';
+    const suggestions = Array.isArray(state.orderInvoiceSuggestions)
+      ? state.orderInvoiceSuggestions
+      : [];
+    const seenNumbers = new Set();
+    suggestions.forEach((entry) => {
+      const invoiceData = entry?.invoice || entry || {};
+      const rawNumber = invoiceData?.numero;
+      const invoiceNumber = typeof rawNumber === 'string' ? rawNumber.trim() : '';
+      if (!invoiceNumber || seenNumbers.has(invoiceNumber)) {
+        return;
+      }
+      seenNumbers.add(invoiceNumber);
+      const option = document.createElement('option');
+      option.value = invoiceNumber;
+      const parts = [invoiceNumber];
+      if (invoiceData?.fecha_emision) {
+        parts.push(invoiceData.fecha_emision);
+      }
+      if (typeof invoiceData?.total === 'number' && Number.isFinite(invoiceData.total)) {
+        parts.push(formatCurrencyUSD(invoiceData.total));
+      }
+      option.label = parts.join(' • ');
+      orderInvoiceSuggestionsList.appendChild(option);
+    });
+  }
+
+  if (!state.orderInvoiceSuggestionsCustomerId) {
+    setOrderInvoiceSuggestionsStatus(
+      'Selecciona un cliente para ver las facturas sugeridas.'
+    );
+    return;
+  }
+  if (state.orderInvoiceSuggestionsLoading) {
+    setOrderInvoiceSuggestionsStatus('Consultando facturas del cliente...');
+    return;
+  }
+  if (state.orderInvoiceSuggestionsError) {
+    setOrderInvoiceSuggestionsStatus(state.orderInvoiceSuggestionsError, { isError: true });
+    return;
+  }
+  if (!state.orderInvoiceSuggestions || !state.orderInvoiceSuggestions.length) {
+    setOrderInvoiceSuggestionsStatus('No se encontraron facturas recientes para el cliente.');
+    return;
+  }
+  setOrderInvoiceSuggestionsStatus(
+    'Selecciona un número de la lista o ingrésalo manualmente.'
+  );
+  updateOrderInvoiceLookupButtonState();
+}
+
+function clearOrderInvoiceSuggestions() {
+  state.orderInvoiceSuggestions = [];
+  state.orderInvoiceSuggestionsCustomerId = null;
+  state.orderInvoiceSuggestionsError = null;
+  state.orderInvoiceSuggestionsLoading = false;
+  if (orderInvoiceSuggestionsList) {
+    orderInvoiceSuggestionsList.innerHTML = '';
+  }
+  setOrderInvoiceSuggestionsStatus('Selecciona un cliente para ver las facturas sugeridas.');
+  clearOrderInvoiceLookup();
+}
+
+async function fetchCustomerInvoicesData(customerId, { force = false } = {}) {
+  if (!state.token) {
+    throw new Error('Inicia sesión para consultar las facturas del cliente.');
+  }
+  const numericId = Number(customerId);
+  if (!Number.isFinite(numericId) || numericId <= 0) {
+    throw new Error('El cliente seleccionado no es válido.');
+  }
+  const cacheKey = String(numericId);
+  if (!force) {
+    const cached = getCachedCustomerInvoices(numericId);
+    if (cached) {
+      return cached;
+    }
+  }
+  const params = new URLSearchParams({
+    page: '1',
+    page_size: String(CUSTOMER_INVOICE_PAGE_SIZE),
+  });
+  const response = await apiFetch(
+    `/customers/${numericId}/contifico/invoices?${params.toString()}`
+  );
+  const items = Array.isArray(response?.items) ? response.items : [];
+  const cacheEntry = {
+    customerId: numericId,
+    documentId: typeof response?.document_id === 'string' ? response.document_id : '',
+    page: typeof response?.page === 'number' ? response.page : 1,
+    pageSize:
+      typeof response?.page_size === 'number' ? response.page_size : CUSTOMER_INVOICE_PAGE_SIZE,
+    items,
+    fetchedAt: Date.now(),
+  };
+  state.customerInvoicesCache[cacheKey] = cacheEntry;
+  return cacheEntry;
+}
+
+async function loadOrderInvoiceSuggestions(customer, options = {}) {
+  const { force = false } = options;
+  if (!orderInvoiceSuggestionsStatus) return;
+  if (!customer || !customer.id || !customer.document_id) {
+    clearOrderInvoiceSuggestions();
+    return;
+  }
+  const numericId = Number(customer.id);
+  if (!Number.isFinite(numericId) || numericId <= 0) {
+    clearOrderInvoiceSuggestions();
+    return;
+  }
+  state.orderInvoiceSuggestionsCustomerId = numericId;
+  state.orderInvoiceSuggestionsLoading = true;
+  state.orderInvoiceSuggestionsError = null;
+
+  const cached = !force ? getCachedCustomerInvoices(numericId) : null;
+  if (cached) {
+    state.orderInvoiceSuggestions = cached.items || [];
+    state.orderInvoiceSuggestionsLoading = false;
+    renderOrderInvoiceSuggestions();
+    return;
+  }
+
+  renderOrderInvoiceSuggestions();
+  const requestId = Date.now();
+  state.orderInvoiceSuggestionRequestId = requestId;
+  try {
+    const data = await fetchCustomerInvoicesData(numericId, { force });
+    if (state.orderInvoiceSuggestionRequestId !== requestId) {
+      return;
+    }
+    state.orderInvoiceSuggestions = Array.isArray(data?.items) ? data.items : [];
+    state.orderInvoiceSuggestionsLoading = false;
+    renderOrderInvoiceSuggestions();
+  } catch (error) {
+    if (state.orderInvoiceSuggestionRequestId !== requestId) {
+      return;
+    }
+    state.orderInvoiceSuggestions = [];
+    state.orderInvoiceSuggestionsLoading = false;
+    state.orderInvoiceSuggestionsError = error?.message || 'No se pudo consultar Contífico.';
+    renderOrderInvoiceSuggestions();
+  }
+}
+
+async function handleOrderInvoiceLookup() {
+  if (!orderInvoiceLookupButton) return;
+  if (!state.token) {
+    showToast('Inicia sesión para consultar Contífico.', 'error');
+    return;
+  }
+  const selectedCustomerId = Number(orderCustomerSelect?.value);
+  if (!Number.isFinite(selectedCustomerId) || selectedCustomerId <= 0) {
+    showToast('Selecciona un cliente antes de consultar la factura.', 'error');
+    return;
+  }
+  const invoiceNumber = newOrderInvoiceInput?.value?.trim() || '';
+  if (!invoiceNumber) {
+    showToast('Ingresa un número de factura para consultarlo.', 'error');
+    newOrderInvoiceInput?.focus();
+    return;
+  }
+
+  const customer =
+    (state.customerOptions || []).find((item) => item.id === selectedCustomerId) ||
+    (state.customers || []).find((item) => item.id === selectedCustomerId) ||
+    null;
+  const documentInput = document.getElementById('newCustomerDocument');
+  const fallbackDocument = documentInput?.value?.trim() || '';
+  const documentId = customer?.document_id?.trim?.() || fallbackDocument;
+  if (!documentId) {
+    showToast(
+      'El cliente seleccionado no tiene un número de documento registrado.',
+      'error'
+    );
+    return;
+  }
+
+  const requestId = Date.now();
+  state.orderInvoiceLookupRequestId = requestId;
+  state.orderInvoiceLookupLoading = true;
+  state.orderInvoiceLookupError = null;
+  state.orderInvoiceLookup = null;
+  state.orderInvoiceLookupCustomerId = selectedCustomerId;
+  state.orderInvoiceLookupNumber = invoiceNumber;
+  renderOrderInvoiceLookupDetails();
+
+  try {
+    const params = new URLSearchParams({
+      customer_document: documentId,
+      document_number: invoiceNumber,
+    });
+    const response = await apiFetch(
+      `/integrations/contifico/invoices/by-customer-and-number?${params.toString()}`
+    );
+    if (state.orderInvoiceLookupRequestId !== requestId) {
+      return;
+    }
+    state.orderInvoiceLookupLoading = false;
+    state.orderInvoiceLookupError = null;
+    state.orderInvoiceLookup = response || null;
+    const normalizedNumber =
+      typeof response?.numero === 'string' && response.numero.trim()
+        ? response.numero.trim()
+        : invoiceNumber;
+    state.orderInvoiceLookupNumber = normalizedNumber;
+    if (newOrderInvoiceInput && normalizedNumber) {
+      newOrderInvoiceInput.value = normalizedNumber;
+    }
+
+    const numericId = selectedCustomerId;
+    const cacheKey = String(numericId);
+    const cacheEntry = getCachedCustomerInvoices(numericId);
+    const newInvoiceEntry = { invoice: response, linked_orders: [] };
+    if (cacheEntry) {
+      const items = Array.isArray(cacheEntry.items) ? cacheEntry.items : [];
+      const existingIndex = items.findIndex(
+        (entry) => (entry?.invoice?.numero || '').trim() === normalizedNumber
+      );
+      if (existingIndex >= 0) {
+        items[existingIndex] = { ...items[existingIndex], invoice: response };
+      } else {
+        items.unshift(newInvoiceEntry);
+      }
+      cacheEntry.items = items;
+      cacheEntry.documentId = cacheEntry.documentId || documentId;
+      cacheEntry.fetchedAt = Date.now();
+    } else {
+      state.customerInvoicesCache[cacheKey] = {
+        customerId: numericId,
+        documentId,
+        page: 1,
+        pageSize: CUSTOMER_INVOICE_PAGE_SIZE,
+        items: [newInvoiceEntry],
+        fetchedAt: Date.now(),
+      };
+    }
+    if (state.selectedCustomerId === numericId) {
+      renderCustomerInvoices(numericId);
+    }
+
+    if (state.orderInvoiceSuggestionsCustomerId === numericId) {
+      const suggestions = Array.isArray(state.orderInvoiceSuggestions)
+        ? [...state.orderInvoiceSuggestions]
+        : [];
+      const existingSuggestionIndex = suggestions.findIndex((entry) => {
+        const invoiceData = entry?.invoice || entry || {};
+        return (invoiceData.numero || '').trim() === normalizedNumber;
+      });
+      if (existingSuggestionIndex >= 0) {
+        suggestions[existingSuggestionIndex] = {
+          ...suggestions[existingSuggestionIndex],
+          invoice: response,
+        };
+      } else {
+        suggestions.unshift(newInvoiceEntry);
+      }
+      state.orderInvoiceSuggestions = suggestions;
+      state.orderInvoiceSuggestionsError = null;
+      renderOrderInvoiceSuggestions();
+    }
+
+    renderOrderInvoiceLookupDetails();
+    showToast('Factura confirmada en Contífico.', 'success');
+  } catch (error) {
+    if (state.orderInvoiceLookupRequestId !== requestId) {
+      return;
+    }
+    state.orderInvoiceLookupLoading = false;
+    state.orderInvoiceLookup = null;
+    state.orderInvoiceLookupError =
+      error?.message || 'No se pudo consultar la factura en Contífico.';
+    renderOrderInvoiceLookupDetails();
+    showToast(state.orderInvoiceLookupError, 'error');
+  }
+}
+
+function setCustomerInvoicesStatus(message, { isError = false } = {}) {
+  if (!customerInvoicesStatus) return;
+  customerInvoicesStatus.textContent = message || '';
+  customerInvoicesStatus.classList.toggle('status-error', Boolean(isError));
+}
+
+function clearCustomerInvoices() {
+  if (customerInvoicesTableBody) {
+    customerInvoicesTableBody.innerHTML = '';
+  }
+  setCustomerInvoicesStatus('Selecciona un cliente para consultar sus facturas en Contífico.');
+}
+
+function renderCustomerInvoices(customerId) {
+  if (!customerInvoicesTableBody) return;
+  const cacheEntry = getCachedCustomerInvoices(customerId);
+  const invoices = Array.isArray(cacheEntry?.items) ? cacheEntry.items : [];
+  customerInvoicesTableBody.innerHTML = '';
+  if (!invoices.length) {
+    setCustomerInvoicesStatus('No se encontraron facturas registradas para el cliente.');
+    return;
+  }
+  const summaryMessage =
+    invoices.length === 1
+      ? 'Se encontró 1 factura para el cliente.'
+      : `Se encontraron ${invoices.length} facturas para el cliente.`;
+  setCustomerInvoicesStatus(summaryMessage);
+
+  invoices.forEach((entry) => {
+    const invoiceData = entry?.invoice || {};
+    const row = document.createElement('tr');
+
+    const numberCell = document.createElement('td');
+    numberCell.textContent = invoiceData?.numero || '—';
+    row.appendChild(numberCell);
+
+    const dateCell = document.createElement('td');
+    dateCell.textContent = invoiceData?.fecha_emision ? formatDate(invoiceData.fecha_emision) : '—';
+    row.appendChild(dateCell);
+
+    const statusCell = document.createElement('td');
+    statusCell.textContent = invoiceData?.estado || '—';
+    row.appendChild(statusCell);
+
+    const totalCell = document.createElement('td');
+    totalCell.textContent =
+      typeof invoiceData?.total === 'number' && Number.isFinite(invoiceData.total)
+        ? formatCurrencyUSD(invoiceData.total)
+        : '—';
+    row.appendChild(totalCell);
+
+    const ordersCell = document.createElement('td');
+    const linkedOrders = Array.isArray(entry?.linked_orders) ? entry.linked_orders : [];
+    if (!linkedOrders.length) {
+      const emptyLabel = document.createElement('span');
+      emptyLabel.className = 'muted';
+      emptyLabel.textContent = 'Sin órdenes vinculadas';
+      ordersCell.appendChild(emptyLabel);
+    } else {
+      const container = document.createElement('div');
+      container.className = 'invoice-orders';
+      linkedOrders.forEach((linkedOrder) => {
+        const pill = document.createElement('span');
+        pill.className = 'invoice-order-pill';
+        const orderNumber = linkedOrder?.order_number || `Orden #${linkedOrder?.order_id || ''}`;
+        const statusLabel = linkedOrder?.status || '';
+        const parts = [orderNumber];
+        if (statusLabel) {
+          parts.push(statusLabel);
+        }
+        pill.textContent = parts.join(' • ');
+        container.appendChild(pill);
+      });
+      ordersCell.appendChild(container);
+    }
+    row.appendChild(ordersCell);
+
+    customerInvoicesTableBody.appendChild(row);
+  });
+}
+
+async function loadCustomerInvoicesForDetail(customer, options = {}) {
+  const { force = false } = options;
+  if (!customer) {
+    clearCustomerInvoices();
+    return;
+  }
+  const numericId = Number(customer.id);
+  if (!Number.isFinite(numericId) || numericId <= 0) {
+    clearCustomerInvoices();
+    return;
+  }
+  const cached = !force ? getCachedCustomerInvoices(numericId) : null;
+  if (cached && !force) {
+    renderCustomerInvoices(numericId);
+    return;
+  }
+
+  setCustomerInvoicesStatus('Consultando facturas del cliente...');
+  const requestId = Date.now();
+  state.customerInvoicesRequestId = requestId;
+  try {
+    const data = await fetchCustomerInvoicesData(numericId, { force });
+    if (state.customerInvoicesRequestId !== requestId) {
+      return;
+    }
+    renderCustomerInvoices(numericId);
+    if (state.orderInvoiceSuggestionsCustomerId === numericId) {
+      state.orderInvoiceSuggestions = Array.isArray(data?.items) ? data.items : [];
+      state.orderInvoiceSuggestionsLoading = false;
+      state.orderInvoiceSuggestionsError = null;
+      renderOrderInvoiceSuggestions();
+    }
+  } catch (error) {
+    if (state.customerInvoicesRequestId !== requestId) {
+      return;
+    }
+    customerInvoicesTableBody.innerHTML = '';
+    const message = error?.message || 'No se pudieron obtener las facturas del cliente.';
+    setCustomerInvoicesStatus(message, { isError: true });
+    if (state.orderInvoiceSuggestionsCustomerId === numericId) {
+      state.orderInvoiceSuggestions = [];
+      state.orderInvoiceSuggestionsLoading = false;
+      state.orderInvoiceSuggestionsError = message;
+      renderOrderInvoiceSuggestions();
+    }
+  } finally {
+    if (state.customerInvoicesRequestId === requestId) {
+      state.customerInvoicesRequestId = 0;
+    }
   }
 }
 
@@ -3230,6 +3798,7 @@ async function populateCustomerDetail(customer) {
   }
 
   renderCustomerOrderHistory(customer);
+  await loadCustomerInvoicesForDetail(customer);
   setCustomerDetailVisible(true);
   renderCustomers();
 }
@@ -3247,6 +3816,7 @@ function clearCustomerDetail(options = {}) {
     customerDetailSummaryElement.textContent = CUSTOMER_DETAIL_DEFAULT_SUMMARY;
   }
   renderCustomerOrderHistory(null);
+  clearCustomerInvoices();
 
   updateCustomerForm?.reset();
   if (updateCustomerMeasurementsContainer) {
@@ -3351,6 +3921,19 @@ function populateOrderDetail(order, options = {}) {
     } else {
       orderDetailMeasurementsContainer.classList.add('muted');
       orderDetailMeasurementsContainer.textContent = 'Sin medidas registradas.';
+    }
+  }
+
+  if (order.customer_id) {
+    const targetId = Number(order.customer_id);
+    const candidate =
+      state.customerOptions.find((item) => item.id === targetId) ||
+      state.customers.find((item) => item.id === targetId) ||
+      (order.customer_document
+        ? { id: targetId, document_id: order.customer_document }
+        : null);
+    if (candidate) {
+      void loadOrderInvoiceSuggestions(candidate);
     }
   }
 
@@ -3616,7 +4199,36 @@ if (orderNextPageButton) {
 
 if (showCreateCustomerButton) {
   showCreateCustomerButton.addEventListener('click', () => {
+    state.pendingOrderCustomerSelection = null;
     setCreateCustomerVisible(true);
+  });
+}
+
+if (orderCreateCustomerButton) {
+  orderCreateCustomerButton.addEventListener('click', () => {
+    state.pendingOrderCustomerSelection = { source: 'order', customerId: null };
+    setCreateCustomerVisible(true);
+  });
+}
+
+if (customerInvoicesRefreshButton) {
+  customerInvoicesRefreshButton.addEventListener('click', async () => {
+    if (!state.selectedCustomerId) {
+      showToast('Selecciona un cliente para actualizar sus facturas.', 'error');
+      return;
+    }
+    const targetId = Number(state.selectedCustomerId);
+    const candidate =
+      state.customers.find((item) => item.id === targetId) ||
+      state.customerOptions.find((item) => item.id === targetId);
+    if (!candidate) {
+      await loadCustomerInvoicesForDetail({ id: targetId }, { force: true });
+      return;
+    }
+    await loadCustomerInvoicesForDetail(candidate, { force: true });
+    if (orderCustomerSelect && Number(orderCustomerSelect.value) === targetId) {
+      await loadOrderInvoiceSuggestions(candidate, { force: true });
+    }
   });
 }
 
@@ -3756,7 +4368,7 @@ if (createCustomerForm) {
     const submitButton = createCustomerForm.querySelector('button[type="submit"]');
     submitButton.disabled = true;
     try {
-      await apiFetch('/customers', {
+      const createdCustomer = await apiFetch('/customers', {
         method: 'POST',
         body: {
           full_name: fullName,
@@ -3765,6 +4377,12 @@ if (createCustomerForm) {
           measurements,
         },
       });
+      if (
+        state.pendingOrderCustomerSelection?.source === 'order' &&
+        createdCustomer?.id
+      ) {
+        state.pendingOrderCustomerSelection.customerId = Number(createdCustomer.id);
+      }
       await loadCustomers();
       await refreshCustomerOptions();
       setCreateCustomerVisible(false);
@@ -3971,26 +4589,42 @@ function handleOrderCustomerChange() {
   const documentInput = document.getElementById('newCustomerDocument');
   const nameInput = document.getElementById('newCustomerName');
   const contactInput = document.getElementById('newCustomerContact');
+  clearOrderInvoiceLookup();
   if (!customer) {
     if (documentInput) documentInput.value = '';
     if (nameInput) nameInput.value = '';
     if (contactInput) contactInput.value = '';
     renderCustomerMeasurementOptions(null);
+    clearOrderInvoiceSuggestions();
+    updateOrderInvoiceLookupButtonState();
     return;
   }
   if (documentInput) documentInput.value = customer.document_id || '';
   if (nameInput) nameInput.value = customer.full_name || '';
   if (contactInput) contactInput.value = customer.phone || '';
   renderCustomerMeasurementOptions(customer);
+  void loadOrderInvoiceSuggestions(customer);
+  updateOrderInvoiceLookupButtonState();
 }
 
 if (orderCustomerSelect) {
   orderCustomerSelect.addEventListener('change', handleOrderCustomerChange);
 }
 
+if (newOrderInvoiceInput) {
+  newOrderInvoiceInput.addEventListener('input', updateOrderInvoiceLookupButtonState);
+}
+
+if (orderInvoiceLookupButton) {
+  orderInvoiceLookupButton.addEventListener('click', () => {
+    void handleOrderInvoiceLookup();
+  });
+}
+
 populateEstablishmentSelect(newOrderOriginSelect);
 populateEstablishmentSelect(orderDetailOriginSelect);
 ensureNewOrderTaskRow();
+clearOrderInvoiceSuggestions();
 
 function parseDateValue(value) {
   if (!value) {
@@ -5263,6 +5897,7 @@ function resetContificoPreviewState() {
   state.contificoPreviewInvoiceLookupError = null;
   state.contificoPreviewInvoiceLookupFetched = false;
   state.contificoPreviewInvoiceLookupNumber = '';
+  state.contificoPreviewInvoiceLookupCustomerDocument = '';
   state.contificoPreviewInvoiceLookupProgress = 0;
   state.contificoPreviewInvoiceLookupStage = '';
   state.contificoPreviewInvoiceLookupMetadata = {};
@@ -5845,6 +6480,9 @@ function renderContificoPreviewInvoiceLookup() {
         element.disabled = true;
       });
     }
+    if (contificoInvoiceLookupDocumentInput) {
+      contificoInvoiceLookupDocumentInput.value = '';
+    }
     if (contificoInvoiceLookupNumberInput) {
       contificoInvoiceLookupNumberInput.value = '';
     }
@@ -5885,6 +6523,10 @@ function renderContificoPreviewInvoiceLookup() {
     });
   }
 
+  if (contificoInvoiceLookupDocumentInput) {
+    contificoInvoiceLookupDocumentInput.value =
+      state.contificoPreviewInvoiceLookupCustomerDocument || '';
+  }
   if (contificoInvoiceLookupNumberInput) {
     contificoInvoiceLookupNumberInput.value = state.contificoPreviewInvoiceLookupNumber || '';
   }
@@ -5973,7 +6615,8 @@ function renderContificoPreviewInvoiceLookup() {
     } else {
       const promptParagraph = document.createElement('p');
       promptParagraph.className = 'muted';
-      promptParagraph.textContent = 'Completa el formulario para ver el detalle de la factura en esta ventana.';
+      promptParagraph.textContent =
+        'Completa el formulario con el documento del cliente y el número de factura para ver el detalle en esta ventana.';
       contificoInvoiceLookupModalDetails.appendChild(promptParagraph);
     }
   }
@@ -6011,7 +6654,8 @@ function renderContificoPreviewInvoiceLookup() {
       statusMessage = 'No se encontraron facturas con el número consultado.';
     }
   } else {
-    statusMessage = 'Ingresa el número exacto de documento para buscar una factura específica.';
+    statusMessage =
+      'Ingresa el documento del cliente y el número exacto de la factura para iniciar la búsqueda.';
   }
   updateContificoStatus(contificoInvoiceLookupStatus, { text: statusMessage, tone });
 
@@ -6320,6 +6964,9 @@ function applyContificoInvoiceLookupJobUpdate(job, requestId) {
   if (job.document_number) {
     state.contificoPreviewInvoiceLookupNumber = job.document_number;
   }
+  if (job.customer_document) {
+    state.contificoPreviewInvoiceLookupCustomerDocument = job.customer_document;
+  }
 
   const progressValue = Number(job.progress);
   if (Number.isFinite(progressValue)) {
@@ -6432,6 +7079,29 @@ async function handleContificoInvoiceLookup(event) {
     return;
   }
 
+  const rawDocument =
+    contificoInvoiceLookupDocumentInput?.value ??
+    state.contificoPreviewInvoiceLookupCustomerDocument ??
+    '';
+  const normalizedDocument = String(rawDocument).trim();
+
+  logInvoiceLookupInfo('Documento del cliente capturado del formulario.', {
+    raw: rawDocument,
+    normalized: normalizedDocument,
+  });
+
+  if (!normalizedDocument) {
+    logInvoiceLookupWarn('Búsqueda cancelada por documento de cliente vacío.', {
+      raw: rawDocument,
+    });
+    state.contificoPreviewInvoiceLookupError = 'Ingresa un documento de cliente válido.';
+    state.contificoPreviewInvoiceLookup = null;
+    state.contificoPreviewInvoiceLookupFetched = true;
+    renderContificoPreviewInvoiceLookup();
+    showToast(state.contificoPreviewInvoiceLookupError, 'error');
+    return;
+  }
+
   const rawNumber =
     contificoInvoiceLookupNumberInput?.value ?? state.contificoPreviewInvoiceLookupNumber ?? '';
   const normalizedNumber = String(rawNumber).trim();
@@ -6459,9 +7129,11 @@ async function handleContificoInvoiceLookup(event) {
   logInvoiceLookupInfo('Preparando consulta puntual en Contífico.', {
     requestId,
     documentNumber: normalizedNumber,
+    customerDocument: normalizedDocument,
   });
 
   state.contificoPreviewInvoiceLookupNumber = normalizedNumber;
+  state.contificoPreviewInvoiceLookupCustomerDocument = normalizedDocument;
   state.contificoPreviewInvoiceLookupLoading = true;
   state.contificoPreviewInvoiceLookupError = null;
   state.contificoPreviewInvoiceLookupFetched = false;
@@ -6483,10 +7155,14 @@ async function handleContificoInvoiceLookup(event) {
     logInvoiceLookupInfo('Solicitando creación de trabajo de búsqueda asíncrona.', {
       requestId,
       documentNumber: normalizedNumber,
+      customerDocument: normalizedDocument,
     });
     const job = await apiFetch('/temp/contifico/invoices/by-number/jobs', {
       method: 'POST',
-      body: { document_number: normalizedNumber },
+      body: {
+        document_number: normalizedNumber,
+        customer_document: normalizedDocument,
+      },
     });
     logInvoiceLookupInfo('Trabajo de búsqueda creado.', {
       requestId,
@@ -6536,6 +7212,7 @@ async function handleContificoInvoiceLookup(event) {
       loading: state.contificoPreviewInvoiceLookupLoading,
       progress: state.contificoPreviewInvoiceLookupProgress,
       error: state.contificoPreviewInvoiceLookupError || null,
+      customerDocument: state.contificoPreviewInvoiceLookupCustomerDocument || null,
     });
   }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -302,6 +302,31 @@
                       Selecciona un cliente para ver sus órdenes anteriores.
                     </div>
                   </div>
+                  <section class="customer-invoices" id="customerInvoicesSection">
+                    <div class="customer-invoices-header">
+                      <h5>Facturas del cliente</h5>
+                      <button type="button" class="secondary" id="customerInvoicesRefreshButton">
+                        Actualizar
+                      </button>
+                    </div>
+                    <p id="customerInvoicesStatus" class="muted small">
+                      Selecciona un cliente para consultar sus facturas en Contífico.
+                    </p>
+                    <div class="table-wrapper compact">
+                      <table class="customer-invoices-table">
+                        <thead>
+                          <tr>
+                            <th>Número</th>
+                            <th>Fecha</th>
+                            <th>Estado</th>
+                            <th>Total</th>
+                            <th>Órdenes vinculadas</th>
+                          </tr>
+                        </thead>
+                        <tbody id="customerInvoicesTableBody"></tbody>
+                      </table>
+                    </div>
+                  </section>
                   <form id="updateCustomerForm" class="form-grid">
                     <div class="form-row">
                       <label for="updateCustomerName">Nombre completo</label>
@@ -345,14 +370,36 @@
                 <input type="text" id="newOrderNumber" required />
               </div>
               <div class="form-row">
-                <label for="newOrderInvoice">Número de factura</label>
-                <input type="text" id="newOrderInvoice" placeholder="Ej. FAC-2024-00001" />
+                <label for="orderCustomerSelect">Cliente</label>
+                <div class="field-with-action">
+                  <select id="orderCustomerSelect" required>
+                    <option value="">Selecciona un cliente</option>
+                  </select>
+                  <button type="button" class="link-button" id="orderCreateCustomerButton">
+                    Registrar nuevo cliente
+                  </button>
+                </div>
               </div>
               <div class="form-row">
-                <label for="orderCustomerSelect">Cliente</label>
-                <select id="orderCustomerSelect" required>
-                  <option value="">Selecciona un cliente</option>
-                </select>
+                <label for="newOrderInvoice">Número de factura</label>
+                <div class="field-with-action">
+                  <input
+                    type="text"
+                    id="newOrderInvoice"
+                    placeholder="Ej. FAC-2024-00001"
+                    list="orderInvoiceSuggestions"
+                    aria-describedby="orderInvoiceSuggestionsStatus orderInvoiceLookupDetails"
+                    autocomplete="off"
+                  />
+                  <button type="button" class="secondary" id="orderInvoiceLookupButton">
+                    Consultar en Contífico
+                  </button>
+                </div>
+                <p id="orderInvoiceSuggestionsStatus" class="muted small"></p>
+                <div
+                  id="orderInvoiceLookupDetails"
+                  class="muted small invoice-lookup-details hidden"
+                ></div>
               </div>
               <div class="form-row">
                 <label for="newCustomerDocument">Documento</label>
@@ -418,6 +465,7 @@
               </div>
               <button type="submit" class="primary">Guardar orden</button>
             </form>
+            <datalist id="orderInvoiceSuggestions"></datalist>
           </section>
 
           <section class="card dashboard-panel hidden" id="ordersPanel">
@@ -545,7 +593,7 @@
                   </div>
                   <div class="form-row">
                     <label for="orderDetailInvoice">Número de factura</label>
-                    <input type="text" id="orderDetailInvoice" />
+                    <input type="text" id="orderDetailInvoice" list="orderInvoiceSuggestions" />
                   </div>
                   <div class="form-row">
                     <label for="orderDetailStatus">Estado</label>
@@ -1003,11 +1051,23 @@
                   <div>
                     <h4>Buscar factura puntual</h4>
                     <p class="muted small">
-                      Introduce el número completo del documento para validar una factura específica.
+                      Introduce la cédula o RUC del cliente y el número completo del documento para validar una factura específica.
                     </p>
                   </div>
                 </header>
                 <form id="contificoInvoiceLookupForm" class="form-grid contifico-preview-form">
+                  <div class="form-row">
+                    <label for="contificoInvoiceLookupDocument">Documento del cliente</label>
+                    <input
+                      type="text"
+                      id="contificoInvoiceLookupDocument"
+                      name="customer_document"
+                      inputmode="numeric"
+                      autocomplete="off"
+                      placeholder="Ej. 0912345678"
+                      required
+                    />
+                  </div>
                   <div class="form-row">
                     <label for="contificoInvoiceLookupNumber">Número de documento</label>
                     <input

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -461,6 +461,25 @@ button[disabled] {
   flex: 1;
 }
 
+.field-with-action {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.field-with-action select {
+  flex: 1;
+}
+
+.field-with-action input {
+  flex: 1;
+}
+
+.field-with-action .link-button {
+  margin-left: 0;
+  white-space: nowrap;
+}
+
 .order-result {
   margin-top: 1.6rem;
   padding: 1.6rem;
@@ -782,6 +801,99 @@ button[disabled] {
   margin: 0;
   font-weight: 600;
   color: var(--primary-dark);
+}
+
+.customer-invoices {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.customer-invoices-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.customer-invoices-header h5 {
+  margin: 0;
+}
+
+.customer-invoices-table {
+  width: 100%;
+}
+
+.customer-invoices-table th,
+.customer-invoices-table td {
+  white-space: nowrap;
+}
+
+.customer-invoices-table td:last-child {
+  white-space: normal;
+}
+
+.invoice-orders {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.invoice-order-pill {
+  background: rgba(17, 17, 17, 0.08);
+  color: var(--primary-dark);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status-error {
+  color: var(--danger);
+}
+
+.status-success {
+  color: var(--success);
+}
+
+.invoice-lookup-details {
+  margin-top: 0.45rem;
+  transition: color 0.2s ease;
+}
+
+.invoice-lookup-details .invoice-lookup-summary {
+  font-weight: 600;
+}
+
+.invoice-lookup-details .invoice-lookup-number {
+  font-weight: 700;
+}
+
+.invoice-lookup-details .invoice-lookup-meta {
+  margin: 0.25rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.invoice-lookup-details .invoice-lookup-meta li {
+  background: rgba(17, 17, 17, 0.08);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.invoice-lookup-details.status-error .invoice-lookup-meta li {
+  background: rgba(210, 54, 105, 0.16);
+}
+
+.invoice-lookup-details.status-success .invoice-lookup-meta li {
+  background: rgba(31, 31, 31, 0.12);
 }
 
 
@@ -1850,6 +1962,10 @@ body.kanban-detail-open {
 
 .table-wrapper {
   overflow-x: auto;
+}
+
+.table-wrapper.compact table {
+  font-size: 0.9rem;
 }
 
 table {


### PR DESCRIPTION
## Summary
- add an inline Contífico lookup button on the order form that queries invoices by customer and number
- show the lookup result details, refresh cached invoice lists, and reuse the number in the form when a match is found
- style the invoice field layout and status indicators to accommodate the new lookup controls
- require the customer document when performing Contífico invoice lookups across backend endpoints, job manager, tests, and preview UI

## Testing
- SECRET_KEY=abcdefghijklmnopqrstuvwxyz012345 PYTHONPATH=backend pytest backend/tests/test_invoice_jobs.py backend/tests/test_contifico_client.py backend/tests/test_customer_contifico_invoices.py


------
https://chatgpt.com/codex/tasks/task_e_68e3eb4dd6308332a0a415bca10c3c6c