### PR TITLE
Fix Contifico customer lookup nested payloads

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -203,6 +203,13 @@ class ContificoClient:
         return normalized
 
     @staticmethod
+    def _normalize_document(value: str) -> str:
+        cleaned = (value or "").strip().lower()
+        for char in ("-", " ", ".", "/", "_"):
+            cleaned = cleaned.replace(char, "")
+        return cleaned
+
+    @staticmethod
     def _sleep(seconds: float) -> None:
         if seconds <= 0:
             return
@@ -270,6 +277,47 @@ class ContificoClient:
                 nested_value = nested.get("identificacion") or nested.get("IDENTIFICACION")
                 if isinstance(nested_value, str) and nested_value.strip():
                     return nested_value.strip()
+        return None
+
+    @classmethod
+    def _extract_customer_document(cls, payload: Dict[str, Any]) -> Optional[str]:
+        if not isinstance(payload, dict):
+            return None
+        keys = (
+            "identificacion",
+            "persona_identificacion",
+            "identification",
+            "personaIdentificacion",
+            "IDENTIFICACION",
+            "PERSONA_IDENTIFICACION",
+            "IDENTIFICATION",
+            "documento",
+            "DOCUMENTO",
+            "numero_documento",
+            "NUMERO_DOCUMENTO",
+            "ruc",
+            "RUC",
+            "cedula",
+            "CEDULA",
+        )
+        for key in keys:
+            value = payload.get(key)
+            if value is None:
+                continue
+            if isinstance(value, (int, float)):
+                candidate = str(value)
+            elif isinstance(value, str):
+                candidate = value.strip()
+            else:
+                continue
+            if candidate:
+                return candidate
+        for nested_key in ("persona", "cliente", "CLIENTE", "PERSONA"):
+            nested = payload.get(nested_key)
+            if isinstance(nested, dict):
+                nested_value = cls._extract_customer_document(nested)
+                if nested_value:
+                    return nested_value
         return None
 
     @classmethod
@@ -354,6 +402,50 @@ class ContificoClient:
                 continue
             seen.add(size)
             yield size
+
+    def fetch_customer_by_document(self, document_id: str) -> Optional[Dict[str, Any]]:
+        """Obtiene la ficha del cliente en Contífico usando su identificación."""
+
+        normalized_target = self._normalize_document(document_id)
+        if not normalized_target:
+            raise ValueError("El número de documento del cliente es obligatorio.")
+
+        params = {"identificacion": document_id.strip()}
+        payload = self._request("GET", "personas", params=params)
+
+        candidates: list[Dict[str, Any]] = []
+
+        seen: set[int] = set()
+
+        def _collect(value: Any) -> None:
+            if isinstance(value, dict):
+                obj_id = id(value)
+                if obj_id in seen:
+                    return
+                seen.add(obj_id)
+                candidates.append(value)
+                for nested in value.values():
+                    _collect(nested)
+            elif isinstance(value, list):
+                for item in value:
+                    _collect(item)
+
+        if payload is None:
+            return None
+
+        _collect(payload)
+        if isinstance(payload, dict):
+            for key in ("results", "data", "datos", "items", "personas", "records", "rows"):
+                _collect(payload.get(key))
+
+        for candidate in candidates:
+            document_value = self._extract_customer_document(candidate)
+            if not document_value:
+                continue
+            if self._normalize_document(document_value) == normalized_target:
+                return candidate
+
+        return None
 
     def list_products(
         self, *, page: int = 1, page_size: int = 100

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -58,6 +58,8 @@ def serialize_customer(customer: Optional[models.Customer]) -> Optional[Dict[str
         "full_name": customer.full_name,
         "document_id": customer.document_id,
         "phone": customer.phone,
+        "email": customer.email,
+        "address": customer.address,
         "created_at": customer.created_at.isoformat() if customer.created_at else None,
         "updated_at": customer.updated_at.isoformat() if customer.updated_at else None,
         "measurements": [
@@ -252,6 +254,8 @@ def get_customers(
             or_(
                 models.Customer.full_name.ilike(pattern),
                 models.Customer.document_id.ilike(pattern),
+                models.Customer.phone.ilike(pattern),
+                models.Customer.email.ilike(pattern),
             )
         )
     total = query.count()
@@ -281,6 +285,8 @@ def create_customer(db: Session, customer_in: schemas.CustomerCreate) -> models.
         full_name=customer_in.full_name,
         document_id=customer_in.document_id,
         phone=customer_in.phone,
+        email=customer_in.email,
+        address=customer_in.address,
     )
     db.add(db_customer)
     db.flush()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from . import auth, crud, models, schemas
 from .config import get_settings
 from .database import Base, engine, get_db
-from .contifico import ContificoClient
+from .contifico import ContificoAPIError, ContificoClient, ContificoClientError
 from .dependencies import (
     admin_required,
     get_contifico_client,
@@ -165,6 +165,47 @@ def list_contifico_warehouses(
 
     _ = current_user
     return build_warehouse_list(contifico_client)
+
+
+@app.get(
+    "/integrations/contifico/customers/{document_id}",
+    response_model=schemas.ContificoCustomer,
+)
+def get_contifico_customer_from_document(
+    document_id: str,
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user: models.User = Depends(staff_required()),
+):
+    _ = current_user
+    normalized_document = document_id.strip()
+    if not normalized_document:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Debe proporcionar un número de identificación válido.",
+        )
+    try:
+        payload = contifico_client.fetch_customer_by_document(normalized_document)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except ContificoAPIError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except ContificoClientError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+    if not payload:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cliente no encontrado en Contífico",
+        )
+    customer = schemas.ContificoCustomer.from_api(payload)
+    if not customer.document_id:
+        customer.document_id = normalized_document
+    return customer
 
 
 @app.get(

--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -111,8 +111,44 @@ def ensure_delivery_date_is_datetime(engine: Engine) -> None:
             return
 
 
+def ensure_customer_contact_columns(engine: Engine) -> None:
+    """Add missing optional contact columns to customers if required."""
+
+    inspector = inspect(engine)
+    table_names = set(inspector.get_table_names())
+    if "customers" not in table_names:
+        return
+
+    column_names = {column["name"] for column in inspector.get_columns("customers")}
+    statements: list[str] = []
+    dialect = engine.dialect.name
+
+    def _column_statement(column: str, definition: str) -> str:
+        if dialect == "sqlite":
+            return f"ALTER TABLE customers ADD COLUMN {column} {definition}"
+        return f"ALTER TABLE customers ADD COLUMN {column} {definition}"
+
+    if "email" not in column_names:
+        statements.append(_column_statement("email", "VARCHAR(255)"))
+    if "address" not in column_names:
+        statements.append(_column_statement("address", "VARCHAR(255)"))
+
+    if not statements:
+        return
+
+    with engine.begin() as connection:
+        for ddl in statements:
+            try:
+                connection.execute(text(ddl))
+            except DBAPIError as exc:
+                if _is_duplicate_column_error(exc):
+                    continue
+                raise
+
+
 def apply_schema_upgrades(engine: Engine) -> None:
     """Apply idempotent schema upgrades required by the application."""
 
     ensure_assigned_vendor_column(engine)
     ensure_delivery_date_is_datetime(engine)
+    ensure_customer_contact_columns(engine)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -120,6 +120,8 @@ class Customer(Base):
     full_name = Column(String(100), nullable=False)
     document_id = Column(String(50), unique=True, nullable=False, index=True)
     phone = Column(String(50), nullable=True)
+    email = Column(String(255), nullable=True)
+    address = Column(String(255), nullable=True)
     created_at = Column(DateTime(timezone=True), default=now, nullable=False)
     updated_at = Column(
         DateTime(timezone=True),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -49,6 +49,8 @@ class CustomerBase(BaseModel):
     full_name: str
     document_id: str
     phone: Optional[str] = None
+    email: Optional[str] = None
+    address: Optional[str] = None
 
 
 class CustomerCreate(CustomerBase):
@@ -59,6 +61,8 @@ class CustomerUpdate(BaseModel):
     full_name: Optional[str] = None
     document_id: Optional[str] = None
     phone: Optional[str] = None
+    email: Optional[str] = None
+    address: Optional[str] = None
     measurements: Optional[List[CustomerMeasurementCreate]] = None
 
 
@@ -293,6 +297,155 @@ class ContificoWarehouse(BaseModel):
             nombre=payload.get("nombre") or payload.get("descripcion"),
             direccion=payload.get("direccion"),
             raw=payload,
+        )
+
+
+class ContificoCustomer(BaseModel):
+    full_name: Optional[str] = None
+    document_id: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+    address: Optional[str] = None
+
+    @classmethod
+    def from_api(cls, payload: Dict[str, Any]) -> "ContificoCustomer":
+        if not isinstance(payload, dict):
+            raise TypeError("El cliente devuelto por Contífico debe ser un diccionario")
+
+        def _normalize_string(value: Any) -> Optional[str]:
+            if isinstance(value, str):
+                candidate = value.strip()
+                return candidate or None
+            if isinstance(value, (int, float)) and not (isinstance(value, float) and math.isnan(value)):
+                return str(value)
+            return None
+
+        def _extract_name(data: Dict[str, Any]) -> Optional[str]:
+            nombres = _normalize_string(
+                data.get("nombres")
+                or data.get("NOMBRES")
+                or data.get("nombre")
+                or data.get("NOMBRE")
+            )
+            apellidos = _normalize_string(
+                data.get("apellidos")
+                or data.get("APELLIDOS")
+                or data.get("apellido")
+                or data.get("APELLIDO")
+            )
+            if nombres and apellidos:
+                return f"{nombres} {apellidos}".strip()
+            if nombres:
+                return nombres
+            if apellidos:
+                return apellidos
+            return None
+
+        def _extract_value(data: Dict[str, Any], keys: tuple[str, ...]) -> Optional[str]:
+            for key in keys:
+                if key not in data:
+                    continue
+                value = data.get(key)
+                if isinstance(value, dict):
+                    nested = _extract_value(value, keys)
+                    if nested:
+                        return nested
+                normalized = _normalize_string(value)
+                if normalized:
+                    return normalized
+            return None
+
+        merged_sources: list[Dict[str, Any]] = [payload]
+        for candidate_key in ("persona", "CLIENTE", "cliente"):
+            nested = payload.get(candidate_key)
+            if isinstance(nested, dict):
+                merged_sources.append(nested)
+
+        full_name = None
+        document_id = None
+        phone = None
+        email = None
+        address = None
+
+        for source in merged_sources:
+            if full_name is None:
+                full_name = (
+                    _extract_name(source)
+                    or _extract_value(
+                        source,
+                        (
+                            "razon_social",
+                            "RAZON_SOCIAL",
+                            "nombre_comercial",
+                            "NOMBRE_COMERCIAL",
+                            "display_name",
+                            "DISPLAY_NAME",
+                        ),
+                    )
+                )
+            if document_id is None:
+                document_id = _extract_value(
+                    source,
+                    (
+                        "identificacion",
+                        "IDENTIFICACION",
+                        "documento",
+                        "DOCUMENTO",
+                        "numero_documento",
+                        "NUMERO_DOCUMENTO",
+                        "ruc",
+                        "RUC",
+                        "cedula",
+                        "CEDULA",
+                    ),
+                )
+            if phone is None:
+                phone = _extract_value(
+                    source,
+                    (
+                        "telefono",
+                        "TELEFONO",
+                        "telefono1",
+                        "TELEFONO1",
+                        "telefono2",
+                        "TELEFONO2",
+                        "celular",
+                        "CELULAR",
+                        "mobile",
+                        "PHONE",
+                    ),
+                )
+            if email is None:
+                email = _extract_value(
+                    source,
+                    (
+                        "correo",
+                        "CORREO",
+                        "email",
+                        "EMAIL",
+                    ),
+                )
+            if address is None:
+                address = _extract_value(
+                    source,
+                    (
+                        "direccion",
+                        "DIRECCION",
+                        "direccion_principal",
+                        "DIRECCION_PRINCIPAL",
+                        "direccion_domicilio",
+                        "DIRECCION_DOMICILIO",
+                        "address",
+                        "ADDRESS",
+                    ),
+                )
+
+        return cls(
+            full_name=full_name,
+            document_id=document_id,
+            phone=phone,
+            email=email,
+            address=address,
         )
 
 

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -1347,3 +1347,117 @@ def test_contifico_invoice_from_api_handles_nested_persona_object() -> None:
     invoice = schemas.ContificoInvoice.from_api(payload)
 
     assert invoice.cliente == "Ana Díaz"
+
+
+def test_contifico_customer_from_api_extracts_fields() -> None:
+    payload = {
+        "nombres": "Juan",
+        "apellidos": "Pérez",
+        "identificacion": "0912345678",
+        "telefono": "0999999999",
+        "correo": "juan@example.com",
+        "direccion": "Av. Siempre Viva 123",
+    }
+
+    customer = schemas.ContificoCustomer.from_api(payload)
+
+    assert customer.full_name == "Juan Pérez"
+    assert customer.document_id == "0912345678"
+    assert customer.phone == "0999999999"
+    assert customer.email == "juan@example.com"
+    assert customer.address == "Av. Siempre Viva 123"
+
+
+def test_contifico_customer_from_api_handles_nested_payload() -> None:
+    payload = {
+        "CLIENTE": {
+            "nombre": "Empresa Demo",
+            "identificacion": "1799999999001",
+            "telefono1": "022222222",
+            "email": "facturacion@example.com",
+            "direccion_principal": "Calle Comercio y Central",
+        }
+    }
+
+    customer = schemas.ContificoCustomer.from_api(payload)
+
+    assert customer.full_name == "Empresa Demo"
+    assert customer.document_id == "1799999999001"
+    assert customer.phone == "022222222"
+    assert customer.email == "facturacion@example.com"
+    assert customer.address == "Calle Comercio y Central"
+
+
+def test_fetch_customer_by_document_returns_match(monkeypatch) -> None:
+    payload = {
+        "identificacion": "0912345678",
+        "nombre": "Juan Perez",
+        "telefono": "0999999999",
+    }
+
+    client = ContificoClient("key", "token")
+
+    def fake_request(method, endpoint, *, params=None, json=None):
+        assert method == "GET"
+        assert endpoint == "personas"
+        assert params == {"identificacion": "0912345678"}
+        return [payload]
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = client.fetch_customer_by_document("0912345678")
+
+    assert result == payload
+
+
+def test_fetch_customer_by_document_handles_nested_payload(monkeypatch) -> None:
+    payload = {
+        "meta": {"count": 1},
+        "results": {
+            "personas": [
+                {
+                    "persona": {
+                        "identificacion": "0912345678",
+                        "nombre": "Juan Perez",
+                    }
+                }
+            ]
+        },
+    }
+
+    client = ContificoClient("key", "token")
+
+    def fake_request(method, endpoint, *, params=None, json=None):
+        assert method == "GET"
+        assert endpoint == "personas"
+        assert params == {"identificacion": "0912345678"}
+        return payload
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = client.fetch_customer_by_document("0912345678")
+
+    assert result == {
+        "persona": {
+            "identificacion": "0912345678",
+            "nombre": "Juan Perez",
+        }
+    }
+
+
+def test_fetch_customer_by_document_returns_none_when_missing(monkeypatch) -> None:
+    client = ContificoClient("key", "token")
+
+    def fake_request(method, endpoint, *, params=None, json=None):
+        return []
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert client.fetch_customer_by_document("0912345678") is None
+
+
+def test_fetch_customer_by_document_validates_input() -> None:
+    client = ContificoClient("key", "token")
+
+    with pytest.raises(ValueError):
+        client.fetch_customer_by_document("   ")

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -16,6 +16,18 @@ def create_legacy_schema(engine):
         connection.execute(
             text(
                 """
+                CREATE TABLE customers (
+                    id INTEGER PRIMARY KEY,
+                    full_name VARCHAR(100) NOT NULL,
+                    document_id VARCHAR(50) NOT NULL,
+                    phone VARCHAR(50)
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
                 CREATE TABLE orders (
                     id INTEGER PRIMARY KEY,
                     order_number VARCHAR(50) NOT NULL,
@@ -58,6 +70,30 @@ def test_apply_schema_upgrades_adds_vendor_column(tmp_path):
     inspector = inspect(engine)
     column_names = {column["name"] for column in inspector.get_columns("orders")}
     assert "assigned_vendor_id" in column_names
+
+
+def test_apply_schema_upgrades_adds_customer_contact_columns(tmp_path):
+    database_path = tmp_path / "legacy_customers.db"
+    engine = create_engine(f"sqlite:///{database_path}")
+    create_legacy_schema(engine)
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("customers")}
+    assert "email" not in columns
+    assert "address" not in columns
+
+    migrations.apply_schema_upgrades(engine)
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("customers")}
+    assert "email" in columns
+    assert "address" in columns
+
+    migrations.apply_schema_upgrades(engine)
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("customers")}
+    assert "email" in columns
+    assert "address" in columns
 
 
 def test_apply_schema_upgrades_handles_missing_table(tmp_path):

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -311,6 +311,17 @@ const updateCustomerMeasurementsContainer = document.getElementById('updateCusto
 const updateCustomerNameInput = document.getElementById('updateCustomerName');
 const updateCustomerDocumentInput = document.getElementById('updateCustomerDocument');
 const updateCustomerPhoneInput = document.getElementById('updateCustomerPhone');
+const customerFullNameInput = document.getElementById('customerFullName');
+const customerDocumentInput = document.getElementById('customerDocumentInput');
+const customerPhoneInput = document.getElementById('customerPhone');
+const customerEmailInput = document.getElementById('customerEmail');
+const customerAddressInput = document.getElementById('customerAddress');
+const fetchContificoCustomerButton = document.getElementById('fetchContificoCustomerButton');
+const contificoCustomerLookupStatus = document.getElementById('contificoCustomerLookupStatus');
+const updateCustomerEmailInput = document.getElementById('updateCustomerEmail');
+const updateCustomerAddressInput = document.getElementById('updateCustomerAddress');
+const updateCustomerFetchContificoButton = document.getElementById('updateCustomerFetchContificoButton');
+const updateContificoCustomerLookupStatus = document.getElementById('updateContificoCustomerLookupStatus');
 const addCustomerMeasurementSetButton = document.getElementById('addCustomerMeasurementSet');
 const addUpdateCustomerMeasurementSetButton = document.getElementById('addUpdateCustomerMeasurementSet');
 const deleteCustomerButton = document.getElementById('deleteCustomerButton');
@@ -798,6 +809,15 @@ function showToast(message, type = 'info') {
   setTimeout(() => {
     toastElement.classList.remove('show', 'success', 'error');
   }, 3500);
+}
+
+function setContificoLookupStatus(element, message, tone = 'info') {
+  if (!element) return;
+  element.textContent = message || '';
+  element.classList.remove('info', 'success', 'error');
+  if (message) {
+    element.classList.add(tone);
+  }
 }
 
 function formatDate(dateString) {
@@ -1908,6 +1928,90 @@ function resetCreateCustomerForm() {
   if (customerMeasurementsContainer) {
     customerMeasurementsContainer.innerHTML = '';
     createMeasurementSetBlock(customerMeasurementsContainer);
+  }
+  setContificoLookupStatus(contificoCustomerLookupStatus, '');
+  if (fetchContificoCustomerButton) {
+    fetchContificoCustomerButton.disabled = false;
+  }
+}
+
+function applyContificoCustomerData(target, data = {}) {
+  if (!data || typeof data !== 'object') return;
+  const name = typeof data.full_name === 'string' ? data.full_name.trim() : '';
+  const documentId = typeof data.document_id === 'string' ? data.document_id.trim() : '';
+  const phone = typeof data.phone === 'string' ? data.phone.trim() : '';
+  const email = typeof data.email === 'string' ? data.email.trim() : '';
+  const address = typeof data.address === 'string' ? data.address.trim() : '';
+
+  if (target === 'create') {
+    if (customerFullNameInput && name) customerFullNameInput.value = name;
+    if (customerDocumentInput && documentId) customerDocumentInput.value = documentId;
+    if (customerPhoneInput && phone) customerPhoneInput.value = phone;
+    if (customerEmailInput && email) customerEmailInput.value = email;
+    if (customerAddressInput && address) customerAddressInput.value = address;
+    return;
+  }
+
+  const nameInput = updateCustomerNameInput || customerDetail?.querySelector('#updateCustomerName');
+  const documentInput =
+    updateCustomerDocumentInput || customerDetail?.querySelector('#updateCustomerDocument');
+  const phoneInput = updateCustomerPhoneInput || customerDetail?.querySelector('#updateCustomerPhone');
+  const emailInput = updateCustomerEmailInput || customerDetail?.querySelector('#updateCustomerEmail');
+  const addressInput =
+    updateCustomerAddressInput || customerDetail?.querySelector('#updateCustomerAddress');
+
+  if (nameInput && name) nameInput.value = name;
+  if (documentInput && documentId) documentInput.value = documentId;
+  if (phoneInput && phone) phoneInput.value = phone;
+  if (emailInput && email) emailInput.value = email;
+  if (addressInput && address) addressInput.value = address;
+}
+
+async function handleContificoCustomerLookup(source) {
+  const isCreate = source === 'create';
+  const documentInput = isCreate
+    ? customerDocumentInput
+    : updateCustomerDocumentInput || customerDetail?.querySelector('#updateCustomerDocument');
+  const statusElement = isCreate
+    ? contificoCustomerLookupStatus
+    : updateContificoCustomerLookupStatus;
+  const triggerButton = isCreate ? fetchContificoCustomerButton : updateCustomerFetchContificoButton;
+
+  if (!documentInput) return;
+
+  const rawDocument = documentInput.value || '';
+  const normalizedDocument = rawDocument.trim();
+  if (!normalizedDocument) {
+    setContificoLookupStatus(statusElement, 'Ingresa una cédula o RUC para consultar.', 'error');
+    documentInput.focus();
+    return;
+  }
+
+  setContificoLookupStatus(statusElement, 'Buscando datos en Contífico...', 'info');
+  if (triggerButton) {
+    triggerButton.disabled = true;
+  }
+  try {
+    const data = await apiFetch(
+      `/integrations/contifico/customers/${encodeURIComponent(normalizedDocument)}`
+    );
+    applyContificoCustomerData(source, data || {});
+    if (documentInput && normalizedDocument) {
+      const returnedDocument =
+        typeof data?.document_id === 'string' ? data.document_id.trim() : '';
+      documentInput.value = returnedDocument || normalizedDocument;
+    }
+    setContificoLookupStatus(
+      statusElement,
+      'Datos importados desde Contífico. Puedes ajustarlos antes de guardar.',
+      'success'
+    );
+  } catch (error) {
+    setContificoLookupStatus(statusElement, error.message || 'No se pudo obtener la información.', 'error');
+  } finally {
+    if (triggerButton) {
+      triggerButton.disabled = false;
+    }
   }
 }
 
@@ -3410,6 +3514,10 @@ function getCustomerDisplayData(customer, ordersForCustomer = []) {
     typeof customer?.document_id === 'string' ? customer.document_id.trim() : '';
   const normalizedContact =
     typeof customer?.phone === 'string' ? customer.phone.trim() : '';
+  const normalizedEmail =
+    typeof customer?.email === 'string' ? customer.email.trim() : '';
+  const normalizedAddress =
+    typeof customer?.address === 'string' ? customer.address.trim() : '';
 
   const cacheKey =
     customer?.id !== null && customer?.id !== undefined ? String(customer.id) : null;
@@ -3451,6 +3559,8 @@ function getCustomerDisplayData(customer, ordersForCustomer = []) {
   const name = normalizedName || fallbackName || cachedDisplay.name || '';
   const document = normalizedDocument || fallbackDocument || cachedDisplay.document || '';
   const contact = normalizedContact || fallbackContact || cachedDisplay.contact || '';
+  const email = normalizedEmail || cachedDisplay.email || '';
+  const address = normalizedAddress || cachedDisplay.address || '';
 
   if (cacheKey) {
     if (!state.customerDisplayCache) {
@@ -3460,6 +3570,8 @@ function getCustomerDisplayData(customer, ordersForCustomer = []) {
       name,
       document,
       contact,
+      email,
+      address,
     };
   }
 
@@ -3467,6 +3579,8 @@ function getCustomerDisplayData(customer, ordersForCustomer = []) {
     name,
     document,
     contact,
+    email,
+    address,
   };
 }
 
@@ -3740,6 +3854,11 @@ async function populateCustomerDetail(customer) {
   if (!customerDetail) return;
   state.selectedCustomerId = customer.id;
 
+  setContificoLookupStatus(updateContificoCustomerLookupStatus, '');
+  if (updateCustomerFetchContificoButton) {
+    updateCustomerFetchContificoButton.disabled = false;
+  }
+
   const cacheKey = String(customer.id);
   const expectedOrderCount =
     typeof customer.order_count === 'number' ? customer.order_count : undefined;
@@ -3772,6 +3891,12 @@ async function populateCustomerDetail(customer) {
     if (displayData.contact) {
       summaryParts.push(`Teléfono: ${displayData.contact}`);
     }
+    if (displayData.email) {
+      summaryParts.push(`Correo: ${displayData.email}`);
+    }
+    if (displayData.address) {
+      summaryParts.push(`Dirección: ${displayData.address}`);
+    }
     const orderCountForSummary =
       typeof expectedOrderCount === 'number' ? expectedOrderCount : ordersForCustomer.length;
     if (orderCountForSummary > 0) {
@@ -3789,6 +3914,9 @@ async function populateCustomerDetail(customer) {
   const documentInput =
     updateCustomerDocumentInput || customerDetail?.querySelector('#updateCustomerDocument');
   const phoneInput = updateCustomerPhoneInput || customerDetail?.querySelector('#updateCustomerPhone');
+  const emailInput = updateCustomerEmailInput || customerDetail?.querySelector('#updateCustomerEmail');
+  const addressInput =
+    updateCustomerAddressInput || customerDetail?.querySelector('#updateCustomerAddress');
 
   const normalizedCustomerName =
     typeof customer?.full_name === 'string' ? customer.full_name.trim() : '';
@@ -3796,6 +3924,10 @@ async function populateCustomerDetail(customer) {
     typeof customer?.document_id === 'string' ? customer.document_id.trim() : '';
   const normalizedCustomerPhone =
     typeof customer?.phone === 'string' ? customer.phone.trim() : '';
+  const normalizedCustomerEmail =
+    typeof customer?.email === 'string' ? customer.email.trim() : '';
+  const normalizedCustomerAddress =
+    typeof customer?.address === 'string' ? customer.address.trim() : '';
   if (nameInput) {
     nameInput.value = normalizedCustomerName || displayData.name || '';
   }
@@ -3804,6 +3936,12 @@ async function populateCustomerDetail(customer) {
   }
   if (phoneInput) {
     phoneInput.value = normalizedCustomerPhone || displayData.contact || '';
+  }
+  if (emailInput) {
+    emailInput.value = normalizedCustomerEmail || displayData.email || '';
+  }
+  if (addressInput) {
+    addressInput.value = normalizedCustomerAddress || displayData.address || '';
   }
 
   if (updateCustomerMeasurementsContainer) {
@@ -3841,6 +3979,10 @@ function clearCustomerDetail(options = {}) {
   updateCustomerForm?.reset();
   if (updateCustomerMeasurementsContainer) {
     updateCustomerMeasurementsContainer.innerHTML = '';
+  }
+  setContificoLookupStatus(updateContificoCustomerLookupStatus, '');
+  if (updateCustomerFetchContificoButton) {
+    updateCustomerFetchContificoButton.disabled = false;
   }
 
   if (reRender) {
@@ -4377,9 +4519,11 @@ if (typeof document !== 'undefined') {
 if (createCustomerForm) {
   createCustomerForm.addEventListener('submit', async (event) => {
     event.preventDefault();
-    const fullName = document.getElementById('customerFullName').value.trim();
-    const documentId = document.getElementById('customerDocumentInput').value.trim();
-    const phone = document.getElementById('customerPhone').value.trim();
+    const fullName = customerFullNameInput?.value.trim() || '';
+    const documentId = customerDocumentInput?.value.trim() || '';
+    const phone = customerPhoneInput?.value.trim() || '';
+    const email = customerEmailInput?.value.trim() || '';
+    const address = customerAddressInput?.value.trim() || '';
     if (!fullName || !documentId) {
       showToast('El nombre y la cédula del cliente son obligatorios.', 'error');
       return;
@@ -4394,6 +4538,8 @@ if (createCustomerForm) {
           full_name: fullName,
           document_id: documentId,
           phone: phone || null,
+          email: email || null,
+          address: address || null,
           measurements,
         },
       });
@@ -4415,6 +4561,12 @@ if (createCustomerForm) {
   });
 }
 
+if (fetchContificoCustomerButton) {
+  fetchContificoCustomerButton.addEventListener('click', () => {
+    void handleContificoCustomerLookup('create');
+  });
+}
+
 if (updateCustomerForm) {
   updateCustomerForm.addEventListener('submit', async (event) => {
     event.preventDefault();
@@ -4428,9 +4580,15 @@ if (updateCustomerForm) {
       updateCustomerDocumentInput || customerDetail?.querySelector('#updateCustomerDocument');
     const phoneInput =
       updateCustomerPhoneInput || customerDetail?.querySelector('#updateCustomerPhone');
+    const emailInput =
+      updateCustomerEmailInput || customerDetail?.querySelector('#updateCustomerEmail');
+    const addressInput =
+      updateCustomerAddressInput || customerDetail?.querySelector('#updateCustomerAddress');
     const fullName = fullNameInput?.value.trim() || '';
     const documentId = documentInput?.value.trim() || '';
     const phone = phoneInput?.value.trim() || '';
+    const email = emailInput?.value.trim() || '';
+    const address = addressInput?.value.trim() || '';
     const measurements = collectMeasurementSets(updateCustomerMeasurementsContainer);
     const submitButton = updateCustomerForm.querySelector('button[type="submit"]');
     submitButton.disabled = true;
@@ -4441,6 +4599,8 @@ if (updateCustomerForm) {
           full_name: fullName || null,
           document_id: documentId || null,
           phone: phone || null,
+          email: email || null,
+          address: address || null,
           measurements,
         },
       });
@@ -4456,6 +4616,12 @@ if (updateCustomerForm) {
     } finally {
       submitButton.disabled = false;
     }
+  });
+}
+
+if (updateCustomerFetchContificoButton) {
+  updateCustomerFetchContificoButton.addEventListener('click', () => {
+    void handleContificoCustomerLookup('update');
   });
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -228,11 +228,33 @@
                     </div>
                     <div class="form-row">
                       <label for="customerDocumentInput">Cédula o identificación</label>
-                      <input type="text" id="customerDocumentInput" required />
+                      <div class="field-with-action">
+                        <input type="text" id="customerDocumentInput" required />
+                        <button type="button" id="fetchContificoCustomerButton" class="secondary">
+                          Buscar en Contífico
+                        </button>
+                      </div>
+                      <p
+                        id="contificoCustomerLookupStatus"
+                        class="muted small contifico-lookup-status"
+                        aria-live="polite"
+                      ></p>
                     </div>
                     <div class="form-row">
                       <label for="customerPhone">Teléfono</label>
                       <input type="text" id="customerPhone" placeholder="Número de contacto" />
+                    </div>
+                    <div class="form-row">
+                      <label for="customerEmail">Correo electrónico</label>
+                      <input type="text" id="customerEmail" placeholder="Correo de contacto" />
+                    </div>
+                    <div class="form-row">
+                      <label for="customerAddress">Dirección</label>
+                      <textarea
+                        id="customerAddress"
+                        rows="2"
+                        placeholder="Dirección de facturación o contacto"
+                      ></textarea>
                     </div>
                     <div class="form-row">
                       <label>Conjuntos de medidas</label>
@@ -334,11 +356,33 @@
                     </div>
                     <div class="form-row">
                       <label for="updateCustomerDocument">Cédula o identificación</label>
-                      <input type="text" id="updateCustomerDocument" required />
+                      <div class="field-with-action">
+                        <input type="text" id="updateCustomerDocument" required />
+                        <button
+                          type="button"
+                          id="updateCustomerFetchContificoButton"
+                          class="secondary"
+                        >
+                          Actualizar desde Contífico
+                        </button>
+                      </div>
+                      <p
+                        id="updateContificoCustomerLookupStatus"
+                        class="muted small contifico-lookup-status"
+                        aria-live="polite"
+                      ></p>
                     </div>
                     <div class="form-row">
                       <label for="updateCustomerPhone">Teléfono</label>
                       <input type="text" id="updateCustomerPhone" />
+                    </div>
+                    <div class="form-row">
+                      <label for="updateCustomerEmail">Correo electrónico</label>
+                      <input type="text" id="updateCustomerEmail" />
+                    </div>
+                    <div class="form-row">
+                      <label for="updateCustomerAddress">Dirección</label>
+                      <textarea id="updateCustomerAddress" rows="2"></textarea>
                     </div>
                     <div class="form-row">
                       <label>Conjuntos de medidas</label>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -282,6 +282,36 @@ h3 {
   gap: 0.35rem;
 }
 
+.field-with-action {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.field-with-action > input,
+.field-with-action > textarea,
+.field-with-action > select {
+  flex: 1 1 12rem;
+}
+
+.contifico-lookup-status {
+  min-height: 1rem;
+  margin: 0;
+}
+
+.contifico-lookup-status.info {
+  color: var(--muted);
+}
+
+.contifico-lookup-status.success {
+  color: var(--success);
+}
+
+.contifico-lookup-status.error {
+  color: var(--danger);
+}
+
 label {
   font-weight: 600;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- ensure Contifico customer lookups traverse nested payload structures when matching identification numbers
- add unit test coverage demonstrating nested personas payloads are correctly matched

## Testing
- pytest backend/tests/test_contifico_client.py::test_fetch_customer_by_document_handles_nested_payload -q

------
https://chatgpt.com/codex/tasks/task_e_68e431c840cc83329a9ce445d4a6fe5e