### PR TITLE
Fix Contifico customer lookup iteration

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -410,8 +410,9 @@ class ContificoClient:
         if not normalized_target:
             raise ValueError("El número de documento del cliente es obligatorio.")
 
-        params = {"identificacion": normalized_target}
-        payload = self._request("GET", "personas", params=params)
+        for candidate in self._customer_document_queries(document_id):
+            params = {"identificacion": candidate}
+            payload = self._request("GET", "personas", params=params)
 
             match = self._find_customer_in_payload(payload, normalized_target)
             if match is not None:


### PR DESCRIPTION
## Summary
- iterate over document query candidates when fetching customers from Contifico
- reuse the existing candidate normalization helper to retry lookups

## Testing
- python3 -m app.main (fails: SECRET_KEY environment variable is required)

------
https://chatgpt.com/codex/tasks/task_e_68e443ce321c8332b38bca42dca54e92