### PR TITLE
feat: add manual job catalog sync

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -144,13 +144,19 @@ def list_statuses() -> List[str]:
 def list_contifico_products(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    category_id: Optional[str] = Query(default=None, description="Identificador de la categoría de productos a filtrar."),
     contifico_client: ContificoClient = Depends(get_contifico_client),
-    current_user: models.User = Depends(admin_required()),
+    current_user: models.User = Depends(vendor_or_admin_required()),
 ):
     """Devuelve un listado de productos desde Contífico."""
 
     _ = current_user
-    return build_product_page(contifico_client, page=page, page_size=page_size)
+    return build_product_page(
+        contifico_client,
+        page=page,
+        page_size=page_size,
+        category_id=category_id,
+    )
 
 
 @app.get(

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -18,6 +18,7 @@ const ORDER_CUSTOMER_DESCRIPTION_DEFAULT =
   'Consulta o actualiza los datos registrados para el cliente de esta orden.';
 const ORDER_CUSTOMER_DESCRIPTION_EMPTY =
   'No se registraron datos adicionales del cliente para esta orden.';
+const CONTIFICO_SEWING_TASK_CATEGORY_ID = 'xGge0zg6H2Q4bADR';
 
 
 const state = {
@@ -60,6 +61,11 @@ const state = {
   orderTasksOrderId: null,
   orderTasksLoading: false,
   orderTasksRequestId: 0,
+  orderTaskSuggestions: [],
+  orderTaskSuggestionsLoading: false,
+  orderTaskSuggestionsLoaded: false,
+  orderTaskSuggestionsUpdatedAt: null,
+  orderTaskSuggestionsError: null,
   customerRequestId: 0,
   orderRequestId: 0,
   customerOptionsRequestId: 0,
@@ -278,8 +284,14 @@ const DASHBOARD_TAB_IDS = [
   'usersPanel',
   'auditLogPanel',
   'contificoPreviewPanel',
+  'jobCatalogPanel',
 ];
-const ADMIN_ONLY_TABS = new Set(['usersPanel', 'auditLogPanel', 'contificoPreviewPanel']);
+const ADMIN_ONLY_TABS = new Set([
+  'usersPanel',
+  'auditLogPanel',
+  'contificoPreviewPanel',
+  'jobCatalogPanel',
+]);
 const dashboardTabButtons = Array.from(document.querySelectorAll('[data-tab]')).filter((btn) =>
   DASHBOARD_TAB_IDS.includes(btn.dataset.tab)
 );
@@ -365,6 +377,11 @@ const measurementsList = document.getElementById('measurementsList');
 const addMeasurementButton = document.getElementById('addMeasurementButton');
 const newOrderTasksList = document.getElementById('newOrderTasksList');
 const addOrderTaskButton = document.getElementById('addOrderTaskButton');
+const orderTaskSuggestionsStatus = document.getElementById('orderTaskSuggestionsStatus');
+const orderTaskSuggestionsDatalist = document.getElementById('orderTaskSuggestions');
+const jobCatalogStatus = document.getElementById('jobCatalogStatus');
+const jobCatalogTableBody = document.getElementById('jobCatalogTableBody');
+const refreshJobCatalogButton = document.getElementById('refreshJobCatalogButton');
 const statusSelect = document.getElementById('newOrderStatus');
 const assignTailorSelect = document.getElementById('assignTailor');
 const assignVendorSelect = document.getElementById('assignVendor');
@@ -415,6 +432,7 @@ const usersTabButton = document.getElementById('usersTabButton');
 const auditLogTabButton = document.getElementById('auditLogTabButton');
 const auditLogTableBody = document.getElementById('auditLogTableBody');
 const contificoPreviewTabButton = document.getElementById('contificoPreviewTabButton');
+const jobCatalogTabButton = document.getElementById('jobCatalogTabButton');
 const contificoPreviewProductsForm = document.getElementById('contificoPreviewProductsForm');
 const contificoPreviewPageInput = document.getElementById('contificoPreviewPage');
 const contificoPreviewPageSizeInput = document.getElementById('contificoPreviewPageSize');
@@ -771,6 +789,7 @@ function setActiveDashboardTab(tabId = 'ordersPanel') {
     renderOrderKanban();
     if (targetTab === 'orderCreatePanel') {
       focusFirstCreateOrderField();
+      ensureOrderTaskSuggestionsLoaded();
     }
   }
 
@@ -1768,6 +1787,7 @@ function createOrderTaskRowElement(data = { description: '' }) {
   descriptionInput.type = 'text';
   descriptionInput.id = descriptionId;
   descriptionInput.dataset.field = 'description';
+  descriptionInput.setAttribute('list', 'orderTaskSuggestions');
   descriptionInput.placeholder = 'Describe el trabajo a realizar';
   descriptionInput.maxLength = 255;
   descriptionInput.value =
@@ -1847,9 +1867,212 @@ function updateNewOrderTaskLabels() {
 
 }
 
+function renderOrderTaskSuggestions() {
+  if (orderTaskSuggestionsStatus) {
+    let message = '';
+    if (state.orderTaskSuggestionsLoading) {
+      message = 'Actualizando trabajos desde Contífico...';
+    } else if (state.orderTaskSuggestionsError) {
+      message = `${state.orderTaskSuggestionsError} Pide a un administrador que actualice el listado desde la pestaña “Listado de trabajos”.`;
+    } else if (state.orderTaskSuggestionsLoaded) {
+      if (state.orderTaskSuggestions.length) {
+        const updatedLabel = state.orderTaskSuggestionsUpdatedAt
+          ? formatDate(state.orderTaskSuggestionsUpdatedAt)
+          : null;
+        message = `Se cargaron ${state.orderTaskSuggestions.length} trabajos desde Contífico como sugerencias.`;
+        if (updatedLabel) {
+          message += ` Última actualización: ${updatedLabel}.`;
+        }
+        message += ' Los administradores pueden administrar el listado desde la pestaña “Listado de trabajos”.';
+      } else {
+        message =
+          'No se encontraron trabajos en la categoría configurada de Contífico. Pide a un administrador que revise la pestaña “Listado de trabajos” para actualizar el listado manualmente.';
+      }
+    } else {
+      message =
+        'Las sugerencias se cargarán automáticamente al iniciar sesión. Los administradores pueden revisarlas en la pestaña “Listado de trabajos”.';
+    }
+    orderTaskSuggestionsStatus.textContent = message;
+  }
+
+  if (orderTaskSuggestionsDatalist) {
+    orderTaskSuggestionsDatalist.innerHTML = '';
+    const suggestions = Array.isArray(state.orderTaskSuggestions)
+      ? state.orderTaskSuggestions
+      : [];
+    suggestions.forEach((item) => {
+      const name = typeof item.nombre === 'string' ? item.nombre.trim() : '';
+      const description = typeof item.descripcion === 'string' ? item.descripcion.trim() : '';
+      const code = typeof item.codigo === 'string' ? item.codigo.trim() : '';
+      const value = name || description || code;
+      if (!value) {
+        return;
+      }
+      const option = document.createElement('option');
+      option.value = value;
+      const labelParts = [];
+      if (code) {
+        labelParts.push(code);
+      }
+      if (name) {
+        labelParts.push(name);
+      } else if (description && description !== value) {
+        labelParts.push(description);
+      }
+      if (labelParts.length) {
+        option.label = labelParts.join(' – ');
+      }
+      orderTaskSuggestionsDatalist.appendChild(option);
+    });
+  }
+
+  if (newOrderTasksList) {
+    const inputs = Array.from(
+      newOrderTasksList.querySelectorAll('input[data-field="description"]')
+    );
+    inputs.forEach((input) => {
+      input.setAttribute('list', 'orderTaskSuggestions');
+    });
+  }
+
+  renderJobCatalog();
+}
+
+function renderJobCatalog() {
+  if (refreshJobCatalogButton) {
+    refreshJobCatalogButton.disabled = state.orderTaskSuggestionsLoading;
+  }
+
+  if (jobCatalogStatus) {
+    let message = '';
+    if (state.orderTaskSuggestionsLoading) {
+      message = 'Sincronizando trabajos desde Contífico...';
+    } else if (state.orderTaskSuggestionsError) {
+      message = `${state.orderTaskSuggestionsError} Usa “Actualizar listado” para intentar nuevamente.`;
+    } else if (state.orderTaskSuggestionsLoaded) {
+      const count = Array.isArray(state.orderTaskSuggestions)
+        ? state.orderTaskSuggestions.length
+        : 0;
+      if (count > 0) {
+        const updatedLabel = state.orderTaskSuggestionsUpdatedAt
+          ? formatDate(state.orderTaskSuggestionsUpdatedAt)
+          : null;
+        message = `Se registran ${count} trabajos.`;
+        if (updatedLabel) {
+          message += ` Última actualización: ${updatedLabel}.`;
+        }
+        message += ' Usa “Actualizar listado” para sincronizar manualmente.';
+      } else {
+        message =
+          'No se encontraron trabajos en la categoría configurada de Contífico. Usa “Actualizar listado” para sincronizar manualmente.';
+      }
+    } else {
+      message = 'El listado se cargará automáticamente al iniciar sesión.';
+    }
+    jobCatalogStatus.textContent = message;
+  }
+
+  if (jobCatalogTableBody) {
+    jobCatalogTableBody.innerHTML = '';
+    const suggestions = Array.isArray(state.orderTaskSuggestions)
+      ? state.orderTaskSuggestions
+      : [];
+    if (!suggestions.length) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 3;
+      cell.className = 'muted text-center';
+      cell.textContent = state.orderTaskSuggestionsLoading
+        ? 'Cargando trabajos...'
+        : 'No hay trabajos registrados.';
+      row.appendChild(cell);
+      jobCatalogTableBody.appendChild(row);
+      return;
+    }
+
+    suggestions.forEach((item) => {
+      const row = document.createElement('tr');
+      const codeCell = document.createElement('td');
+      const nameCell = document.createElement('td');
+      const descriptionCell = document.createElement('td');
+
+      const code = typeof item.codigo === 'string' ? item.codigo.trim() : '';
+      const name = typeof item.nombre === 'string' ? item.nombre.trim() : '';
+      const description = typeof item.descripcion === 'string' ? item.descripcion.trim() : '';
+
+      codeCell.textContent = code || '—';
+      nameCell.textContent = name || '—';
+      descriptionCell.textContent = description || '—';
+
+      row.append(codeCell, nameCell, descriptionCell);
+      jobCatalogTableBody.appendChild(row);
+    });
+  }
+}
+
+async function loadOrderTaskSuggestions(force = false) {
+  if (state.orderTaskSuggestionsLoading) {
+    return;
+  }
+  if (!force && state.orderTaskSuggestionsLoaded) {
+    renderOrderTaskSuggestions();
+    return;
+  }
+  state.orderTaskSuggestionsLoading = true;
+  renderOrderTaskSuggestions();
+  try {
+    const url =
+      `/integrations/contifico/products?page=1&page_size=${CONTIFICO_MAX_PAGE_SIZE}` +
+      `&category_id=${encodeURIComponent(CONTIFICO_SEWING_TASK_CATEGORY_ID)}`;
+    const response = await apiFetch(url);
+    const items = Array.isArray(response?.items) ? response.items : [];
+    state.orderTaskSuggestions = items
+      .map((item) => ({
+        id: item?.id ?? null,
+        codigo: typeof item?.codigo === 'string' ? item.codigo : '',
+        nombre: typeof item?.nombre === 'string' ? item.nombre : '',
+        descripcion: typeof item?.descripcion === 'string' ? item.descripcion : '',
+      }))
+      .filter((item) => item.nombre || item.descripcion || item.codigo);
+    state.orderTaskSuggestionsError = null;
+    state.orderTaskSuggestionsLoaded = true;
+    state.orderTaskSuggestionsUpdatedAt = new Date().toISOString();
+  } catch (error) {
+    const hasExistingSuggestions =
+      Array.isArray(state.orderTaskSuggestions) && state.orderTaskSuggestions.length > 0;
+    state.orderTaskSuggestionsError =
+      error?.message || 'No se pudieron obtener los trabajos desde Contífico.';
+    if (!hasExistingSuggestions) {
+      state.orderTaskSuggestions = [];
+      state.orderTaskSuggestionsLoaded = false;
+      state.orderTaskSuggestionsUpdatedAt = null;
+    }
+    showToast(state.orderTaskSuggestionsError, 'error');
+  } finally {
+    state.orderTaskSuggestionsLoading = false;
+    renderOrderTaskSuggestions();
+  }
+}
+
+function ensureOrderTaskSuggestionsLoaded() {
+  if (state.orderTaskSuggestionsLoaded || state.orderTaskSuggestionsLoading) {
+    renderOrderTaskSuggestions();
+    return;
+  }
+  void loadOrderTaskSuggestions();
+}
+
 if (addOrderTaskButton) {
   addOrderTaskButton.addEventListener('click', () => addNewOrderTaskRow());
 }
+
+if (refreshJobCatalogButton) {
+  refreshJobCatalogButton.addEventListener('click', () => {
+    void loadOrderTaskSuggestions(true);
+  });
+}
+
+renderOrderTaskSuggestions();
 
 function addMeasurementRowToList(listElement, data = { nombre: '', valor: '' }) {
   if (!listElement) return;
@@ -1962,6 +2185,7 @@ function resetCreateOrderForm() {
     newOrderTasksList.innerHTML = '';
     addNewOrderTaskRow();
   }
+  renderOrderTaskSuggestions();
   renderCustomerMeasurementOptions(null);
   clearOrderInvoiceSuggestions();
 }
@@ -2495,6 +2719,7 @@ async function bootstrapAuthenticatedSession({ showWelcomeToast = false } = {}) 
   await loadCustomers();
   await refreshCustomerOptions();
   await loadOrders();
+  await loadOrderTaskSuggestions();
   if (state.user?.role === 'administrador') {
     await loadUsers();
     await loadAuditLogs();
@@ -3504,6 +3729,11 @@ function handleLogout(auto = false) {
   state.orderInvoiceSuggestionRequestId = 0;
   state.orderInvoiceSuggestionsLoading = false;
   state.orderInvoiceSuggestionsError = null;
+  state.orderTaskSuggestions = [];
+  state.orderTaskSuggestionsLoading = false;
+  state.orderTaskSuggestionsLoaded = false;
+  state.orderTaskSuggestionsUpdatedAt = null;
+  state.orderTaskSuggestionsError = null;
   state.orderInvoiceLookup = null;
   state.orderInvoiceLookupLoading = false;
   state.orderInvoiceLookupError = null;
@@ -3522,6 +3752,7 @@ function handleLogout(auto = false) {
   setOrderInvoiceSuggestionsStatus('');
   renderOrderInvoiceSuggestions();
   renderOrderInvoiceLookupDetails();
+  renderOrderTaskSuggestions();
   if (currentUserNameElement) {
     currentUserNameElement.textContent = '';
   }
@@ -3549,6 +3780,9 @@ function handleLogout(auto = false) {
   }
   if (contificoPreviewTabButton) {
     contificoPreviewTabButton.classList.add('hidden');
+  }
+  if (jobCatalogTabButton) {
+    jobCatalogTabButton.classList.add('hidden');
   }
   setActiveDashboardTab('ordersPanel');
   hideDashboard();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,6 +141,14 @@
             >
               Contífico (vista previa)
             </button>
+            <button
+              type="button"
+              class="dashboard-tab admin-only hidden"
+              data-tab="jobCatalogPanel"
+              id="jobCatalogTabButton"
+            >
+              Listado de trabajos
+            </button>
           </nav>
 
           <section class="card dashboard-panel hidden" id="customersPanel">
@@ -494,6 +502,8 @@
                 </p>
                 <div id="newOrderTasksList" class="measurement-list"></div>
                 <button type="button" id="addOrderTaskButton" class="secondary">Agregar trabajo</button>
+                <p id="orderTaskSuggestionsStatus" class="muted small"></p>
+                <datalist id="orderTaskSuggestions"></datalist>
               </div>
               <div class="form-row">
                 <label for="assignTailor">Asignar a sastre</label>
@@ -510,6 +520,36 @@
               <button type="submit" class="primary">Guardar orden</button>
             </form>
             <datalist id="orderInvoiceSuggestions"></datalist>
+          </section>
+
+          <section class="card dashboard-panel hidden" id="jobCatalogPanel">
+            <div class="panel-header">
+              <div>
+                <h3>Listado de trabajos</h3>
+                <p class="muted">
+                  Consulta los trabajos sincronizados desde Contífico y actualiza el listado cuando lo
+                  necesites.
+                </p>
+              </div>
+              <div class="panel-actions">
+                <button type="button" class="secondary" id="refreshJobCatalogButton">
+                  Actualizar listado
+                </button>
+              </div>
+            </div>
+            <p id="jobCatalogStatus" class="muted small"></p>
+            <div class="table-wrapper compact">
+              <table class="job-catalog-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Código</th>
+                    <th scope="col">Nombre</th>
+                    <th scope="col">Descripción</th>
+                  </tr>
+                </thead>
+                <tbody id="jobCatalogTableBody"></tbody>
+              </table>
+            </div>
           </section>
 
           <section class="card dashboard-panel hidden" id="ordersPanel">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -570,6 +570,36 @@ button[disabled] {
   border-color: var(--primary);
 }
 
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.panel-header h3 {
+  margin: 0;
+}
+
+.panel-header p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  max-width: 48ch;
+}
+
+.panel-actions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.panel-actions button {
+  white-space: nowrap;
+}
+
 .customer-panel-header {
   display: flex;
   flex-wrap: wrap;
@@ -2253,6 +2283,16 @@ th {
   background: rgba(17, 17, 17, 0.26);
 }
 
+.job-catalog-table th,
+.job-catalog-table td {
+  vertical-align: top;
+}
+
+.job-catalog-table td {
+  max-width: 28ch;
+  word-break: break-word;
+}
+
 .order-task-input-label {
   font-weight: 600;
 }
@@ -2523,6 +2563,10 @@ th {
 
 .muted {
   color: var(--muted);
+}
+
+.text-center {
+  text-align: center;
 }
 
 .small {


### PR DESCRIPTION
## Summary
- preload the Contífico sewing jobs once per session and reuse them for order task suggestions
- add an admin-only "Listado de trabajos" panel to review and manually refresh the cached jobs
- update styles to support the new panel layout and table presentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e59d9c949c83329f700da2c17af31e