### PR TITLE
docs: redefine project as Contífico→Odoo migrator (v0.2.0)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,8 +1,20 @@
 # Portal de Sastrería
 
-Versión 0.1.2
+Versión 0.2.0
 
-Aplicación completa para gestionar y consultar órdenes de un taller de sastrería. El proyecto incluye un backend basado en FastAPI con autenticación JWT y un frontend ligero en HTML/JavaScript para clientes y personal interno.
+Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
+
+
+## Enfoque actual: Migrador Contífico → Odoo
+
+A partir de la **versión 0.2.0**, este repositorio pasa a enfocarse en la migración de datos de negocio desde Contífico hacia Odoo.
+
+Prioridades iniciales de migración:
+- Clientes (contactos y datos fiscales).
+- Productos y servicios.
+- Facturas y movimientos clave para continuidad operativa.
+
+La estrategia será incremental, con etapas de mapeo de datos, validaciones y sincronización controlada para minimizar riesgos en producción.
 
 ## Requisitos
 


### PR DESCRIPTION
## Summary
- Bumped documented project version from `0.1.2` to `0.2.0` in `README.MD`.
- Updated the project description to reflect the new strategic goal: orderly migration from Contífico to Odoo.
- Added a new section, **"Enfoque actual: Migrador Contífico → Odoo"**, documenting the new scope and first migration priorities.

## Why
The repository objective changed and needed to be made explicit in top-level documentation, including version progression and immediate data-migration priorities.

## Files changed
- `README.MD`

## Notes
- No runtime code changes were introduced in this commit; this is a documentation/version-alignment update to establish the new direction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5640273748332823071ad78dcb038)