### PR TITLE
Improve SQLAlchemy missing dependency messaging

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,3 +1,13 @@
+"""Database session and engine helpers."""
+
+from importlib.util import find_spec
+
+if find_spec("sqlalchemy") is None:
+    raise ModuleNotFoundError(
+        "SQLAlchemy no está instalado. Ejecuta `pip install -r backend/requirements.txt` "
+        "desde la carpeta del backend antes de iniciar la API."
+    )
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 

--- a/backend/create_admin.py
+++ b/backend/create_admin.py
@@ -1,6 +1,13 @@
 """Utility script to bootstrap an administrator user."""
 
 import argparse
+from importlib.util import find_spec
+
+if find_spec("sqlalchemy") is None:
+    raise ModuleNotFoundError(
+        "SQLAlchemy no está instalado. Ejecuta `pip install -r backend/requirements.txt` "
+        "antes de usar create_admin.py."
+    )
 
 from sqlalchemy.orm import Session
 

--- a/backend/seed_database.py
+++ b/backend/seed_database.py
@@ -9,7 +9,14 @@ import secrets
 import string
 from collections import Counter
 from datetime import UTC, date, datetime, time, timedelta
+from importlib.util import find_spec
 from typing import Iterable, List, Optional, Sequence, Tuple
+
+if find_spec("sqlalchemy") is None:
+    raise ModuleNotFoundError(
+        "SQLAlchemy no está instalado. Ejecuta `pip install -r backend/requirements.txt` "
+        "antes de usar seed_database.py."
+    )
 
 from sqlalchemy import MetaData, Table, delete, inspect, select
 


### PR DESCRIPTION
## Summary
- add upfront SQLAlchemy availability checks in the database module and CLI helpers
- raise clearer guidance about installing backend requirements when the ORM dependency is missing

## Testing
- pip install -r backend/requirements.txt
- pytest backend/tests *(interrupted after partial run)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d6c0961dd88332bd91a422647ddf52)