### PR TITLE
Add modal to view customer details from order summary

### DIFF
--- a/frontend/order-detail.js
+++ b/frontend/order-detail.js
@@ -10,8 +10,6 @@ const headingStatusElement = document.getElementById('orderHeadingStatus');
 const statusMessageElement = document.getElementById('orderDetailStatusMessage');
 const contentElement = document.getElementById('orderDetailContent');
 const summaryCustomerElement = document.getElementById('orderSummaryCustomer');
-const summaryDocumentElement = document.getElementById('orderSummaryDocument');
-const summaryContactElement = document.getElementById('orderSummaryContact');
 const summaryInvoiceElement = document.getElementById('orderSummaryInvoice');
 const summaryOriginElement = document.getElementById('orderSummaryOrigin');
 const summaryDeliveryElement = document.getElementById('orderSummaryDelivery');
@@ -21,6 +19,14 @@ const notesElement = document.getElementById('orderDetailNotes');
 const measurementsElement = document.getElementById('orderDetailMeasurements');
 const tasksContainerElement = document.getElementById('orderDetailTasks');
 const currentYearElement = document.getElementById('currentYear');
+
+const customerDetailModalElement = document.getElementById('customerDetailModal');
+const customerDetailDialogElement = document.getElementById('customerDetailDialog');
+const customerDetailNameElement = document.getElementById('customerDetailName');
+const customerDetailDocumentElement = document.getElementById('customerDetailDocument');
+const customerDetailContactElement = document.getElementById('customerDetailContact');
+const customerDetailDescriptionElement = document.getElementById('customerDetailDescription');
+const customerDetailCloseElements = document.querySelectorAll('[data-close-customer-modal]');
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 const ORDER_FETCH_MAX_ATTEMPTS = 5;
@@ -306,6 +312,182 @@ function setSummaryField(element, value, fallback = '—') {
   }
 }
 
+function syncBodyModalState() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const hasVisibleModal = Boolean(document.querySelector('.modal-overlay:not(.hidden)'));
+  document.body.classList.toggle('modal-open', hasVisibleModal);
+}
+
+function normalizeTextContent(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  try {
+    return value.toString().trim();
+  } catch (error) {
+    return '';
+  }
+}
+
+const customerDetailState = {
+  name: '',
+  document: '',
+  contact: '',
+  hasAnyDetail: false,
+};
+
+let lastFocusedElementBeforeCustomerModal = null;
+let isCustomerModalOpen = false;
+
+function updateCustomerModalContent() {
+  if (customerDetailNameElement) {
+    setSummaryField(customerDetailNameElement, customerDetailState.name, 'Sin registrar');
+  }
+  if (customerDetailDocumentElement) {
+    setSummaryField(customerDetailDocumentElement, customerDetailState.document, 'Sin registrar');
+  }
+  if (customerDetailContactElement) {
+    setSummaryField(customerDetailContactElement, customerDetailState.contact, 'Sin registrar');
+  }
+  if (customerDetailDescriptionElement) {
+    if (customerDetailState.hasAnyDetail) {
+      customerDetailDescriptionElement.textContent =
+        'Consulta los datos registrados para el cliente asociado a esta orden.';
+      customerDetailDescriptionElement.classList.remove('is-empty');
+    } else {
+      customerDetailDescriptionElement.textContent =
+        'No se registraron datos adicionales del cliente.';
+      customerDetailDescriptionElement.classList.add('is-empty');
+    }
+  }
+}
+
+function applyCustomerSummaryAvailability() {
+  if (!summaryCustomerElement) {
+    return;
+  }
+  const interactive = customerDetailState.hasAnyDetail;
+  summaryCustomerElement.disabled = !interactive;
+  summaryCustomerElement.classList.toggle('is-interactive', interactive);
+  if (interactive) {
+    summaryCustomerElement.setAttribute('aria-label', 'Ver datos del cliente');
+    summaryCustomerElement.setAttribute('aria-haspopup', 'dialog');
+    summaryCustomerElement.setAttribute('title', 'Ver datos del cliente');
+  } else {
+    summaryCustomerElement.removeAttribute('aria-label');
+    summaryCustomerElement.removeAttribute('aria-haspopup');
+    summaryCustomerElement.removeAttribute('title');
+  }
+}
+
+function resetCustomerDetailState(fallback = 'Sin registrar') {
+  customerDetailState.name = '';
+  customerDetailState.document = '';
+  customerDetailState.contact = '';
+  customerDetailState.hasAnyDetail = false;
+  if (summaryCustomerElement) {
+    setSummaryField(summaryCustomerElement, '', fallback);
+  }
+  updateCustomerModalContent();
+  applyCustomerSummaryAvailability();
+}
+
+function updateCustomerDetailState(order) {
+  if (!order) {
+    resetCustomerDetailState();
+    return;
+  }
+
+  customerDetailState.name = normalizeTextContent(order.customer_name);
+  customerDetailState.document = normalizeTextContent(order.customer_document);
+  customerDetailState.contact = normalizeTextContent(order.customer_contact);
+  customerDetailState.hasAnyDetail = Boolean(
+    customerDetailState.name || customerDetailState.document || customerDetailState.contact
+  );
+
+  if (summaryCustomerElement) {
+    setSummaryField(summaryCustomerElement, customerDetailState.name, 'Sin registrar');
+  }
+  updateCustomerModalContent();
+  applyCustomerSummaryAvailability();
+}
+
+function openCustomerDetailModal() {
+  if (!customerDetailModalElement || !customerDetailState.hasAnyDetail) {
+    return;
+  }
+  if (!customerDetailModalElement.classList.contains('hidden')) {
+    return;
+  }
+  lastFocusedElementBeforeCustomerModal =
+    document.activeElement && typeof document.activeElement.focus === 'function'
+      ? document.activeElement
+      : null;
+  customerDetailModalElement.classList.remove('hidden');
+  customerDetailModalElement.setAttribute('aria-hidden', 'false');
+  syncBodyModalState();
+  if (customerDetailDialogElement) {
+    customerDetailDialogElement.focus();
+  }
+  isCustomerModalOpen = true;
+}
+
+function closeCustomerDetailModal() {
+  if (!customerDetailModalElement || customerDetailModalElement.classList.contains('hidden')) {
+    return;
+  }
+  customerDetailModalElement.classList.add('hidden');
+  customerDetailModalElement.setAttribute('aria-hidden', 'true');
+  syncBodyModalState();
+  isCustomerModalOpen = false;
+  if (lastFocusedElementBeforeCustomerModal && typeof lastFocusedElementBeforeCustomerModal.focus === 'function') {
+    lastFocusedElementBeforeCustomerModal.focus();
+  } else if (summaryCustomerElement) {
+    summaryCustomerElement.focus();
+  }
+  lastFocusedElementBeforeCustomerModal = null;
+}
+
+function setupCustomerDetailModal() {
+  if (summaryCustomerElement) {
+    summaryCustomerElement.addEventListener('click', () => {
+      if (summaryCustomerElement.disabled) {
+        return;
+      }
+      openCustomerDetailModal();
+    });
+  }
+
+  customerDetailCloseElements.forEach((element) => {
+    element.addEventListener('click', () => {
+      closeCustomerDetailModal();
+    });
+  });
+
+  if (customerDetailModalElement) {
+    customerDetailModalElement.addEventListener('click', (event) => {
+      if (event?.target?.dataset?.closeCustomerModal === 'true') {
+        closeCustomerDetailModal();
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (!isCustomerModalOpen) {
+      return;
+    }
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      event.preventDefault();
+      closeCustomerDetailModal();
+    }
+  });
+}
+
 function renderNotes(notes) {
   if (!notesElement) return;
   const normalized = typeof notes === 'string' ? notes.trim() : '';
@@ -478,9 +660,7 @@ function renderOrder(order) {
     headingStatusElement.appendChild(createStatusBadgeElement(order.status));
   }
 
-  setSummaryField(summaryCustomerElement, order.customer_name || '', 'Sin registrar');
-  setSummaryField(summaryDocumentElement, order.customer_document || '', 'Sin registrar');
-  setSummaryField(summaryContactElement, order.customer_contact || '', 'Sin registrar');
+  updateCustomerDetailState(order);
   setSummaryField(summaryInvoiceElement, order.invoice_number || '', 'Sin número registrado');
   setSummaryField(summaryOriginElement, order.origin_branch || '', 'Sin definir');
   const deliveryLabel = formatDeliveryDateLabel(order);
@@ -674,4 +854,6 @@ function initialise() {
   loadOrderDetails(orderId, token);
 }
 
+setupCustomerDetailModal();
+resetCustomerDetailState('—');
 initialise();

--- a/frontend/order.html
+++ b/frontend/order.html
@@ -100,15 +100,16 @@
             <dl class="order-detail-summary-grid">
               <div class="order-detail-summary-item">
                 <dt>Cliente</dt>
-                <dd id="orderSummaryCustomer">—</dd>
-              </div>
-              <div class="order-detail-summary-item">
-                <dt>Documento</dt>
-                <dd id="orderSummaryDocument">—</dd>
-              </div>
-              <div class="order-detail-summary-item">
-                <dt>Contacto</dt>
-                <dd id="orderSummaryContact">—</dd>
+                <dd>
+                  <button
+                    type="button"
+                    id="orderSummaryCustomer"
+                    class="order-detail-customer-button muted"
+                    disabled
+                  >
+                    —
+                  </button>
+                </dd>
               </div>
               <div class="order-detail-summary-item">
                 <dt>Factura</dt>
@@ -156,6 +157,56 @@
         </div>
       </section>
     </main>
+
+    <div
+      id="customerDetailModal"
+      class="modal-overlay hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="customerDetailTitle"
+      aria-hidden="true"
+    >
+      <div class="modal-backdrop" data-close-customer-modal="true"></div>
+      <div
+        id="customerDetailDialog"
+        class="modal-dialog"
+        role="document"
+        tabindex="-1"
+      >
+        <div class="modal-content customer-modal">
+          <div class="customer-modal-header">
+            <div>
+              <h4 id="customerDetailTitle">Datos del cliente</h4>
+              <p id="customerDetailDescription" class="muted small">
+                Consulta los datos registrados para el cliente asociado a esta orden.
+              </p>
+            </div>
+            <button
+              type="button"
+              class="link-button"
+              data-close-customer-modal="true"
+              aria-label="Cerrar datos del cliente"
+            >
+              Cerrar
+            </button>
+          </div>
+          <dl class="customer-modal-info">
+            <div class="customer-modal-info-item">
+              <dt>Nombre completo</dt>
+              <dd id="customerDetailName" class="muted">Sin registrar</dd>
+            </div>
+            <div class="customer-modal-info-item">
+              <dt>Documento</dt>
+              <dd id="customerDetailDocument" class="muted">Sin registrar</dd>
+            </div>
+            <div class="customer-modal-info-item">
+              <dt>Contacto</dt>
+              <dd id="customerDetailContact" class="muted">Sin registrar</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </div>
 
     <footer class="container footer">
       <small>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1218,6 +1218,41 @@ button[disabled] {
   word-break: break-word;
 }
 
+.order-detail-customer-button {
+  font: inherit;
+  font-weight: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: default;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.order-detail-customer-button.is-interactive {
+  cursor: pointer;
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.2em;
+}
+
+.order-detail-customer-button.is-interactive:hover,
+.order-detail-customer-button.is-interactive:focus-visible {
+  text-decoration-thickness: 0.12em;
+}
+
+.order-detail-customer-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.order-detail-customer-button:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
 .order-detail-notes {
   margin: 0;
   line-height: 1.6;
@@ -1503,6 +1538,46 @@ button[disabled] {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.customer-modal {
+  gap: 1.25rem;
+}
+
+.customer-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.customer-modal-info {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem;
+}
+
+.customer-modal-info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.customer-modal-info-item dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+}
+
+.customer-modal-info-item dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  word-break: break-word;
 }
 
 .contifico-modal {


### PR DESCRIPTION
## Summary
- hide sensitive customer fields from the order summary and replace the value with a clickable button
- populate a new customer detail modal from the order payload and wire up open/close behaviour
- style the customer trigger and modal layout to match the existing design system

## Testing
- Manual verification via local stub API and Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68e4347fa5ac8332bf407b414032643e