### PR TITLE
Add Contifico product preview category endpoints

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -503,11 +503,20 @@ class ContificoClient:
         return False
 
     def list_products(
-        self, *, page: int = 1, page_size: int = 100
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+        category_id: str | int | None = None,
     ) -> Iterable[Dict[str, Any]]:
         """Devuelve un lote de productos desde Contífico."""
 
-        params = {"result_page": page, "result_size": page_size}
+        params: Dict[str, Any] = {"result_page": page, "result_size": page_size}
+        if category_id is not None:
+            category_value = str(category_id).strip()
+            if not category_value:
+                raise ValueError("El identificador de la categoría no puede estar vacío.")
+            params["categoria"] = category_value
         data = self._request("GET", "producto/", params=params)
         if data is None:
             return []
@@ -516,6 +525,45 @@ class ContificoClient:
         raise ContificoAPIError(
             status_code=200,
             detail="El formato de respuesta para productos no es el esperado.",
+            payload=data,
+        )
+
+    def get_product(self, product_id: str | int) -> Dict[str, Any]:
+        """Obtiene la información de un producto específico."""
+
+        if isinstance(product_id, str):
+            normalized_id = product_id.strip()
+        else:
+            normalized_id = str(product_id)
+        if not normalized_id:
+            raise ValueError("El identificador del producto es obligatorio.")
+
+        data = self._request("GET", f"producto/{normalized_id}/")
+        if isinstance(data, dict):
+            return data
+        if data is None:
+            raise ContificoAPIError(
+                status_code=200,
+                detail="El producto solicitado no fue encontrado.",
+                payload=data,
+            )
+        raise ContificoAPIError(
+            status_code=200,
+            detail="El formato de respuesta para un producto no es el esperado.",
+            payload=data,
+        )
+
+    def list_product_categories(self) -> Iterable[Dict[str, Any]]:
+        """Lista las categorías de productos configuradas en Contífico."""
+
+        data = self._request("GET", "producto/categoria/")
+        if data is None:
+            return []
+        if isinstance(data, list):
+            return data
+        raise ContificoAPIError(
+            status_code=200,
+            detail="El formato de respuesta para categorías de productos no es el esperado.",
             payload=data,
         )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -274,6 +274,28 @@ class ContificoProduct(BaseModel):
         )
 
 
+class ContificoProductCategory(BaseModel):
+    id: Optional[Union[int, str]] = None
+    codigo: Optional[str] = None
+    nombre: Optional[str] = None
+    descripcion: Optional[str] = None
+    raw: Dict[str, Any] = Field(default_factory=dict, description="Respuesta original de Contífico.")
+
+    @classmethod
+    def from_api(cls, payload: Dict[str, Any]) -> "ContificoProductCategory":
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "La categoría de producto devuelta por Contífico debe ser un diccionario"
+            )
+        return cls(
+            id=payload.get("id"),
+            codigo=payload.get("codigo") or payload.get("abreviatura"),
+            nombre=payload.get("nombre") or payload.get("descripcion"),
+            descripcion=payload.get("descripcion"),
+            raw=payload,
+        )
+
+
 class ContificoProductPage(BaseModel):
     items: List[ContificoProduct] = Field(default_factory=list)
     page: int

--- a/backend/app/temp_contifico.py
+++ b/backend/app/temp_contifico.py
@@ -24,9 +24,17 @@ def build_product_page(
     *,
     page: int,
     page_size: int,
+    category_id: str | None = None,
 ) -> schemas.ContificoProductPage:
     try:
-        products = contifico_client.list_products(page=page, page_size=page_size)
+        products = contifico_client.list_products(
+            page=page, page_size=page_size, category_id=category_id
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     except ContificoTransportError as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -37,6 +45,54 @@ def build_product_page(
 
     items = [schemas.ContificoProduct.from_api(product) for product in products]
     return schemas.ContificoProductPage(page=page, page_size=page_size, items=items)
+
+
+def fetch_product_detail(
+    contifico_client: ContificoClient,
+    *,
+    product_id: str,
+) -> schemas.ContificoProduct:
+    try:
+        product = contifico_client.get_product(product_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except ContificoTransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.detail,
+        ) from exc
+    except ContificoAPIError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    if not isinstance(product, dict):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="El formato de respuesta para el producto no es el esperado.",
+        )
+
+    return schemas.ContificoProduct.from_api(product)
+
+
+def build_product_category_list(
+    contifico_client: ContificoClient,
+) -> list[schemas.ContificoProductCategory]:
+    try:
+        categories = contifico_client.list_product_categories()
+    except ContificoTransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.detail,
+        ) from exc
+    except ContificoAPIError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    return [
+        schemas.ContificoProductCategory.from_api(category)
+        for category in categories
+    ]
 
 
 def build_warehouse_list(contifico_client: ContificoClient) -> list[schemas.ContificoWarehouse]:
@@ -176,13 +232,45 @@ def serialize_invoice_lookup_job(job) -> schemas.ContificoInvoiceLookupJob:
 def preview_contifico_products(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    category_id: str | None = Query(default=None),
     contifico_client: ContificoClient = Depends(get_contifico_client),
     current_user=Depends(admin_required()),
 ):
     """Vista temporal de productos obtenidos desde Contífico."""
 
     _ = current_user
-    return build_product_page(contifico_client, page=page, page_size=page_size)
+    return build_product_page(
+        contifico_client,
+        page=page,
+        page_size=page_size,
+        category_id=category_id,
+    )
+
+
+@router.get("/products/{product_id}", response_model=schemas.ContificoProduct)
+def preview_contifico_product_detail(
+    product_id: str,
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user=Depends(admin_required()),
+):
+    """Detalle temporal de un producto obtenido desde Contífico."""
+
+    _ = current_user
+    return fetch_product_detail(contifico_client, product_id=product_id)
+
+
+@router.get(
+    "/product-categories",
+    response_model=list[schemas.ContificoProductCategory],
+)
+def preview_contifico_product_categories(
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user=Depends(admin_required()),
+):
+    """Lista temporal de categorías de productos desde Contífico."""
+
+    _ = current_user
+    return build_product_category_list(contifico_client)
 
 
 @router.get("/warehouses", response_model=list[schemas.ContificoWarehouse])

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -24,9 +24,11 @@ from app.contifico import (
 from app.temp_contifico import (
     build_invoice_page,
     build_product_page,
+    build_product_category_list,
     build_warehouse_list,
     fetch_invoice_by_customer_and_document,
     fetch_invoice_by_document_number,
+    fetch_product_detail,
 )
 
 
@@ -82,6 +84,42 @@ def test_list_products_success() -> None:
     assert str(captured["url"]).startswith("https://api.example.com/v1/producto/")
 
 
+def test_list_products_with_category_filter() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json=[{"id": 1, "codigo": "SKU-2"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "pos-token-abc",
+        base_url="https://api.example.com/v1",
+        transport=transport,
+    )
+
+    products = list(client.list_products(category_id="CAT-1"))
+
+    assert products == [{"id": 1, "codigo": "SKU-2"}]
+    params = captured["params"]
+    assert isinstance(params, dict)
+    assert params["categoria"] == "CAT-1"
+
+
+def test_list_products_rejects_blank_category() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=[]))
+    client = ContificoClient(
+        "key123",
+        "pos-token-abc",
+        base_url="https://api.example.com/v1",
+        transport=transport,
+    )
+
+    with pytest.raises(ValueError):
+        list(client.list_products(category_id="   "))
+
+
 def test_list_products_error_response() -> None:
     def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(401, json={"mensaje": "No autorizado"})
@@ -99,6 +137,58 @@ def test_list_products_error_response() -> None:
 
     assert exc_info.value.status_code == 401
     assert "No autorizado" in exc_info.value.detail
+
+
+def test_get_product_success() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"id": 42, "codigo": "SKU-42"})
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    product = client.get_product(42)
+
+    assert product["id"] == 42
+    assert str(captured["url"]).endswith("/producto/42/")
+
+
+def test_get_product_rejects_blank_identifier() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={}))
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    with pytest.raises(ValueError):
+        client.get_product("   ")
+
+
+def test_list_product_categories_success() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/producto/categoria/")
+        return httpx.Response(200, json=[{"id": "CAT-1", "nombre": "Camisas"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    categories = list(client.list_product_categories())
+
+    assert categories == [{"id": "CAT-1", "nombre": "Camisas"}]
 
 
 def test_list_warehouses_success() -> None:
@@ -1083,9 +1173,10 @@ def test_find_invoice_by_document_number_handles_404_error() -> None:
 
 def test_build_product_page_success() -> None:
     class StubClient:
-        def list_products(self, *, page: int, page_size: int):
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
             assert page == 2
             assert page_size == 5
+            assert category_id is None
             return [
                 {"id": 1, "nombre": "Camisa"},
                 {"id": 2, "nombre": "Pantalón"},
@@ -1101,7 +1192,7 @@ def test_build_product_page_success() -> None:
 
 def test_build_product_page_raises_http_exception() -> None:
     class StubClient:
-        def list_products(self, *, page: int, page_size: int):
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
             raise ContificoTransportError("Network error")
 
     with pytest.raises(HTTPException) as exc_info:
@@ -1110,6 +1201,92 @@ def test_build_product_page_raises_http_exception() -> None:
     assert exc_info.value.status_code == 503
     assert "Network error" in exc_info.value.detail
 
+
+def test_build_product_page_with_category() -> None:
+    class StubClient:
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
+            assert category_id == "CAT-9"
+            return []
+
+    result = build_product_page(StubClient(), page=1, page_size=10, category_id="CAT-9")
+
+    assert result.items == []
+    assert result.page == 1
+    assert result.page_size == 10
+
+
+def test_build_product_page_with_invalid_category() -> None:
+    class StubClient:
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
+            raise ValueError("Categoría inválida")
+
+    with pytest.raises(HTTPException) as exc_info:
+        build_product_page(StubClient(), page=1, page_size=10, category_id=" ")
+
+    assert exc_info.value.status_code == 422
+    assert "Categoría inválida" in exc_info.value.detail
+
+
+def test_build_product_category_list_success() -> None:
+    class StubClient:
+        def list_product_categories(self):
+            return [
+                {"id": "CAT-1", "nombre": "Camisas"},
+                {"id": "CAT-2", "nombre": "Pantalones"},
+            ]
+
+    result = build_product_category_list(StubClient())
+
+    assert len(result) == 2
+    assert result[0].nombre == "Camisas"
+
+
+def test_build_product_category_list_handles_error() -> None:
+    class StubClient:
+        def list_product_categories(self):
+            raise ContificoAPIError(404, "No disponible")
+
+    with pytest.raises(HTTPException) as exc_info:
+        build_product_category_list(StubClient())
+
+    assert exc_info.value.status_code == 404
+    assert "No disponible" in exc_info.value.detail
+
+
+def test_fetch_product_detail_success() -> None:
+    class StubClient:
+        def get_product(self, product_id: str):
+            assert product_id == "SKU-1"
+            return {"id": "SKU-1", "nombre": "Camisa"}
+
+    result = fetch_product_detail(StubClient(), product_id="SKU-1")
+
+    assert result.id == "SKU-1"
+    assert result.nombre == "Camisa"
+
+
+def test_fetch_product_detail_handles_errors() -> None:
+    class StubClient:
+        def get_product(self, product_id: str):
+            raise ContificoAPIError(404, "No existe")
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_product_detail(StubClient(), product_id="SKU-1")
+
+    assert exc_info.value.status_code == 404
+    assert "No existe" in exc_info.value.detail
+
+
+def test_fetch_product_detail_handles_validation_error() -> None:
+    class StubClient:
+        def get_product(self, product_id: str):
+            raise ValueError("ID inválido")
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_product_detail(StubClient(), product_id=" ")
+
+    assert exc_info.value.status_code == 422
+    assert "ID inválido" in exc_info.value.detail
 
 def test_build_warehouse_list_success() -> None:
     class StubClient:


### PR DESCRIPTION
## Summary
- add product detail retrieval, category filtering and category listing helpers to the Contifico client
- expose preview endpoints for product categories and individual products using the new helpers
- extend the Contifico preview tests to cover category flows and validation

## Testing
- pytest -k "product" tests/test_contifico_client.py


------
https://chatgpt.com/codex/tasks/task_e_68e58589bfb08332b9f0544eb58544e4