### PR TITLE
Handle Contifico customer 404 responses

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -412,7 +412,15 @@ class ContificoClient:
 
         for candidate in self._customer_document_queries(document_id):
             params = {"identificacion": candidate}
-            payload = self._request("GET", "personas", params=params)
+            try:
+                payload = self._request("GET", "personas", params=params)
+            except ContificoAPIError as exc:
+                if exc.status_code == HTTPStatus.NOT_FOUND:
+                    # Contífico devuelve 404 con una página HTML cuando el
+                    # cliente no existe. Lo tratamos como "no encontrado" y
+                    # seguimos probando con otras variantes del documento.
+                    continue
+                raise
 
             match = self._find_customer_in_payload(payload, normalized_target)
             if match is not None:

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -101,6 +101,32 @@ def test_list_products_error_response() -> None:
     assert "No autorizado" in exc_info.value.detail
 
 
+def test_fetch_customer_by_document_treats_html_not_found_as_missing() -> None:
+    attempts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(request.url.params.get("identificacion", ""))
+        return httpx.Response(
+            HTTPStatus.NOT_FOUND,
+            text="<html><body>El objeto que intenta consultar o modificar no existe.</body></html>",
+            headers={"Content-Type": "text/html; charset=utf-8"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    result = client.fetch_customer_by_document("0919957423")
+
+    assert result is None
+    # Se prueban las variantes con y sin sufijo 001.
+    assert attempts == ["0919957423", "0919957423001"]
+
+
 def test_list_warehouses_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path.endswith("/bodega/")


### PR DESCRIPTION
## Summary
- ignore 404 responses from Contifico when looking up customers so the integration keeps searching other document variants and returns a clean not-found result
- add regression test ensuring HTML 404 responses are treated as missing customers instead of surfacing raw markup

## Testing
- pytest tests/test_contifico_client.py::test_fetch_customer_by_document_treats_html_not_found_as_missing

------
https://chatgpt.com/codex/tasks/task_e_68e44558ab088332a6a94dac160d702b