### PR TITLE
Add Contífico preview modules for categories and product detail

### DIFF
--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -503,11 +503,20 @@ class ContificoClient:
         return False
 
     def list_products(
-        self, *, page: int = 1, page_size: int = 100
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+        category_id: str | int | None = None,
     ) -> Iterable[Dict[str, Any]]:
         """Devuelve un lote de productos desde Contífico."""
 
-        params = {"result_page": page, "result_size": page_size}
+        params: Dict[str, Any] = {"result_page": page, "result_size": page_size}
+        if category_id is not None:
+            category_value = str(category_id).strip()
+            if not category_value:
+                raise ValueError("El identificador de la categoría no puede estar vacío.")
+            params["categoria"] = category_value
         data = self._request("GET", "producto/", params=params)
         if data is None:
             return []
@@ -516,6 +525,45 @@ class ContificoClient:
         raise ContificoAPIError(
             status_code=200,
             detail="El formato de respuesta para productos no es el esperado.",
+            payload=data,
+        )
+
+    def get_product(self, product_id: str | int) -> Dict[str, Any]:
+        """Obtiene la información de un producto específico."""
+
+        if isinstance(product_id, str):
+            normalized_id = product_id.strip()
+        else:
+            normalized_id = str(product_id)
+        if not normalized_id:
+            raise ValueError("El identificador del producto es obligatorio.")
+
+        data = self._request("GET", f"producto/{normalized_id}/")
+        if isinstance(data, dict):
+            return data
+        if data is None:
+            raise ContificoAPIError(
+                status_code=200,
+                detail="El producto solicitado no fue encontrado.",
+                payload=data,
+            )
+        raise ContificoAPIError(
+            status_code=200,
+            detail="El formato de respuesta para un producto no es el esperado.",
+            payload=data,
+        )
+
+    def list_product_categories(self) -> Iterable[Dict[str, Any]]:
+        """Lista las categorías de productos configuradas en Contífico."""
+
+        data = self._request("GET", "producto/categoria/")
+        if data is None:
+            return []
+        if isinstance(data, list):
+            return data
+        raise ContificoAPIError(
+            status_code=200,
+            detail="El formato de respuesta para categorías de productos no es el esperado.",
             payload=data,
         )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -274,6 +274,28 @@ class ContificoProduct(BaseModel):
         )
 
 
+class ContificoProductCategory(BaseModel):
+    id: Optional[Union[int, str]] = None
+    codigo: Optional[str] = None
+    nombre: Optional[str] = None
+    descripcion: Optional[str] = None
+    raw: Dict[str, Any] = Field(default_factory=dict, description="Respuesta original de Contífico.")
+
+    @classmethod
+    def from_api(cls, payload: Dict[str, Any]) -> "ContificoProductCategory":
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "La categoría de producto devuelta por Contífico debe ser un diccionario"
+            )
+        return cls(
+            id=payload.get("id"),
+            codigo=payload.get("codigo") or payload.get("abreviatura"),
+            nombre=payload.get("nombre") or payload.get("descripcion"),
+            descripcion=payload.get("descripcion"),
+            raw=payload,
+        )
+
+
 class ContificoProductPage(BaseModel):
     items: List[ContificoProduct] = Field(default_factory=list)
     page: int

--- a/backend/app/temp_contifico.py
+++ b/backend/app/temp_contifico.py
@@ -24,9 +24,17 @@ def build_product_page(
     *,
     page: int,
     page_size: int,
+    category_id: str | None = None,
 ) -> schemas.ContificoProductPage:
     try:
-        products = contifico_client.list_products(page=page, page_size=page_size)
+        products = contifico_client.list_products(
+            page=page, page_size=page_size, category_id=category_id
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     except ContificoTransportError as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -37,6 +45,54 @@ def build_product_page(
 
     items = [schemas.ContificoProduct.from_api(product) for product in products]
     return schemas.ContificoProductPage(page=page, page_size=page_size, items=items)
+
+
+def fetch_product_detail(
+    contifico_client: ContificoClient,
+    *,
+    product_id: str,
+) -> schemas.ContificoProduct:
+    try:
+        product = contifico_client.get_product(product_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except ContificoTransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.detail,
+        ) from exc
+    except ContificoAPIError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    if not isinstance(product, dict):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="El formato de respuesta para el producto no es el esperado.",
+        )
+
+    return schemas.ContificoProduct.from_api(product)
+
+
+def build_product_category_list(
+    contifico_client: ContificoClient,
+) -> list[schemas.ContificoProductCategory]:
+    try:
+        categories = contifico_client.list_product_categories()
+    except ContificoTransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.detail,
+        ) from exc
+    except ContificoAPIError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    return [
+        schemas.ContificoProductCategory.from_api(category)
+        for category in categories
+    ]
 
 
 def build_warehouse_list(contifico_client: ContificoClient) -> list[schemas.ContificoWarehouse]:
@@ -176,13 +232,45 @@ def serialize_invoice_lookup_job(job) -> schemas.ContificoInvoiceLookupJob:
 def preview_contifico_products(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    category_id: str | None = Query(default=None),
     contifico_client: ContificoClient = Depends(get_contifico_client),
     current_user=Depends(admin_required()),
 ):
     """Vista temporal de productos obtenidos desde Contífico."""
 
     _ = current_user
-    return build_product_page(contifico_client, page=page, page_size=page_size)
+    return build_product_page(
+        contifico_client,
+        page=page,
+        page_size=page_size,
+        category_id=category_id,
+    )
+
+
+@router.get("/products/{product_id}", response_model=schemas.ContificoProduct)
+def preview_contifico_product_detail(
+    product_id: str,
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user=Depends(admin_required()),
+):
+    """Detalle temporal de un producto obtenido desde Contífico."""
+
+    _ = current_user
+    return fetch_product_detail(contifico_client, product_id=product_id)
+
+
+@router.get(
+    "/product-categories",
+    response_model=list[schemas.ContificoProductCategory],
+)
+def preview_contifico_product_categories(
+    contifico_client: ContificoClient = Depends(get_contifico_client),
+    current_user=Depends(admin_required()),
+):
+    """Lista temporal de categorías de productos desde Contífico."""
+
+    _ = current_user
+    return build_product_category_list(contifico_client)
 
 
 @router.get("/warehouses", response_model=list[schemas.ContificoWarehouse])

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -24,9 +24,11 @@ from app.contifico import (
 from app.temp_contifico import (
     build_invoice_page,
     build_product_page,
+    build_product_category_list,
     build_warehouse_list,
     fetch_invoice_by_customer_and_document,
     fetch_invoice_by_document_number,
+    fetch_product_detail,
 )
 
 
@@ -82,6 +84,42 @@ def test_list_products_success() -> None:
     assert str(captured["url"]).startswith("https://api.example.com/v1/producto/")
 
 
+def test_list_products_with_category_filter() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json=[{"id": 1, "codigo": "SKU-2"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "pos-token-abc",
+        base_url="https://api.example.com/v1",
+        transport=transport,
+    )
+
+    products = list(client.list_products(category_id="CAT-1"))
+
+    assert products == [{"id": 1, "codigo": "SKU-2"}]
+    params = captured["params"]
+    assert isinstance(params, dict)
+    assert params["categoria"] == "CAT-1"
+
+
+def test_list_products_rejects_blank_category() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=[]))
+    client = ContificoClient(
+        "key123",
+        "pos-token-abc",
+        base_url="https://api.example.com/v1",
+        transport=transport,
+    )
+
+    with pytest.raises(ValueError):
+        list(client.list_products(category_id="   "))
+
+
 def test_list_products_error_response() -> None:
     def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(401, json={"mensaje": "No autorizado"})
@@ -99,6 +137,58 @@ def test_list_products_error_response() -> None:
 
     assert exc_info.value.status_code == 401
     assert "No autorizado" in exc_info.value.detail
+
+
+def test_get_product_success() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"id": 42, "codigo": "SKU-42"})
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    product = client.get_product(42)
+
+    assert product["id"] == 42
+    assert str(captured["url"]).endswith("/producto/42/")
+
+
+def test_get_product_rejects_blank_identifier() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={}))
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    with pytest.raises(ValueError):
+        client.get_product("   ")
+
+
+def test_list_product_categories_success() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/producto/categoria/")
+        return httpx.Response(200, json=[{"id": "CAT-1", "nombre": "Camisas"}])
+
+    transport = httpx.MockTransport(handler)
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com",
+        transport=transport,
+    )
+
+    categories = list(client.list_product_categories())
+
+    assert categories == [{"id": "CAT-1", "nombre": "Camisas"}]
 
 
 def test_list_warehouses_success() -> None:
@@ -1083,9 +1173,10 @@ def test_find_invoice_by_document_number_handles_404_error() -> None:
 
 def test_build_product_page_success() -> None:
     class StubClient:
-        def list_products(self, *, page: int, page_size: int):
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
             assert page == 2
             assert page_size == 5
+            assert category_id is None
             return [
                 {"id": 1, "nombre": "Camisa"},
                 {"id": 2, "nombre": "Pantalón"},
@@ -1101,7 +1192,7 @@ def test_build_product_page_success() -> None:
 
 def test_build_product_page_raises_http_exception() -> None:
     class StubClient:
-        def list_products(self, *, page: int, page_size: int):
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
             raise ContificoTransportError("Network error")
 
     with pytest.raises(HTTPException) as exc_info:
@@ -1110,6 +1201,92 @@ def test_build_product_page_raises_http_exception() -> None:
     assert exc_info.value.status_code == 503
     assert "Network error" in exc_info.value.detail
 
+
+def test_build_product_page_with_category() -> None:
+    class StubClient:
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
+            assert category_id == "CAT-9"
+            return []
+
+    result = build_product_page(StubClient(), page=1, page_size=10, category_id="CAT-9")
+
+    assert result.items == []
+    assert result.page == 1
+    assert result.page_size == 10
+
+
+def test_build_product_page_with_invalid_category() -> None:
+    class StubClient:
+        def list_products(self, *, page: int, page_size: int, category_id: str | None = None):
+            raise ValueError("Categoría inválida")
+
+    with pytest.raises(HTTPException) as exc_info:
+        build_product_page(StubClient(), page=1, page_size=10, category_id=" ")
+
+    assert exc_info.value.status_code == 422
+    assert "Categoría inválida" in exc_info.value.detail
+
+
+def test_build_product_category_list_success() -> None:
+    class StubClient:
+        def list_product_categories(self):
+            return [
+                {"id": "CAT-1", "nombre": "Camisas"},
+                {"id": "CAT-2", "nombre": "Pantalones"},
+            ]
+
+    result = build_product_category_list(StubClient())
+
+    assert len(result) == 2
+    assert result[0].nombre == "Camisas"
+
+
+def test_build_product_category_list_handles_error() -> None:
+    class StubClient:
+        def list_product_categories(self):
+            raise ContificoAPIError(404, "No disponible")
+
+    with pytest.raises(HTTPException) as exc_info:
+        build_product_category_list(StubClient())
+
+    assert exc_info.value.status_code == 404
+    assert "No disponible" in exc_info.value.detail
+
+
+def test_fetch_product_detail_success() -> None:
+    class StubClient:
+        def get_product(self, product_id: str):
+            assert product_id == "SKU-1"
+            return {"id": "SKU-1", "nombre": "Camisa"}
+
+    result = fetch_product_detail(StubClient(), product_id="SKU-1")
+
+    assert result.id == "SKU-1"
+    assert result.nombre == "Camisa"
+
+
+def test_fetch_product_detail_handles_errors() -> None:
+    class StubClient:
+        def get_product(self, product_id: str):
+            raise ContificoAPIError(404, "No existe")
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_product_detail(StubClient(), product_id="SKU-1")
+
+    assert exc_info.value.status_code == 404
+    assert "No existe" in exc_info.value.detail
+
+
+def test_fetch_product_detail_handles_validation_error() -> None:
+    class StubClient:
+        def get_product(self, product_id: str):
+            raise ValueError("ID inválido")
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_product_detail(StubClient(), product_id=" ")
+
+    assert exc_info.value.status_code == 422
+    assert "ID inválido" in exc_info.value.detail
 
 def test_build_warehouse_list_success() -> None:
     class StubClient:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -83,6 +83,16 @@ const state = {
   contificoPreviewProductsLoading: false,
   contificoPreviewProductsError: null,
   contificoPreviewProductsFetched: false,
+  contificoPreviewProductsCategoryId: '',
+  contificoPreviewProductCategories: [],
+  contificoPreviewProductCategoriesLoading: false,
+  contificoPreviewProductCategoriesError: null,
+  contificoPreviewProductCategoriesFetched: false,
+  contificoPreviewProductDetailId: '',
+  contificoPreviewProductDetail: null,
+  contificoPreviewProductDetailLoading: false,
+  contificoPreviewProductDetailError: null,
+  contificoPreviewProductDetailFetched: false,
   contificoPreviewWarehouses: [],
   contificoPreviewWarehousesLoading: false,
   contificoPreviewWarehousesError: null,
@@ -410,6 +420,15 @@ const contificoPreviewPageInput = document.getElementById('contificoPreviewPage'
 const contificoPreviewPageSizeInput = document.getElementById('contificoPreviewPageSize');
 const contificoPreviewProductsStatus = document.getElementById('contificoPreviewProductsStatus');
 const contificoPreviewProductsTableBody = document.getElementById('contificoPreviewProductsTableBody');
+const contificoPreviewCategoryInput = document.getElementById('contificoPreviewCategoryId');
+const contificoPreviewClearCategoryButton = document.getElementById('contificoPreviewClearCategoryButton');
+const contificoPreviewCategoriesButton = document.getElementById('contificoPreviewCategoriesButton');
+const contificoPreviewCategoriesStatus = document.getElementById('contificoPreviewCategoriesStatus');
+const contificoPreviewCategoriesTableBody = document.getElementById('contificoPreviewCategoriesTableBody');
+const contificoPreviewProductDetailForm = document.getElementById('contificoPreviewProductDetailForm');
+const contificoPreviewProductIdInput = document.getElementById('contificoPreviewProductId');
+const contificoPreviewProductDetailStatus = document.getElementById('contificoPreviewProductDetailStatus');
+const contificoPreviewProductDetailResult = document.getElementById('contificoPreviewProductDetailResult');
 const contificoPreviewWarehousesButton = document.getElementById('contificoPreviewWarehousesButton');
 const contificoPreviewWarehousesStatus = document.getElementById('contificoPreviewWarehousesStatus');
 const contificoPreviewWarehousesTableBody = document.getElementById('contificoPreviewWarehousesTableBody');
@@ -3628,6 +3647,24 @@ if (contificoPreviewProductsForm) {
   contificoPreviewProductsForm.addEventListener('submit', handleContificoPreviewProductsFetch);
 }
 
+if (contificoPreviewClearCategoryButton) {
+  contificoPreviewClearCategoryButton.addEventListener('click', handleContificoPreviewClearCategory);
+}
+
+if (contificoPreviewCategoriesButton) {
+  contificoPreviewCategoriesButton.addEventListener(
+    'click',
+    handleContificoPreviewProductCategoriesFetch
+  );
+}
+
+if (contificoPreviewProductDetailForm) {
+  contificoPreviewProductDetailForm.addEventListener(
+    'submit',
+    handleContificoPreviewProductDetailFetch
+  );
+}
+
 if (contificoPreviewWarehousesButton) {
   contificoPreviewWarehousesButton.addEventListener('click', handleContificoPreviewWarehousesFetch);
 }
@@ -6239,6 +6276,16 @@ function resetContificoPreviewState() {
   state.contificoPreviewProductsLoading = false;
   state.contificoPreviewProductsError = null;
   state.contificoPreviewProductsFetched = false;
+  state.contificoPreviewProductsCategoryId = '';
+  state.contificoPreviewProductCategories = [];
+  state.contificoPreviewProductCategoriesLoading = false;
+  state.contificoPreviewProductCategoriesError = null;
+  state.contificoPreviewProductCategoriesFetched = false;
+  state.contificoPreviewProductDetailId = '';
+  state.contificoPreviewProductDetail = null;
+  state.contificoPreviewProductDetailLoading = false;
+  state.contificoPreviewProductDetailError = null;
+  state.contificoPreviewProductDetailFetched = false;
   state.contificoPreviewWarehouses = [];
   state.contificoPreviewWarehousesLoading = false;
   state.contificoPreviewWarehousesError = null;
@@ -6284,6 +6331,12 @@ function renderContificoPreviewProducts() {
         element.disabled = true;
       });
     }
+    if (contificoPreviewCategoryInput) {
+      contificoPreviewCategoryInput.value = '';
+    }
+    if (contificoPreviewClearCategoryButton) {
+      contificoPreviewClearCategoryButton.disabled = true;
+    }
     if (contificoPreviewProductsTableBody) {
       contificoPreviewProductsTableBody.innerHTML = '';
     }
@@ -6308,6 +6361,14 @@ function renderContificoPreviewProducts() {
     contificoPreviewPageSizeInput.value = String(
       state.contificoPreviewProductsPageSize || CONTIFICO_DEFAULT_PAGE_SIZE
     );
+  }
+  if (contificoPreviewCategoryInput) {
+    contificoPreviewCategoryInput.value = state.contificoPreviewProductsCategoryId || '';
+    contificoPreviewCategoryInput.disabled = state.contificoPreviewProductsLoading;
+  }
+  if (contificoPreviewClearCategoryButton) {
+    contificoPreviewClearCategoryButton.disabled =
+      state.contificoPreviewProductsLoading || !state.contificoPreviewProductsCategoryId;
   }
 
   if (contificoPreviewProductsTableBody) {
@@ -6379,15 +6440,276 @@ function renderContificoPreviewProducts() {
     tone = 'error';
   } else if (state.contificoPreviewProductsFetched) {
     if (state.contificoPreviewProducts.length) {
-      statusMessage = `Se muestran ${state.contificoPreviewProducts.length} productos (página ${state.contificoPreviewProductsPage}).`;
+      const categorySuffix = state.contificoPreviewProductsCategoryId
+        ? `, categoría ${state.contificoPreviewProductsCategoryId}`
+        : '';
+      statusMessage = `Se muestran ${state.contificoPreviewProducts.length} productos (página ${state.contificoPreviewProductsPage}${categorySuffix}).`;
       tone = 'success';
     } else {
       statusMessage = 'No se recibieron productos para la página consultada.';
     }
   } else {
-    statusMessage = 'Define la página y presiona “Consultar productos” para obtener datos desde Contífico.';
+    statusMessage =
+      'Define la página, el tamaño o una categoría y presiona “Consultar productos” para obtener datos desde Contífico.';
   }
   updateContificoStatus(contificoPreviewProductsStatus, { text: statusMessage, tone });
+}
+
+function renderContificoPreviewProductCategories() {
+  const isAdmin = state.token && state.user?.role === 'administrador';
+  if (!isAdmin) {
+    if (contificoPreviewCategoriesButton) {
+      contificoPreviewCategoriesButton.disabled = true;
+      contificoPreviewCategoriesButton.removeAttribute('aria-busy');
+      contificoPreviewCategoriesButton.textContent = 'Cargar categorías';
+    }
+    if (contificoPreviewCategoriesTableBody) {
+      contificoPreviewCategoriesTableBody.innerHTML = '';
+    }
+    updateContificoStatus(contificoPreviewCategoriesStatus, {
+      text: 'Inicia sesión como administrador para consultar categorías en Contífico.',
+      tone: 'info',
+    });
+    return;
+  }
+
+  if (contificoPreviewCategoriesButton) {
+    contificoPreviewCategoriesButton.disabled =
+      state.contificoPreviewProductCategoriesLoading;
+    if (state.contificoPreviewProductCategoriesLoading) {
+      contificoPreviewCategoriesButton.setAttribute('aria-busy', 'true');
+      contificoPreviewCategoriesButton.textContent = 'Consultando…';
+    } else {
+      contificoPreviewCategoriesButton.removeAttribute('aria-busy');
+      contificoPreviewCategoriesButton.textContent = 'Cargar categorías';
+    }
+  }
+
+  if (contificoPreviewCategoriesTableBody) {
+    contificoPreviewCategoriesTableBody.innerHTML = '';
+    const categories = Array.isArray(state.contificoPreviewProductCategories)
+      ? state.contificoPreviewProductCategories
+      : [];
+
+    if (categories.length) {
+      categories.forEach((category) => {
+        const row = document.createElement('tr');
+
+        const idCell = document.createElement('td');
+        const categoryId = category?.id;
+        idCell.textContent =
+          categoryId === null || categoryId === undefined || categoryId === ''
+            ? '—'
+            : String(categoryId);
+        idCell.dataset.label = 'ID';
+
+        const codeCell = document.createElement('td');
+        const categoryCode = category?.codigo;
+        codeCell.textContent =
+          categoryCode === null || categoryCode === undefined || categoryCode === ''
+            ? '—'
+            : String(categoryCode);
+        codeCell.dataset.label = 'Código';
+
+        const nameCell = document.createElement('td');
+        const categoryName = category?.nombre || category?.descripcion;
+        nameCell.textContent =
+          categoryName === null || categoryName === undefined || categoryName === ''
+            ? '—'
+            : String(categoryName);
+        nameCell.dataset.label = 'Nombre';
+
+        const descriptionCell = document.createElement('td');
+        const categoryDescription = category?.descripcion;
+        descriptionCell.textContent =
+          categoryDescription === null || categoryDescription === undefined || categoryDescription === ''
+            ? '—'
+            : String(categoryDescription);
+        descriptionCell.dataset.label = 'Descripción';
+
+        const actionCell = document.createElement('td');
+        actionCell.dataset.label = 'Acciones';
+        const useButton = document.createElement('button');
+        useButton.type = 'button';
+        useButton.className = 'secondary';
+        const normalizedId =
+          categoryId === null || categoryId === undefined ? '' : String(categoryId).trim();
+        const normalizedCode =
+          categoryCode === null || categoryCode === undefined ? '' : String(categoryCode).trim();
+        const filterValue = normalizedId || normalizedCode;
+        if (!filterValue) {
+          useButton.disabled = true;
+          useButton.textContent = 'Sin ID disponible';
+        } else {
+          useButton.textContent = 'Usar en productos';
+          useButton.addEventListener('click', () => {
+            state.contificoPreviewProductsCategoryId = filterValue;
+            state.contificoPreviewProductsPage = 1;
+            if (contificoPreviewCategoryInput) {
+              contificoPreviewCategoryInput.value = filterValue;
+              contificoPreviewCategoryInput.focus();
+            }
+            if (contificoPreviewPageInput) {
+              contificoPreviewPageInput.value = '1';
+            }
+            renderContificoPreviewProducts();
+            showToast('Filtro de productos actualizado con la categoría seleccionada.', 'success');
+            if (!state.contificoPreviewProductsLoading) {
+              handleContificoPreviewProductsFetch();
+            }
+          });
+        }
+        actionCell.appendChild(useButton);
+
+        row.appendChild(idCell);
+        row.appendChild(codeCell);
+        row.appendChild(nameCell);
+        row.appendChild(descriptionCell);
+        row.appendChild(actionCell);
+        contificoPreviewCategoriesTableBody.appendChild(row);
+      });
+    } else if (
+      state.contificoPreviewProductCategoriesFetched &&
+      !state.contificoPreviewProductCategoriesLoading &&
+      !state.contificoPreviewProductCategoriesError
+    ) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 5;
+      cell.className = 'muted';
+      cell.textContent = 'No se encontraron categorías configuradas en Contífico.';
+      row.appendChild(cell);
+      contificoPreviewCategoriesTableBody.appendChild(row);
+    }
+  }
+
+  let statusMessage = '';
+  let tone = 'info';
+  if (state.contificoPreviewProductCategoriesLoading) {
+    statusMessage = 'Consultando categorías en Contífico...';
+    tone = 'loading';
+  } else if (state.contificoPreviewProductCategoriesError) {
+    statusMessage = state.contificoPreviewProductCategoriesError;
+    tone = 'error';
+  } else if (state.contificoPreviewProductCategoriesFetched) {
+    if (state.contificoPreviewProductCategories.length) {
+      statusMessage = `Se muestran ${state.contificoPreviewProductCategories.length} categorías.`;
+      tone = 'success';
+    } else {
+      statusMessage = 'No se encontraron categorías configuradas en Contífico.';
+    }
+  } else {
+    statusMessage = 'Haz clic en “Cargar categorías” para consultar la API de Contífico.';
+  }
+  updateContificoStatus(contificoPreviewCategoriesStatus, { text: statusMessage, tone });
+}
+
+function renderContificoPreviewProductDetail() {
+  const isAdmin = state.token && state.user?.role === 'administrador';
+  if (!isAdmin) {
+    if (contificoPreviewProductDetailForm) {
+      const elements = contificoPreviewProductDetailForm.querySelectorAll('input, button');
+      elements.forEach((element) => {
+        element.disabled = true;
+      });
+    }
+    if (contificoPreviewProductIdInput) {
+      contificoPreviewProductIdInput.value = '';
+    }
+    if (contificoPreviewProductDetailResult) {
+      contificoPreviewProductDetailResult.innerHTML = '';
+    }
+    updateContificoStatus(contificoPreviewProductDetailStatus, {
+      text: 'Inicia sesión como administrador para consultar productos específicos en Contífico.',
+      tone: 'info',
+    });
+    return;
+  }
+
+  if (contificoPreviewProductDetailForm) {
+    const elements = contificoPreviewProductDetailForm.querySelectorAll('input, button');
+    elements.forEach((element) => {
+      element.disabled = state.contificoPreviewProductDetailLoading;
+    });
+  }
+
+  if (contificoPreviewProductIdInput) {
+    contificoPreviewProductIdInput.value = state.contificoPreviewProductDetailId || '';
+  }
+
+  if (contificoPreviewProductDetailResult) {
+    contificoPreviewProductDetailResult.innerHTML = '';
+    const detail = state.contificoPreviewProductDetail;
+    if (detail) {
+      const list = document.createElement('dl');
+      list.className = 'contifico-preview-detail-list';
+      const entries = [
+        ['ID', detail.id],
+        ['Código', detail.codigo],
+        ['Nombre', detail.nombre || detail.descripcion],
+        ['Descripción', detail.descripcion],
+        ['Precio base', formatCurrencyUSD(detail.pvp1)],
+        ['Precio alterno 2', formatCurrencyUSD(detail.pvp2)],
+        ['Precio alterno 3', formatCurrencyUSD(detail.pvp3)],
+      ];
+      entries.forEach(([label, value]) => {
+        const dt = document.createElement('dt');
+        dt.textContent = label;
+        const dd = document.createElement('dd');
+        if (value === null || value === undefined || value === '') {
+          dd.textContent = '—';
+        } else {
+          dd.textContent = String(value);
+        }
+        list.appendChild(dt);
+        list.appendChild(dd);
+      });
+      contificoPreviewProductDetailResult.appendChild(list);
+
+      const rawPayload = detail.raw ?? detail;
+      if (rawPayload && typeof rawPayload === 'object') {
+        const detailsElement = document.createElement('details');
+        detailsElement.classList.add('contifico-invoice-raw');
+        const summary = document.createElement('summary');
+        summary.textContent = 'Ver respuesta completa';
+        detailsElement.appendChild(summary);
+        const pre = document.createElement('pre');
+        pre.textContent = JSON.stringify(rawPayload, null, 2);
+        detailsElement.appendChild(pre);
+        contificoPreviewProductDetailResult.appendChild(detailsElement);
+      }
+    } else if (
+      state.contificoPreviewProductDetailFetched &&
+      !state.contificoPreviewProductDetailLoading &&
+      !state.contificoPreviewProductDetailError
+    ) {
+      const emptyMessage = document.createElement('p');
+      emptyMessage.className = 'muted';
+      emptyMessage.textContent = 'No se encontró un producto con el identificador consultado.';
+      contificoPreviewProductDetailResult.appendChild(emptyMessage);
+    }
+  }
+
+  let statusMessage = '';
+  let tone = 'info';
+  if (state.contificoPreviewProductDetailLoading) {
+    statusMessage = 'Consultando producto en Contífico...';
+    tone = 'loading';
+  } else if (state.contificoPreviewProductDetailError) {
+    statusMessage = state.contificoPreviewProductDetailError;
+    tone = 'error';
+  } else if (state.contificoPreviewProductDetailFetched) {
+    if (state.contificoPreviewProductDetail) {
+      statusMessage = 'Producto obtenido correctamente desde Contífico.';
+      tone = 'success';
+    } else {
+      statusMessage = 'No se encontró un producto con el identificador consultado.';
+    }
+  } else {
+    statusMessage =
+      'Ingresa un ID o código y presiona “Consultar producto” para obtener información desde Contífico.';
+  }
+  updateContificoStatus(contificoPreviewProductDetailStatus, { text: statusMessage, tone });
 }
 
 function renderContificoPreviewWarehouses() {
@@ -7050,6 +7372,8 @@ function renderContificoPreviewInvoiceLookup() {
 }
 function renderContificoPreview() {
   renderContificoPreviewProducts();
+  renderContificoPreviewProductCategories();
+  renderContificoPreviewProductDetail();
   renderContificoPreviewWarehouses();
   renderContificoPreviewCustomerInvoices();
   renderContificoPreviewCustomerInvoiceLookup();
@@ -7074,21 +7398,31 @@ async function handleContificoPreviewProductsFetch(event) {
       state.contificoPreviewProductsPageSize ??
       CONTIFICO_DEFAULT_PAGE_SIZE
   );
+  const rawCategoryId =
+    contificoPreviewCategoryInput?.value ?? state.contificoPreviewProductsCategoryId ?? '';
   const normalizedPage = Number.isFinite(rawPage) && rawPage > 0 ? Math.floor(rawPage) : 1;
   const normalizedPageSize = Number.isFinite(rawPageSize) && rawPageSize > 0
     ? Math.min(Math.floor(rawPageSize), CONTIFICO_MAX_PAGE_SIZE)
     : CONTIFICO_DEFAULT_PAGE_SIZE;
+  const normalizedCategoryId = String(rawCategoryId ?? '').trim();
 
   state.contificoPreviewProductsPage = normalizedPage;
   state.contificoPreviewProductsPageSize = normalizedPageSize;
+  state.contificoPreviewProductsCategoryId = normalizedCategoryId;
   state.contificoPreviewProductsLoading = true;
   state.contificoPreviewProductsError = null;
+  state.contificoPreviewProductsFetched = false;
   renderContificoPreviewProducts();
 
   try {
-    const response = await apiFetch(
-      `/temp/contifico/products?page=${normalizedPage}&page_size=${normalizedPageSize}`
-    );
+    const params = new URLSearchParams({
+      page: String(normalizedPage),
+      page_size: String(normalizedPageSize),
+    });
+    if (normalizedCategoryId) {
+      params.append('category_id', normalizedCategoryId);
+    }
+    const response = await apiFetch(`/temp/contifico/products?${params.toString()}`);
     const items = Array.isArray(response?.items) ? response.items : [];
     state.contificoPreviewProducts = items;
     state.contificoPreviewProductsPage = Number.isFinite(response?.page)
@@ -7108,6 +7442,107 @@ async function handleContificoPreviewProductsFetch(event) {
   } finally {
     state.contificoPreviewProductsLoading = false;
     renderContificoPreviewProducts();
+  }
+}
+
+function handleContificoPreviewClearCategory() {
+  if (!state.token || !state.user || state.user.role !== 'administrador') {
+    showToast('Solo los administradores pueden modificar el filtro de Contífico.', 'error');
+    return;
+  }
+  if (state.contificoPreviewProductsLoading) {
+    return;
+  }
+  state.contificoPreviewProductsCategoryId = '';
+  if (contificoPreviewCategoryInput) {
+    contificoPreviewCategoryInput.value = '';
+    contificoPreviewCategoryInput.focus();
+  }
+  renderContificoPreviewProducts();
+}
+
+async function handleContificoPreviewProductCategoriesFetch() {
+  if (!state.token || !state.user || state.user.role !== 'administrador') {
+    showToast('Solo los administradores pueden consultar Contífico.', 'error');
+    return;
+  }
+  if (state.contificoPreviewProductCategoriesLoading) {
+    return;
+  }
+
+  state.contificoPreviewProductCategoriesLoading = true;
+  state.contificoPreviewProductCategoriesError = null;
+  state.contificoPreviewProductCategoriesFetched = false;
+  renderContificoPreviewProductCategories();
+
+  try {
+    const response = await apiFetch('/temp/contifico/product-categories');
+    const items = Array.isArray(response) ? response : [];
+    state.contificoPreviewProductCategories = items;
+    state.contificoPreviewProductCategoriesFetched = true;
+    renderContificoPreviewProductCategories();
+  } catch (error) {
+    state.contificoPreviewProductCategoriesError =
+      error.message || 'No se pudieron consultar las categorías.';
+    state.contificoPreviewProductCategories = [];
+    state.contificoPreviewProductCategoriesFetched = true;
+    renderContificoPreviewProductCategories();
+    showToast(state.contificoPreviewProductCategoriesError, 'error');
+  } finally {
+    state.contificoPreviewProductCategoriesLoading = false;
+    renderContificoPreviewProductCategories();
+  }
+}
+
+async function handleContificoPreviewProductDetailFetch(event) {
+  if (event) {
+    event.preventDefault();
+  }
+  if (!state.token || !state.user || state.user.role !== 'administrador') {
+    showToast('Solo los administradores pueden consultar Contífico.', 'error');
+    return;
+  }
+  if (state.contificoPreviewProductDetailLoading) {
+    return;
+  }
+
+  const rawProductId =
+    contificoPreviewProductIdInput?.value ?? state.contificoPreviewProductDetailId ?? '';
+  const normalizedProductId = String(rawProductId ?? '').trim();
+
+  if (!normalizedProductId) {
+    state.contificoPreviewProductDetailError = 'Ingresa un identificador de producto válido.';
+    state.contificoPreviewProductDetail = null;
+    state.contificoPreviewProductDetailFetched = true;
+    renderContificoPreviewProductDetail();
+    showToast(state.contificoPreviewProductDetailError, 'error');
+    return;
+  }
+
+  state.contificoPreviewProductDetailId = normalizedProductId;
+  state.contificoPreviewProductDetailLoading = true;
+  state.contificoPreviewProductDetailError = null;
+  state.contificoPreviewProductDetailFetched = false;
+  state.contificoPreviewProductDetail = null;
+  renderContificoPreviewProductDetail();
+
+  try {
+    const product = await apiFetch(
+      `/temp/contifico/products/${encodeURIComponent(normalizedProductId)}`
+    );
+    state.contificoPreviewProductDetail = product || null;
+    state.contificoPreviewProductDetailFetched = true;
+    renderContificoPreviewProductDetail();
+  } catch (error) {
+    state.contificoPreviewProductDetailError =
+      error.message || 'No se pudo consultar el producto.';
+    state.contificoPreviewProductDetail = null;
+    state.contificoPreviewProductDetailFetched = true;
+    renderContificoPreviewProductDetail();
+    showToast(state.contificoPreviewProductDetailError, 'error');
+  } finally {
+    state.contificoPreviewProductDetailLoading = false;
+    renderContificoPreviewProductDetail();
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -933,6 +933,25 @@
                     <label for="contificoPreviewPageSize">Filas por página</label>
                     <input type="number" id="contificoPreviewPageSize" min="1" max="200" step="1" value="25" />
                   </div>
+                  <div class="form-row">
+                    <label for="contificoPreviewCategoryId">Categoría (opcional)</label>
+                    <div class="field-with-action">
+                      <input
+                        type="text"
+                        id="contificoPreviewCategoryId"
+                        name="category_id"
+                        placeholder="ID o código de la categoría"
+                        autocomplete="off"
+                      />
+                      <button type="button" class="secondary" id="contificoPreviewClearCategoryButton">
+                        Quitar filtro
+                      </button>
+                    </div>
+                    <p class="muted small">
+                      Usa el módulo de categorías para rellenar este campo automáticamente y consultar los
+                      productos de dicha categoría.
+                    </p>
+                  </div>
                   <div class="form-row contifico-preview-submit">
                     <button type="submit" class="primary">Consultar productos</button>
                   </div>
@@ -956,6 +975,78 @@
                     <tbody id="contificoPreviewProductsTableBody"></tbody>
                   </table>
                 </div>
+              </article>
+
+              <article class="contifico-preview-card">
+                <header class="contifico-preview-card-header">
+                  <div>
+                    <h4>Categorías de productos</h4>
+                    <p class="muted small">
+                      Descarga el catálogo de categorías configuradas en Contífico para facilitar las pruebas del
+                      listado de productos.
+                    </p>
+                  </div>
+                </header>
+                <div class="contifico-preview-actions">
+                  <button type="button" class="primary" id="contificoPreviewCategoriesButton">
+                    Cargar categorías
+                  </button>
+                </div>
+                <p
+                  id="contificoPreviewCategoriesStatus"
+                  class="contifico-preview-status muted small"
+                  role="status"
+                  aria-live="polite"
+                ></p>
+                <div class="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>ID</th>
+                        <th>Código</th>
+                        <th>Nombre</th>
+                        <th>Descripción</th>
+                        <th>Acciones</th>
+                      </tr>
+                    </thead>
+                    <tbody id="contificoPreviewCategoriesTableBody"></tbody>
+                  </table>
+                </div>
+              </article>
+
+              <article class="contifico-preview-card">
+                <header class="contifico-preview-card-header">
+                  <div>
+                    <h4>Producto específico</h4>
+                    <p class="muted small">
+                      Consulta los detalles de un producto puntual utilizando su identificador o código registrado en
+                      Contífico.
+                    </p>
+                  </div>
+                </header>
+                <form id="contificoPreviewProductDetailForm" class="form-grid contifico-preview-form">
+                  <div class="form-row">
+                    <label for="contificoPreviewProductId">ID o código del producto</label>
+                    <input
+                      type="text"
+                      id="contificoPreviewProductId"
+                      name="product_id"
+                      placeholder="Ej. 123 o SKU-001"
+                      autocomplete="off"
+                      required
+                    />
+                  </div>
+                  <div class="form-row contifico-preview-submit">
+                    <button type="submit" class="primary">Consultar producto</button>
+                  </div>
+                </form>
+                <p
+                  id="contificoPreviewProductDetailStatus"
+                  class="contifico-preview-status muted small"
+                  role="status"
+                  aria-live="polite"
+                ></p>
+                <div id="contificoPreviewProductDetailResult" class="contifico-preview-detail"></div>
               </article>
 
               <article class="contifico-preview-card">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2388,6 +2388,29 @@ th {
   color: var(--primary);
 }
 
+.contifico-preview-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.contifico-preview-detail-list {
+  display: grid;
+  grid-template-columns: minmax(0, 160px) minmax(0, 1fr);
+  gap: 0.35rem 1rem;
+  margin: 0;
+}
+
+.contifico-preview-detail-list dt {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.contifico-preview-detail-list dd {
+  margin: 0;
+  word-break: break-word;
+}
+
 .contifico-progress {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a category filter to the Contífico preview product list and persist the selection in state
- expose UI modules to fetch product categories and single product details from the preview API
- style the new preview panels, including definition list rendering and reusable raw payload toggles

## Testing
- pytest -k "product" tests/test_contifico_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e58589bfb08332b9f0544eb58544e4