### PR TITLE
Require customer document for Contífico invoice lookups

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3178,6 +3178,8 @@ function handleLogout(auto = false) {
   state.customerOptions = [];
   state.customerOrdersCache = {};
   state.customerDisplayCache = {};
+  state.customerInvoicesCache = {};
+  state.customerInvoicesRequestId = 0;
   state.customerSearchTerm = '';
   state.orderSearchTerm = '';
   state.customerPage = 1;
@@ -3205,11 +3207,29 @@ function handleLogout(auto = false) {
   state.customerRequestId = 0;
   state.orderRequestId = 0;
   state.customerOptionsRequestId = 0;
+  state.orderInvoiceSuggestions = [];
+  state.orderInvoiceSuggestionsCustomerId = null;
+  state.orderInvoiceSuggestionRequestId = 0;
+  state.orderInvoiceSuggestionsLoading = false;
+  state.orderInvoiceSuggestionsError = null;
+  state.orderInvoiceLookup = null;
+  state.orderInvoiceLookupLoading = false;
+  state.orderInvoiceLookupError = null;
+  state.orderInvoiceLookupCustomerId = null;
+  state.orderInvoiceLookupNumber = '';
+  state.orderInvoiceLookupRequestId = 0;
   state.users = [];
   state.usersLoaded = false;
   state.usersLoadError = null;
   state.editingUserId = null;
   resetContificoPreviewState();
+  setCustomerInvoicesStatus('');
+  if (customerInvoicesTableBody) {
+    customerInvoicesTableBody.innerHTML = '';
+  }
+  setOrderInvoiceSuggestionsStatus('');
+  renderOrderInvoiceSuggestions();
+  renderOrderInvoiceLookupDetails();
   if (currentUserNameElement) {
     currentUserNameElement.textContent = '';
   }


### PR DESCRIPTION
## Summary
- add an inline Contífico lookup button on the order form that queries invoices by customer and number
- show the lookup result details, refresh cached invoice lists, and reuse the number in the form when a match is found
- style the invoice field layout and status indicators to accommodate the new lookup controls
- require the customer document when performing Contífico invoice lookups across backend endpoints, job manager, tests, and preview UI
- clear Contífico invoice caches and UI state during logout to avoid stale data after re-authentication

## Testing
- SECRET_KEY=abcdefghijklmnopqrstuvwxyz012345 PYTHONPATH=backend pytest backend/tests/test_invoice_jobs.py backend/tests/test_contifico_client.py backend/tests/test_customer_contifico_invoices.py

------
https://chatgpt.com/codex/tasks/task_e_68e42da941348332a04849afe812b32e