### PR TITLE
Stream Contifico invoice catalog to disk

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,7 @@
 # Portal de Sastrería
 
+Versión 0.1.1
+
 Aplicación completa para gestionar y consultar órdenes de un taller de sastrería. El proyecto incluye un backend basado en FastAPI con autenticación JWT y un frontend ligero en HTML/JavaScript para clientes y personal interno.
 
 ## Requisitos
@@ -39,6 +41,23 @@ export SECRET_KEY="pon-aqui-una-clave-de-al-menos-32-caracteres"
 # export CONTIFICO_API_KEY="tu-api-key"
 # export CONTIFICO_API_TOKEN="tu-api-token"
 ```
+
+#### Límites para la búsqueda de facturas en Contífico
+
+Para evitar cargar el catálogo completo de facturas en memoria, la descarga se realiza en
+bloques y se persiste a disco. Estos parámetros se pueden ajustar con variables de entorno:
+
+- `CONTIFICO_INVOICE_CATALOG_PAGE_SIZE` (predeterminado: `100`): cuántas facturas se
+  solicitan por página.
+- `CONTIFICO_INVOICE_CATALOG_MAX_PAGES` (predeterminado: `200`): número máximo de páginas
+  a recorrer.
+- `CONTIFICO_INVOICE_CATALOG_MAX_RECORDS` (predeterminado: `20000`, usa `0` o `None` para
+  desactivar): cantidad máxima de facturas a descargar antes de detener la búsqueda.
+- `CONTIFICO_INVOICE_CATALOG_STOP_ON_FIRST_MATCH` (predeterminado: `true`): detiene la
+  descarga del catálogo en cuanto se encuentra la factura buscada.
+
+Al buscar una factura, el cliente elimina de memoria las páginas que ya fueron persistidas,
+manteniendo sólo las coincidencias necesarias para continuar con la consulta.
 
 La aplicación fallará con un mensaje descriptivo si `SECRET_KEY` no está definida o es
 demasiado corta.

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Portal de Sastrería
 
-Versión 0.1.1
+Versión 0.1.2
 
 Aplicación completa para gestionar y consultar órdenes de un taller de sastrería. El proyecto incluye un backend basado en FastAPI con autenticación JWT y un frontend ligero en HTML/JavaScript para clientes y personal interno.
 
@@ -109,6 +109,21 @@ python -m app.main
 ```
 
 La documentación interactiva estará disponible en `http://<host>:<puerto>/docs`.
+
+### Posibles causas de caída o bloqueo en el VPS
+
+- **Falta de variables críticas**: si `SECRET_KEY` no está definida o tiene menos de 32
+  caracteres, la API detendrá el arranque con un error descriptivo. Ajusta la variable en
+  `.env` o en el entorno antes de iniciar el servicio.
+- **Problemas de disco**: el backend usa SQLite por defecto (`sastreria.db`) y persiste
+  cachés de facturas de Contífico en `./data`. Ambos requieren permisos de escritura y
+  espacio libre suficiente; un disco lleno o de solo lectura impedirá escribir y puede
+  forzar la caída del proceso de aplicación o del servidor de la base de datos.
+- **Recursos saturados**: aunque las descargas del catálogo de Contífico ahora se podan y
+  persisten por página, tamaños de página y límites de registros demasiado altos, o
+  tiempos de espera muy amplios, pueden consumir CPU/ RAM o hilos hasta provocar que el
+  proceso sea terminado por el sistema operativo. Ajusta los límites mediante las
+  variables de entorno documentadas arriba para mantener el consumo controlado.
 
 ### 2. Preparar el frontend
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,6 +67,33 @@ class Settings(BaseSettings):
             "para búsquedas locales."
         ),
     )
+    contifico_invoice_catalog_page_size: int = Field(
+        default=100,
+        ge=1,
+        description=(
+            "Cantidad de facturas solicitadas por página al construir el catálogo local."
+        ),
+    )
+    contifico_invoice_catalog_max_pages: int = Field(
+        default=200,
+        ge=1,
+        description="Número máximo de páginas a descargar del catálogo de facturas.",
+    )
+    contifico_invoice_catalog_max_records: int | None = Field(
+        default=20000,
+        ge=0,
+        description=(
+            "Límite superior de facturas a descargar antes de detener el catálogo. "
+            "Usa 0 o None para desactivar este tope."
+        ),
+    )
+    contifico_invoice_catalog_stop_on_first_match: bool = Field(
+        default=True,
+        description=(
+            "Detiene la descarga del catálogo al encontrar la primera factura que coincida "
+            "con la búsqueda en curso."
+        ),
+    )
     contifico_invoice_lookup_job_timeout_seconds: float | None = Field(
         default=120.0,
         ge=0.0,

--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -63,8 +63,10 @@ class ContificoClient:
     INVOICE_LOOKUP_RETRY_BACKOFF_BASE = 0.5
     INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 2
     INVOICE_LOOKUP_SERVER_COOLDOWN_BASE = 2.0
-    INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 200
-    INVOICE_LOOKUP_CATALOG_MAX_PAGES = 400
+    INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 100
+    INVOICE_LOOKUP_CATALOG_MAX_PAGES = 200
+    INVOICE_LOOKUP_CATALOG_MAX_RECORDS: int | None = 20000
+    INVOICE_LOOKUP_CATALOG_STOP_ON_FIRST_MATCH = True
     INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 2
     INVOICE_LOOKUP_CATALOG_BACKOFF_BASE = 1.0
     INVOICE_LOOKUP_DIRECT_FALLBACK_STATUSES = {
@@ -82,6 +84,10 @@ class ContificoClient:
         timeout: float = 30.0,
         transport: httpx.BaseTransport | None = None,
         invoice_cache_path: str | Path | None = None,
+        invoice_catalog_page_size: int | None = None,
+        invoice_catalog_max_pages: int | None = None,
+        invoice_catalog_max_records: int | None = None,
+        invoice_catalog_stop_on_first_match: bool | None = None,
     ) -> None:
         if not api_key or not api_key.strip():
             raise ContificoConfigurationError(
@@ -105,6 +111,26 @@ class ContificoClient:
         self._invoice_catalog_complete = False
         self._cache_loaded = False
         self._cache_dirty = False
+
+        self.invoice_catalog_page_size = self._coerce_positive_int(
+            invoice_catalog_page_size, self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE
+        )
+        self.invoice_catalog_max_pages = self._coerce_positive_int(
+            invoice_catalog_max_pages, self.INVOICE_LOOKUP_CATALOG_MAX_PAGES
+        )
+        if invoice_catalog_max_records is None:
+            self.invoice_catalog_max_records = self.INVOICE_LOOKUP_CATALOG_MAX_RECORDS
+        else:
+            try:
+                records_cap = int(invoice_catalog_max_records)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                records_cap = self.INVOICE_LOOKUP_CATALOG_MAX_RECORDS
+            self.invoice_catalog_max_records = None if records_cap <= 0 else records_cap
+        self.invoice_catalog_stop_on_first_match = (
+            self.INVOICE_LOOKUP_CATALOG_STOP_ON_FIRST_MATCH
+            if invoice_catalog_stop_on_first_match is None
+            else bool(invoice_catalog_stop_on_first_match)
+        )
 
         self._load_persistent_cache()
 
@@ -210,10 +236,18 @@ class ContificoClient:
         return cleaned
 
     @staticmethod
+    def _coerce_positive_int(value: int | None, default: int) -> int:
+        try:
+            candidate = int(value) if value is not None else int(default)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            candidate = default
+        return candidate if candidate > 0 else default
+
+    @staticmethod
     def _sleep(seconds: float) -> None:
         if seconds <= 0:
             return
-        time.sleep(seconds)
+        time.sleep(min(seconds, 0.1))
 
     @classmethod
     def _extract_invoice_number(cls, payload: Dict[str, Any]) -> Optional[str]:
@@ -1276,28 +1310,32 @@ class ContificoClient:
                 return True
         return False
 
-    def _cache_invoice(self, invoice: Dict[str, Any]) -> None:
+    def _cache_invoice(self, invoice: Dict[str, Any]) -> list[str]:
+        added_keys: list[str] = []
         if not isinstance(invoice, dict):
-            return
+            return added_keys
         candidate = self._extract_invoice_number(invoice)
         if not candidate:
-            return
+            return added_keys
         normalized_candidate = self._normalize_invoice_number(candidate)
         if not normalized_candidate:
-            return
+            return added_keys
         self._invoice_cache[normalized_candidate] = invoice
+        added_keys.append(normalized_candidate)
         self._cache_dirty = True
         logger.info("Cached invoice %s", normalized_candidate)
         if "-" in normalized_candidate:
             compact_candidate = normalized_candidate.replace("-", "")
             if compact_candidate and compact_candidate not in self._invoice_cache:
                 self._invoice_cache[compact_candidate] = invoice
+                added_keys.append(compact_candidate)
                 self._cache_dirty = True
                 logger.info(
                     "Cached compact invoice key %s for %s",
                     compact_candidate,
                     normalized_candidate,
                 )
+        return added_keys
 
     def _get_cached_invoice(
         self, normalized_target: str, compact_target: str | None
@@ -1319,31 +1357,51 @@ class ContificoClient:
     def _lookup_invoice_from_catalog(
         self, normalized_target: str, compact_target: str | None
     ) -> Optional[Dict[str, Any]]:
-        self._ensure_invoice_catalog()
+        self._ensure_invoice_catalog(
+            normalized_target=normalized_target, compact_target=compact_target
+        )
         return self._get_cached_invoice(normalized_target, compact_target)
 
-    def _ensure_invoice_catalog(self) -> None:
+    def _ensure_invoice_catalog(
+        self, *, normalized_target: str | None = None, compact_target: str | None = None
+    ) -> None:
         if self._invoice_catalog_complete:
             logger.info("Invoice catalog already cached locally")
-            return
+            if normalized_target or compact_target:
+                cached = self._get_cached_invoice(normalized_target or "", compact_target)
+                if cached is not None:
+                    return
+                logger.info(
+                    "Invoice %s not found in memory; performing incremental catalog search",
+                    normalized_target or compact_target,
+                )
+            else:
+                return
         logger.info("Downloading invoice catalog for local cache")
-        self._download_invoice_catalog()
-        self._invoice_catalog_complete = True
+        self._invoice_catalog_complete = self._download_invoice_catalog(
+            normalized_target=normalized_target, compact_target=compact_target
+        )
 
-    def _download_invoice_catalog(self) -> None:
-        for page in range(1, self.INVOICE_LOOKUP_CATALOG_MAX_PAGES + 1):
+    def _download_invoice_catalog(
+        self, *, normalized_target: str | None = None, compact_target: str | None = None
+    ) -> bool:
+        preexisting_keys = set(self._invoice_cache.keys())
+        total_records = 0
+        keep_keys = {key for key in (normalized_target, compact_target) if key}
+
+        for page in range(1, self.invoice_catalog_max_pages + 1):
             retry_attempt = 0
             while True:
                 try:
                     logger.info(
                         "Requesting invoice catalog page=%d page_size=%d",
                         page,
-                        self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE,
+                        self.invoice_catalog_page_size,
                     )
                     invoices = list(
                         self.list_invoices(
                             page=page,
-                            page_size=self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE,
+                            page_size=self.invoice_catalog_page_size,
                         )
                     )
                     break
@@ -1369,17 +1427,55 @@ class ContificoClient:
             if not invoices:
                 logger.info("Catalog download finished early at page=%d", page)
                 self._flush_persistent_cache()
-                return
+                return True
 
+            page_keys: list[str] = []
             for invoice in invoices:
-                self._cache_invoice(invoice)
+                page_keys.extend(self._cache_invoice(invoice))
 
-            if len(invoices) < self.INVOICE_LOOKUP_CATALOG_PAGE_SIZE:
+            total_records += len(invoices)
+
+            match = self._get_cached_invoice(normalized_target, compact_target)
+            if match is not None and self.invoice_catalog_stop_on_first_match:
+                logger.info(
+                    "Catalog download stopped early after finding invoice %s",
+                    normalized_target or compact_target,
+                )
+                self._flush_persistent_cache()
+                self._prune_page_cache(preexisting_keys, page_keys, keep_keys)
+                return False
+
+            if (
+                self.invoice_catalog_max_records is not None
+                and total_records >= self.invoice_catalog_max_records
+            ):
+                logger.info(
+                    "Catalog download stopped after reaching record limit %d",
+                    self.invoice_catalog_max_records,
+                )
+                self._flush_persistent_cache()
+                self._prune_page_cache(preexisting_keys, page_keys, keep_keys)
+                return False
+
+            if len(invoices) < self.invoice_catalog_page_size:
                 logger.info("Catalog download completed after page=%d", page)
                 self._flush_persistent_cache()
-                return
+                self._prune_page_cache(preexisting_keys, page_keys, keep_keys)
+                return True
+
+            self._flush_persistent_cache()
+            self._prune_page_cache(preexisting_keys, page_keys, keep_keys)
 
         self._flush_persistent_cache()
+        return False
+
+    def _prune_page_cache(
+        self, existing_keys: set[str], page_keys: list[str], keep_keys: set[str]
+    ) -> None:
+        for key in page_keys:
+            if key in existing_keys or key in keep_keys:
+                continue
+            self._invoice_cache.pop(key, None)
 
     def _load_persistent_cache(self) -> None:
         if self._cache_loaded:

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -48,6 +48,12 @@ def get_contifico_client() -> ContificoClient:
             base_url=settings.contifico_api_base_url,
             timeout=settings.contifico_timeout_seconds,
             invoice_cache_path=settings.contifico_invoice_cache_path,
+            invoice_catalog_page_size=settings.contifico_invoice_catalog_page_size,
+            invoice_catalog_max_pages=settings.contifico_invoice_catalog_max_pages,
+            invoice_catalog_max_records=settings.contifico_invoice_catalog_max_records,
+            invoice_catalog_stop_on_first_match=(
+                settings.contifico_invoice_catalog_stop_on_first_match
+            ),
         )
     except ContificoConfigurationError as exc:  # pragma: no cover - validación defensiva
         raise HTTPException(

--- a/backend/app/invoice_jobs.py
+++ b/backend/app/invoice_jobs.py
@@ -63,6 +63,12 @@ def _default_client_factory() -> ContificoClient:
         base_url=settings.contifico_api_base_url,
         timeout=settings.contifico_timeout_seconds,
         invoice_cache_path=settings.contifico_invoice_cache_path,
+        invoice_catalog_page_size=settings.contifico_invoice_catalog_page_size,
+        invoice_catalog_max_pages=settings.contifico_invoice_catalog_max_pages,
+        invoice_catalog_max_records=settings.contifico_invoice_catalog_max_records,
+        invoice_catalog_stop_on_first_match=(
+            settings.contifico_invoice_catalog_stop_on_first_match
+        ),
     )
 
 

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -1032,8 +1032,10 @@ def test_find_invoice_by_document_number_downloads_catalog_after_timeouts(
     client.INVOICE_LOOKUP_MAX_PAGES = 1
     client.INVOICE_LOOKUP_SERVER_RETRIES = 0
     client.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 0
-    client.INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 2
-    client.INVOICE_LOOKUP_CATALOG_MAX_PAGES = 1
+    client.invoice_catalog_page_size = 2
+    client.invoice_catalog_max_pages = 1
+    client.invoice_catalog_max_records = None
+    client.invoice_catalog_stop_on_first_match = False
     client.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 0
 
     invoice = client.find_invoice_by_document_number("001-001-0000044")
@@ -1043,7 +1045,7 @@ def test_find_invoice_by_document_number_downloads_catalog_after_timeouts(
     assert requests[0][0] == "direct"
     assert any(kind == "search" for kind, _ in requests)
     assert catalog_requests == [{"result_page": "1", "result_size": "2", "tipo_registro": "CLI", "tipo": "FAC"}]
-    assert client._invoice_catalog_complete is True
+    assert client._invoice_catalog_complete is False
     assert "001-001-0000044" in client._invoice_cache
     assert sleeps == []
 
@@ -1083,8 +1085,10 @@ def test_find_invoice_by_document_number_reuses_catalog_without_http() -> None:
     client.INVOICE_LOOKUP_MAX_PAGES = 1
     client.INVOICE_LOOKUP_SERVER_RETRIES = 0
     client.INVOICE_LOOKUP_SERVER_FAILURE_ATTEMPTS = 0
-    client.INVOICE_LOOKUP_CATALOG_PAGE_SIZE = 1
-    client.INVOICE_LOOKUP_CATALOG_MAX_PAGES = 1
+    client.invoice_catalog_page_size = 1
+    client.invoice_catalog_max_pages = 1
+    client.invoice_catalog_max_records = None
+    client.invoice_catalog_stop_on_first_match = False
     client.INVOICE_LOOKUP_CATALOG_SERVER_RETRIES = 0
 
     invoice = client.find_invoice_by_document_number("001-001-0000045")


### PR DESCRIPTION
## Summary
- add configurable Contífico catalog pagination, record caps, and incremental search to reduce memory usage
- stream catalog downloads to disk while pruning in-memory pages and capping retry backoffs
- document new Contífico limits in the README and bump the project version number

## Testing
- python -m pytest tests/test_contifico_client.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a1509b93083328c523cf2ff98515c)