### PR TITLE
Refine customer detail access in order management panel

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -342,9 +342,7 @@ const updateOrderForm = document.getElementById('updateOrderForm');
 const orderDetailNumberElement = document.getElementById('orderDetailNumber');
 const orderDetailCreatedAtElement = document.getElementById('orderDetailCreatedAt');
 const orderDetailUpdatedAtElement = document.getElementById('orderDetailUpdatedAt');
-const orderDetailCustomerInput = document.getElementById('orderDetailCustomer');
-const orderDetailDocumentInput = document.getElementById('orderDetailDocument');
-const orderDetailContactInput = document.getElementById('orderDetailContact');
+const orderDetailCustomerButton = document.getElementById('orderDetailCustomerButton');
 const orderDetailStatusSelect = document.getElementById('orderDetailStatus');
 const orderDetailTailorSelect = document.getElementById('orderDetailTailor');
 const orderDetailVendorSelect = document.getElementById('orderDetailVendor');
@@ -361,6 +359,13 @@ const orderTaskDescriptionInput = document.getElementById('orderTaskDescription'
 const orderTaskResponsibleSelect = document.getElementById('orderTaskResponsibleSelect');
 const orderTasksPermissionsNotice = document.getElementById('orderTasksPermissionsNotice');
 const closeOrderDetailButton = document.getElementById('closeOrderDetailButton');
+const orderCustomerDetailOverlay = document.getElementById('orderCustomerDetailOverlay');
+const orderCustomerDetailDialog = document.getElementById('orderCustomerDetailDialog');
+const orderCustomerDetailName = document.getElementById('orderCustomerDetailName');
+const orderCustomerDetailDocument = document.getElementById('orderCustomerDetailDocument');
+const orderCustomerDetailContact = document.getElementById('orderCustomerDetailContact');
+const orderCustomerDetailDescription = document.getElementById('orderCustomerDetailDescription');
+const orderCustomerDetailCloseElements = document.querySelectorAll('[data-order-customer-modal-close]');
 const toastElement = document.getElementById('toast');
 const currentYearElement = document.getElementById('currentYear');
 const currentUserNameElement = document.getElementById('currentUserName');
@@ -3859,6 +3864,147 @@ if (closeCustomerDetailButton) {
   });
 }
 
+const orderCustomerDetailState = {
+  name: '',
+  document: '',
+  contact: '',
+  hasAnyDetail: false,
+};
+
+let lastOrderCustomerDetailTrigger = null;
+
+function normalizeOrderCustomerDetailValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  try {
+    return value.toString().trim();
+  } catch (error) {
+    return '';
+  }
+}
+
+function setOrderCustomerDetailField(element, value, fallback = 'Sin registrar') {
+  if (!element) {
+    return;
+  }
+  const normalized = normalizeOrderCustomerDetailValue(value);
+  if (normalized) {
+    element.textContent = normalized;
+    element.classList.remove('muted');
+  } else {
+    element.textContent = fallback;
+    element.classList.add('muted');
+  }
+}
+
+function updateOrderCustomerDetailModalContent() {
+  setOrderCustomerDetailField(orderCustomerDetailName, orderCustomerDetailState.name);
+  setOrderCustomerDetailField(orderCustomerDetailDocument, orderCustomerDetailState.document);
+  setOrderCustomerDetailField(orderCustomerDetailContact, orderCustomerDetailState.contact);
+  if (orderCustomerDetailDescription) {
+    if (orderCustomerDetailState.hasAnyDetail) {
+      orderCustomerDetailDescription.textContent =
+        'Consulta los datos registrados para el cliente asociado a esta orden.';
+    } else {
+      orderCustomerDetailDescription.textContent =
+        'No se registraron datos adicionales del cliente.';
+    }
+  }
+}
+
+function updateOrderCustomerDetailTrigger() {
+  if (!orderDetailCustomerButton) {
+    return;
+  }
+  const label = orderCustomerDetailState.name || 'Sin registrar';
+  orderDetailCustomerButton.textContent = label;
+  if (orderCustomerDetailState.name) {
+    orderDetailCustomerButton.classList.remove('muted');
+  } else {
+    orderDetailCustomerButton.classList.add('muted');
+  }
+  const interactive = orderCustomerDetailState.hasAnyDetail;
+  orderDetailCustomerButton.disabled = !interactive;
+  orderDetailCustomerButton.classList.toggle('is-interactive', interactive);
+  if (interactive) {
+    orderDetailCustomerButton.setAttribute('aria-label', 'Ver datos del cliente');
+    orderDetailCustomerButton.setAttribute('aria-haspopup', 'dialog');
+    orderDetailCustomerButton.setAttribute('title', 'Ver datos del cliente');
+  } else {
+    orderDetailCustomerButton.removeAttribute('aria-label');
+    orderDetailCustomerButton.removeAttribute('aria-haspopup');
+    orderDetailCustomerButton.removeAttribute('title');
+  }
+}
+
+function resetOrderCustomerDetailState() {
+  orderCustomerDetailState.name = '';
+  orderCustomerDetailState.document = '';
+  orderCustomerDetailState.contact = '';
+  orderCustomerDetailState.hasAnyDetail = false;
+  updateOrderCustomerDetailTrigger();
+  updateOrderCustomerDetailModalContent();
+}
+
+function applyOrderCustomerDetailState(order) {
+  if (!order) {
+    resetOrderCustomerDetailState();
+    return;
+  }
+
+  orderCustomerDetailState.name = normalizeOrderCustomerDetailValue(order.customer_name);
+  orderCustomerDetailState.document = normalizeOrderCustomerDetailValue(order.customer_document);
+  orderCustomerDetailState.contact = normalizeOrderCustomerDetailValue(order.customer_contact);
+  orderCustomerDetailState.hasAnyDetail = Boolean(
+    orderCustomerDetailState.name ||
+      orderCustomerDetailState.document ||
+      orderCustomerDetailState.contact,
+  );
+
+  updateOrderCustomerDetailTrigger();
+  updateOrderCustomerDetailModalContent();
+}
+
+function openOrderCustomerDetailModal() {
+  if (!orderCustomerDetailOverlay || !orderCustomerDetailState.hasAnyDetail) {
+    return;
+  }
+  if (!orderCustomerDetailOverlay.classList.contains('hidden')) {
+    return;
+  }
+  lastOrderCustomerDetailTrigger =
+    document.activeElement && typeof document.activeElement.focus === 'function'
+      ? document.activeElement
+      : null;
+  orderCustomerDetailOverlay.classList.remove('hidden');
+  orderCustomerDetailOverlay.setAttribute('aria-hidden', 'false');
+  updateModalBodyState();
+  requestAnimationFrame(() => {
+    if (orderCustomerDetailDialog?.isConnected) {
+      orderCustomerDetailDialog.focus();
+    }
+  });
+}
+
+function closeOrderCustomerDetailModal() {
+  if (!orderCustomerDetailOverlay || orderCustomerDetailOverlay.classList.contains('hidden')) {
+    return;
+  }
+  orderCustomerDetailOverlay.classList.add('hidden');
+  orderCustomerDetailOverlay.setAttribute('aria-hidden', 'true');
+  updateModalBodyState();
+  if (lastOrderCustomerDetailTrigger?.isConnected) {
+    lastOrderCustomerDetailTrigger.focus();
+  } else if (orderDetailCustomerButton?.isConnected) {
+    orderDetailCustomerButton.focus();
+  }
+  lastOrderCustomerDetailTrigger = null;
+}
+
 document.addEventListener('keydown', (event) => {
   if (event.key !== 'Escape' || event.defaultPrevented) {
     return;
@@ -3867,6 +4013,13 @@ document.addEventListener('keydown', (event) => {
   if (detailOpen) {
     event.preventDefault();
     clearCustomerDetail({ reRender: true });
+    return;
+  }
+  const orderCustomerModalOpen =
+    orderCustomerDetailOverlay && !orderCustomerDetailOverlay.classList.contains('hidden');
+  if (orderCustomerModalOpen) {
+    event.preventDefault();
+    closeOrderCustomerDetailModal();
     return;
   }
   const createOpen = customerCreateOverlay && !customerCreateOverlay.classList.contains('hidden');
@@ -3894,15 +4047,7 @@ function populateOrderDetail(order, options = {}) {
   if (orderDetailUpdatedAtElement) {
     orderDetailUpdatedAtElement.textContent = formatDate(order.updated_at);
   }
-  if (orderDetailCustomerInput) {
-    orderDetailCustomerInput.value = order.customer_name || '';
-  }
-  if (orderDetailDocumentInput) {
-    orderDetailDocumentInput.value = order.customer_document || '';
-  }
-  if (orderDetailContactInput) {
-    orderDetailContactInput.value = order.customer_contact || '';
-  }
+  applyOrderCustomerDetailState(order);
   if (orderDetailStatusSelect) {
     populateStatusSelect(orderDetailStatusSelect, order.status);
   }
@@ -3982,13 +4127,12 @@ function clearOrderDetail(options = {}) {
   const focusElement = lastKanbanFocusedElement;
 
   state.selectedOrderId = null;
+  closeOrderCustomerDetailModal();
+  resetOrderCustomerDetailState();
   updateOrderForm?.reset();
   if (orderDetailNumberElement) orderDetailNumberElement.textContent = '';
   if (orderDetailCreatedAtElement) orderDetailCreatedAtElement.textContent = '';
   if (orderDetailUpdatedAtElement) orderDetailUpdatedAtElement.textContent = '';
-  if (orderDetailCustomerInput) orderDetailCustomerInput.value = '';
-  if (orderDetailDocumentInput) orderDetailDocumentInput.value = '';
-  if (orderDetailContactInput) orderDetailContactInput.value = '';
   if (orderDetailStatusSelect) populateStatusSelect(orderDetailStatusSelect);
   if (orderDetailTailorSelect) populateTailorSelect(orderDetailTailorSelect);
   if (orderDetailVendorSelect) populateVendorSelect(orderDetailVendorSelect);
@@ -4073,7 +4217,6 @@ async function handleOrderUpdate(event) {
         assigned_vendor_id: orderDetailVendorSelect?.value
           ? Number(orderDetailVendorSelect.value)
           : null,
-        customer_contact: orderDetailContactInput?.value.trim() || null,
         notes: orderDetailNotesTextarea?.value.trim() || null,
         delivery_date: deliveryDateValue ? deliveryDateValue : null,
         invoice_number: invoiceValue,
@@ -4105,6 +4248,29 @@ async function handleOrderUpdate(event) {
       markKanbanDataStale();
     }
   }
+}
+
+if (orderDetailCustomerButton) {
+  orderDetailCustomerButton.addEventListener('click', () => {
+    if (orderDetailCustomerButton.disabled) {
+      return;
+    }
+    openOrderCustomerDetailModal();
+  });
+}
+
+orderCustomerDetailCloseElements.forEach((element) => {
+  element.addEventListener('click', () => {
+    closeOrderCustomerDetailModal();
+  });
+});
+
+if (orderCustomerDetailOverlay) {
+  orderCustomerDetailOverlay.addEventListener('click', (event) => {
+    if (event.target === orderCustomerDetailOverlay) {
+      closeOrderCustomerDetailModal();
+    }
+  });
 }
 
 if (addCustomerMeasurementSetButton) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -580,16 +580,15 @@
                 </div>
                 <form id="updateOrderForm" class="form-grid">
                   <div class="form-row">
-                    <label for="orderDetailCustomer">Cliente</label>
-                    <input type="text" id="orderDetailCustomer" readonly />
-                  </div>
-                  <div class="form-row">
-                    <label for="orderDetailDocument">Documento</label>
-                    <input type="text" id="orderDetailDocument" readonly />
-                  </div>
-                  <div class="form-row">
-                    <label for="orderDetailContact">Contacto</label>
-                    <input type="text" id="orderDetailContact" />
+                    <label for="orderDetailCustomerButton">Cliente</label>
+                    <button
+                      type="button"
+                      id="orderDetailCustomerButton"
+                      class="order-detail-customer-button muted"
+                      disabled
+                    >
+                      Sin registrar
+                    </button>
                   </div>
                   <div class="form-row">
                     <label for="orderDetailInvoice">Número de factura</label>
@@ -716,6 +715,56 @@
             </div>
 
           </section>
+
+          <div
+            id="orderCustomerDetailOverlay"
+            class="modal-overlay hidden"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="orderCustomerDetailTitle"
+            aria-hidden="true"
+          >
+            <div class="modal-backdrop" data-order-customer-modal-close="true"></div>
+            <div
+              id="orderCustomerDetailDialog"
+              class="modal-dialog"
+              role="document"
+              tabindex="-1"
+            >
+              <div class="modal-content customer-modal">
+                <div class="customer-modal-header">
+                  <div>
+                    <h4 id="orderCustomerDetailTitle">Datos del cliente</h4>
+                    <p id="orderCustomerDetailDescription" class="muted small">
+                      Consulta los datos registrados para el cliente asociado a esta orden.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    class="link-button"
+                    data-order-customer-modal-close="true"
+                    aria-label="Cerrar datos del cliente"
+                  >
+                    Cerrar
+                  </button>
+                </div>
+                <dl class="customer-modal-info">
+                  <div class="customer-modal-info-item">
+                    <dt>Nombre completo</dt>
+                    <dd id="orderCustomerDetailName" class="muted">Sin registrar</dd>
+                  </div>
+                  <div class="customer-modal-info-item">
+                    <dt>Documento</dt>
+                    <dd id="orderCustomerDetailDocument" class="muted">Sin registrar</dd>
+                  </div>
+                  <div class="customer-modal-info-item">
+                    <dt>Contacto</dt>
+                    <dd id="orderCustomerDetailContact" class="muted">Sin registrar</dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+          </div>
 
           <section class="card dashboard-panel hidden" id="usersPanel">
             <div class="users-panel-header">

--- a/frontend/order-detail.js
+++ b/frontend/order-detail.js
@@ -10,8 +10,6 @@ const headingStatusElement = document.getElementById('orderHeadingStatus');
 const statusMessageElement = document.getElementById('orderDetailStatusMessage');
 const contentElement = document.getElementById('orderDetailContent');
 const summaryCustomerElement = document.getElementById('orderSummaryCustomer');
-const summaryDocumentElement = document.getElementById('orderSummaryDocument');
-const summaryContactElement = document.getElementById('orderSummaryContact');
 const summaryInvoiceElement = document.getElementById('orderSummaryInvoice');
 const summaryOriginElement = document.getElementById('orderSummaryOrigin');
 const summaryDeliveryElement = document.getElementById('orderSummaryDelivery');
@@ -21,6 +19,14 @@ const notesElement = document.getElementById('orderDetailNotes');
 const measurementsElement = document.getElementById('orderDetailMeasurements');
 const tasksContainerElement = document.getElementById('orderDetailTasks');
 const currentYearElement = document.getElementById('currentYear');
+
+const customerDetailModalElement = document.getElementById('customerDetailModal');
+const customerDetailDialogElement = document.getElementById('customerDetailDialog');
+const customerDetailNameElement = document.getElementById('customerDetailName');
+const customerDetailDocumentElement = document.getElementById('customerDetailDocument');
+const customerDetailContactElement = document.getElementById('customerDetailContact');
+const customerDetailDescriptionElement = document.getElementById('customerDetailDescription');
+const customerDetailCloseElements = document.querySelectorAll('[data-close-customer-modal]');
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 const ORDER_FETCH_MAX_ATTEMPTS = 5;
@@ -306,6 +312,182 @@ function setSummaryField(element, value, fallback = '—') {
   }
 }
 
+function syncBodyModalState() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const hasVisibleModal = Boolean(document.querySelector('.modal-overlay:not(.hidden)'));
+  document.body.classList.toggle('modal-open', hasVisibleModal);
+}
+
+function normalizeTextContent(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  try {
+    return value.toString().trim();
+  } catch (error) {
+    return '';
+  }
+}
+
+const customerDetailState = {
+  name: '',
+  document: '',
+  contact: '',
+  hasAnyDetail: false,
+};
+
+let lastFocusedElementBeforeCustomerModal = null;
+let isCustomerModalOpen = false;
+
+function updateCustomerModalContent() {
+  if (customerDetailNameElement) {
+    setSummaryField(customerDetailNameElement, customerDetailState.name, 'Sin registrar');
+  }
+  if (customerDetailDocumentElement) {
+    setSummaryField(customerDetailDocumentElement, customerDetailState.document, 'Sin registrar');
+  }
+  if (customerDetailContactElement) {
+    setSummaryField(customerDetailContactElement, customerDetailState.contact, 'Sin registrar');
+  }
+  if (customerDetailDescriptionElement) {
+    if (customerDetailState.hasAnyDetail) {
+      customerDetailDescriptionElement.textContent =
+        'Consulta los datos registrados para el cliente asociado a esta orden.';
+      customerDetailDescriptionElement.classList.remove('is-empty');
+    } else {
+      customerDetailDescriptionElement.textContent =
+        'No se registraron datos adicionales del cliente.';
+      customerDetailDescriptionElement.classList.add('is-empty');
+    }
+  }
+}
+
+function applyCustomerSummaryAvailability() {
+  if (!summaryCustomerElement) {
+    return;
+  }
+  const interactive = customerDetailState.hasAnyDetail;
+  summaryCustomerElement.disabled = !interactive;
+  summaryCustomerElement.classList.toggle('is-interactive', interactive);
+  if (interactive) {
+    summaryCustomerElement.setAttribute('aria-label', 'Ver datos del cliente');
+    summaryCustomerElement.setAttribute('aria-haspopup', 'dialog');
+    summaryCustomerElement.setAttribute('title', 'Ver datos del cliente');
+  } else {
+    summaryCustomerElement.removeAttribute('aria-label');
+    summaryCustomerElement.removeAttribute('aria-haspopup');
+    summaryCustomerElement.removeAttribute('title');
+  }
+}
+
+function resetCustomerDetailState(fallback = 'Sin registrar') {
+  customerDetailState.name = '';
+  customerDetailState.document = '';
+  customerDetailState.contact = '';
+  customerDetailState.hasAnyDetail = false;
+  if (summaryCustomerElement) {
+    setSummaryField(summaryCustomerElement, '', fallback);
+  }
+  updateCustomerModalContent();
+  applyCustomerSummaryAvailability();
+}
+
+function updateCustomerDetailState(order) {
+  if (!order) {
+    resetCustomerDetailState();
+    return;
+  }
+
+  customerDetailState.name = normalizeTextContent(order.customer_name);
+  customerDetailState.document = normalizeTextContent(order.customer_document);
+  customerDetailState.contact = normalizeTextContent(order.customer_contact);
+  customerDetailState.hasAnyDetail = Boolean(
+    customerDetailState.name || customerDetailState.document || customerDetailState.contact
+  );
+
+  if (summaryCustomerElement) {
+    setSummaryField(summaryCustomerElement, customerDetailState.name, 'Sin registrar');
+  }
+  updateCustomerModalContent();
+  applyCustomerSummaryAvailability();
+}
+
+function openCustomerDetailModal() {
+  if (!customerDetailModalElement || !customerDetailState.hasAnyDetail) {
+    return;
+  }
+  if (!customerDetailModalElement.classList.contains('hidden')) {
+    return;
+  }
+  lastFocusedElementBeforeCustomerModal =
+    document.activeElement && typeof document.activeElement.focus === 'function'
+      ? document.activeElement
+      : null;
+  customerDetailModalElement.classList.remove('hidden');
+  customerDetailModalElement.setAttribute('aria-hidden', 'false');
+  syncBodyModalState();
+  if (customerDetailDialogElement) {
+    customerDetailDialogElement.focus();
+  }
+  isCustomerModalOpen = true;
+}
+
+function closeCustomerDetailModal() {
+  if (!customerDetailModalElement || customerDetailModalElement.classList.contains('hidden')) {
+    return;
+  }
+  customerDetailModalElement.classList.add('hidden');
+  customerDetailModalElement.setAttribute('aria-hidden', 'true');
+  syncBodyModalState();
+  isCustomerModalOpen = false;
+  if (lastFocusedElementBeforeCustomerModal && typeof lastFocusedElementBeforeCustomerModal.focus === 'function') {
+    lastFocusedElementBeforeCustomerModal.focus();
+  } else if (summaryCustomerElement) {
+    summaryCustomerElement.focus();
+  }
+  lastFocusedElementBeforeCustomerModal = null;
+}
+
+function setupCustomerDetailModal() {
+  if (summaryCustomerElement) {
+    summaryCustomerElement.addEventListener('click', () => {
+      if (summaryCustomerElement.disabled) {
+        return;
+      }
+      openCustomerDetailModal();
+    });
+  }
+
+  customerDetailCloseElements.forEach((element) => {
+    element.addEventListener('click', () => {
+      closeCustomerDetailModal();
+    });
+  });
+
+  if (customerDetailModalElement) {
+    customerDetailModalElement.addEventListener('click', (event) => {
+      if (event?.target?.dataset?.closeCustomerModal === 'true') {
+        closeCustomerDetailModal();
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (!isCustomerModalOpen) {
+      return;
+    }
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      event.preventDefault();
+      closeCustomerDetailModal();
+    }
+  });
+}
+
 function renderNotes(notes) {
   if (!notesElement) return;
   const normalized = typeof notes === 'string' ? notes.trim() : '';
@@ -478,9 +660,7 @@ function renderOrder(order) {
     headingStatusElement.appendChild(createStatusBadgeElement(order.status));
   }
 
-  setSummaryField(summaryCustomerElement, order.customer_name || '', 'Sin registrar');
-  setSummaryField(summaryDocumentElement, order.customer_document || '', 'Sin registrar');
-  setSummaryField(summaryContactElement, order.customer_contact || '', 'Sin registrar');
+  updateCustomerDetailState(order);
   setSummaryField(summaryInvoiceElement, order.invoice_number || '', 'Sin número registrado');
   setSummaryField(summaryOriginElement, order.origin_branch || '', 'Sin definir');
   const deliveryLabel = formatDeliveryDateLabel(order);
@@ -674,4 +854,6 @@ function initialise() {
   loadOrderDetails(orderId, token);
 }
 
+setupCustomerDetailModal();
+resetCustomerDetailState('—');
 initialise();

--- a/frontend/order.html
+++ b/frontend/order.html
@@ -100,15 +100,16 @@
             <dl class="order-detail-summary-grid">
               <div class="order-detail-summary-item">
                 <dt>Cliente</dt>
-                <dd id="orderSummaryCustomer">—</dd>
-              </div>
-              <div class="order-detail-summary-item">
-                <dt>Documento</dt>
-                <dd id="orderSummaryDocument">—</dd>
-              </div>
-              <div class="order-detail-summary-item">
-                <dt>Contacto</dt>
-                <dd id="orderSummaryContact">—</dd>
+                <dd>
+                  <button
+                    type="button"
+                    id="orderSummaryCustomer"
+                    class="order-detail-customer-button muted"
+                    disabled
+                  >
+                    —
+                  </button>
+                </dd>
               </div>
               <div class="order-detail-summary-item">
                 <dt>Factura</dt>
@@ -156,6 +157,56 @@
         </div>
       </section>
     </main>
+
+    <div
+      id="customerDetailModal"
+      class="modal-overlay hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="customerDetailTitle"
+      aria-hidden="true"
+    >
+      <div class="modal-backdrop" data-close-customer-modal="true"></div>
+      <div
+        id="customerDetailDialog"
+        class="modal-dialog"
+        role="document"
+        tabindex="-1"
+      >
+        <div class="modal-content customer-modal">
+          <div class="customer-modal-header">
+            <div>
+              <h4 id="customerDetailTitle">Datos del cliente</h4>
+              <p id="customerDetailDescription" class="muted small">
+                Consulta los datos registrados para el cliente asociado a esta orden.
+              </p>
+            </div>
+            <button
+              type="button"
+              class="link-button"
+              data-close-customer-modal="true"
+              aria-label="Cerrar datos del cliente"
+            >
+              Cerrar
+            </button>
+          </div>
+          <dl class="customer-modal-info">
+            <div class="customer-modal-info-item">
+              <dt>Nombre completo</dt>
+              <dd id="customerDetailName" class="muted">Sin registrar</dd>
+            </div>
+            <div class="customer-modal-info-item">
+              <dt>Documento</dt>
+              <dd id="customerDetailDocument" class="muted">Sin registrar</dd>
+            </div>
+            <div class="customer-modal-info-item">
+              <dt>Contacto</dt>
+              <dd id="customerDetailContact" class="muted">Sin registrar</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </div>
 
     <footer class="container footer">
       <small>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1218,6 +1218,41 @@ button[disabled] {
   word-break: break-word;
 }
 
+.order-detail-customer-button {
+  font: inherit;
+  font-weight: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: default;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.order-detail-customer-button.is-interactive {
+  cursor: pointer;
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.2em;
+}
+
+.order-detail-customer-button.is-interactive:hover,
+.order-detail-customer-button.is-interactive:focus-visible {
+  text-decoration-thickness: 0.12em;
+}
+
+.order-detail-customer-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.order-detail-customer-button:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
 .order-detail-notes {
   margin: 0;
   line-height: 1.6;
@@ -1503,6 +1538,46 @@ button[disabled] {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.customer-modal {
+  gap: 1.25rem;
+}
+
+.customer-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.customer-modal-info {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem;
+}
+
+.customer-modal-info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.customer-modal-info-item dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+}
+
+.customer-modal-info-item dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  word-break: break-word;
 }
 
 .contifico-modal {


### PR DESCRIPTION
## Summary
- replace the customer/document/contact inputs in the order detail form with a single interactive customer trigger
- add a modal that displays the client’s name, document, and contact data when opened from an order
- hook the modal into the existing focus and escape handling to keep the dashboard accessible

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4347fa5ac8332bf407b414032643e