### PR TITLE
Fix Contifico customer lookup endpoint

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -412,7 +412,12 @@ class ContificoClient:
 
         for candidate in self._customer_document_queries(document_id):
             params = {"identificacion": candidate}
-            payload = self._request("GET", "personas", params=params)
+            try:
+                payload = self._request("GET", "persona/", params=params)
+            except ContificoAPIError as exc:
+                if exc.status_code == HTTPStatus.NOT_FOUND:
+                    continue
+                raise
 
             match = self._find_customer_in_payload(payload, normalized_target)
             if match is not None:

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -1399,7 +1399,7 @@ def test_fetch_customer_by_document_returns_match(monkeypatch) -> None:
 
     def fake_request(method, endpoint, *, params=None, json=None):
         assert method == "GET"
-        assert endpoint == "personas"
+        assert endpoint == "persona/"
         assert params == {"identificacion": "0912345678"}
         return [payload]
 
@@ -1429,7 +1429,7 @@ def test_fetch_customer_by_document_handles_nested_payload(monkeypatch) -> None:
 
     def fake_request(method, endpoint, *, params=None, json=None):
         assert method == "GET"
-        assert endpoint == "personas"
+        assert endpoint == "persona/"
         assert params == {"identificacion": "0912345678"}
         return payload
 
@@ -1494,7 +1494,7 @@ def test_fetch_customer_by_document_falls_back_between_variants(monkeypatch) -> 
 
     def fake_request(method, endpoint, *, params=None, json=None):
         assert method == "GET"
-        assert endpoint == "personas"
+        assert endpoint == "persona/"
         assert json is None
         attempts.append(params["identificacion"])
         if params == {"identificacion": "0919957423"}:


### PR DESCRIPTION
## Summary
- update the Contifico customer lookup to call the correct `persona/` endpoint and ignore 404 responses while trying alternate document variants
- align unit tests with the corrected endpoint expectation

## Testing
- `cd backend && pytest tests/test_contifico_client.py::test_fetch_customer_by_document_returns_match tests/test_contifico_client.py::test_fetch_customer_by_document_handles_nested_payload tests/test_contifico_client.py::test_fetch_customer_by_document_falls_back_between_variants`


------
https://chatgpt.com/codex/tasks/task_e_68e44558ab088332a6a94dac160d702b