### PR TITLE
Improve product fetch resilience with retries, backoff and resume state; add tests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.31
+Versión 1.0.33
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.33
+Versión 1.0.34
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any, Callable
 import json
 
-from ..contifico import ContificoClient, ContificoTransportError
+import time
+
+from ..contifico import ContificoAPIError, ContificoClient, ContificoTransportError
 from .rules import (
     detect_brand, detect_color, detect_category, calculate_total_stock, should_exclude_zero_stock,
     parse_shirt_sku, parse_suit_sku, parse_blazer_sku, parse_tie_sku, parse_bowtie_sku, parse_fajin_sku,
@@ -39,6 +41,9 @@ class MigrationOutput:
 
 
 class OdooMigrationService:
+    PRODUCT_PAGE_SERVER_RETRIES = 3
+    PRODUCT_PAGE_RETRY_BACKOFF_BASE_SECONDS = 0.8
+
     def __init__(self, client: ContificoClient, output_root: str | Path = "backend/data/odoo_migration"):
         self.client = client; self.output_root = Path(output_root)
         self._warehouse_by_id = {w.get("id"): w for w in WAREHOUSE_CATALOG if w.get("id")}
@@ -330,17 +335,69 @@ class OdooMigrationService:
         return [c.strip() for c in line.split(',') if c.strip()]
 
     def _fetch_products(self, *, page_size:int, max_pages:int, progress_callback=None, debug_lines=None, raw_lines=None):
-        items=[]; pages=0
-        for page in range(1,max_pages+1):
+        resume_state_path = self.output_root / "products_fetch_resume_state.json"
+        resume_items_path = self.output_root / "products_fetch_resume_items.jsonl"
+        items, start_page = self._load_fetch_resume_state(
+            resume_state_path=resume_state_path,
+            resume_items_path=resume_items_path,
+            page_size=page_size,
+            max_pages=max_pages,
+        )
+        pages = start_page - 1
+        for page in range(start_page, max_pages + 1):
             if progress_callback: progress_callback({"stage":"fetching","page":page,"max_pages":max_pages,"found_items":len(items)})
             batch, effective_page_size = self._fetch_products_page_with_fallback(page=page, page_size=page_size); pages=page
             if debug_lines is not None: debug_lines.append(f"fetch page={page} items={len(batch)}")
             if raw_lines is not None: raw_lines.append(json.dumps({"page":page,"response":batch}, ensure_ascii=False))
             if not batch: break
-            items.extend([b for b in batch if isinstance(b,dict)])
+            page_items = [b for b in batch if isinstance(b,dict)]
+            items.extend(page_items)
+            self._save_fetch_resume_state(
+                resume_state_path=resume_state_path,
+                resume_items_path=resume_items_path,
+                page=page,
+                page_size=page_size,
+                max_pages=max_pages,
+                page_items=page_items,
+            )
             if progress_callback: progress_callback({"stage":"fetched_page","page":page,"fetched":len(batch),"found_items":len(items)})
             if len(batch)<effective_page_size: break
+        self._clear_fetch_resume_state(resume_state_path=resume_state_path, resume_items_path=resume_items_path)
         return items, pages, pages>=max_pages
+
+    def _load_fetch_resume_state(self, *, resume_state_path: Path, resume_items_path: Path, page_size: int, max_pages: int) -> tuple[list[dict[str, Any]], int]:
+        if not resume_state_path.exists() or not resume_items_path.exists():
+            return [], 1
+        try:
+            state = json.loads(resume_state_path.read_text(encoding="utf-8"))
+            if int(state.get("page_size") or 0) != int(page_size) or int(state.get("max_pages") or 0) != int(max_pages):
+                return [], 1
+            last_page = int(state.get("last_successful_page") or 0)
+            items = []
+            for line in resume_items_path.read_text(encoding="utf-8").splitlines():
+                payload = json.loads(line)
+                if isinstance(payload, dict):
+                    items.append(payload)
+            return items, max(1, last_page + 1)
+        except Exception:
+            return [], 1
+
+    def _save_fetch_resume_state(self, *, resume_state_path: Path, resume_items_path: Path, page: int, page_size: int, max_pages: int, page_items: list[dict[str, Any]]) -> None:
+        resume_state_path.parent.mkdir(parents=True, exist_ok=True)
+        with resume_items_path.open("a", encoding="utf-8") as fh:
+            for item in page_items:
+                fh.write(json.dumps(item, ensure_ascii=False) + "\n")
+        resume_state_path.write_text(
+            json.dumps({"last_successful_page": page, "page_size": page_size, "max_pages": max_pages}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _clear_fetch_resume_state(*, resume_state_path: Path, resume_items_path: Path) -> None:
+        if resume_state_path.exists():
+            resume_state_path.unlink()
+        if resume_items_path.exists():
+            resume_items_path.unlink()
 
     def _fetch_products_page_with_fallback(self, *, page: int, page_size: int) -> tuple[list[dict[str, Any]], int]:
         sizes = [page_size]
@@ -352,11 +409,19 @@ class OdooMigrationService:
             sizes.append(25)
         last_exc: Exception | None = None
         for size in sizes:
-            try:
-                return list(self.client.list_products(page=page, page_size=size)), size
-            except ContificoTransportError as exc:
-                last_exc = exc
-                continue
+            for attempt in range(1, self.PRODUCT_PAGE_SERVER_RETRIES + 1):
+                try:
+                    return list(self.client.list_products(page=page, page_size=size)), size
+                except ContificoTransportError as exc:
+                    last_exc = exc
+                except ContificoAPIError as exc:
+                    if exc.status_code not in {429, 500, 502, 503, 504}:
+                        raise
+                    last_exc = exc
+
+                if attempt < self.PRODUCT_PAGE_SERVER_RETRIES:
+                    time.sleep(self.PRODUCT_PAGE_RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)))
+            continue
         if last_exc:
             raise last_exc
         return [], page_size

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -400,13 +400,9 @@ class OdooMigrationService:
             resume_items_path.unlink()
 
     def _fetch_products_page_with_fallback(self, *, page: int, page_size: int) -> tuple[list[dict[str, Any]], int]:
+        # Importante: no degradar page_size entre reintentos porque el número de página
+        # representa offsets distintos para cada tamaño y puede crear huecos/duplicados.
         sizes = [page_size]
-        if page_size > 100:
-            sizes.extend([100, 50, 25])
-        elif page_size > 50:
-            sizes.extend([50, 25])
-        elif page_size > 25:
-            sizes.append(25)
         last_exc: Exception | None = None
         for size in sizes:
             for attempt in range(1, self.PRODUCT_PAGE_SERVER_RETRIES + 1):

--- a/backend/tests/test_odoo_migration_fetch_resilience.py
+++ b/backend/tests/test_odoo_migration_fetch_resilience.py
@@ -1,0 +1,97 @@
+from app.contifico import ContificoAPIError, ContificoTransportError
+from app.odoo_migration.service import OdooMigrationService
+
+
+class StubClient:
+    def __init__(self):
+        self.calls = []
+
+    def list_products(self, *, page: int, page_size: int):
+        self.calls.append((page, page_size))
+        if len(self.calls) < 3:
+            raise ContificoTransportError("transient network error")
+        return [{"id": "P-1", "codigo": "SKU-1"}]
+
+
+class StubClientApiError:
+    def __init__(self):
+        self.calls = []
+
+    def list_products(self, *, page: int, page_size: int):
+        self.calls.append((page, page_size))
+        if len(self.calls) < 2:
+            raise ContificoAPIError(503, "service unavailable")
+        return [{"id": "P-2", "codigo": "SKU-2"}]
+
+
+class StubClientNonRetriable:
+    def list_products(self, *, page: int, page_size: int):
+        raise ContificoAPIError(400, "bad request")
+
+
+def test_fetch_products_page_retries_transport_errors_then_succeeds(monkeypatch):
+    monkeypatch.setattr("app.odoo_migration.service.time.sleep", lambda _s: None)
+    client = StubClient()
+    service = OdooMigrationService(client=client)
+
+    rows, effective_size = service._fetch_products_page_with_fallback(page=1, page_size=200)
+
+    assert rows == [{"id": "P-1", "codigo": "SKU-1"}]
+    assert effective_size == 200
+    assert client.calls == [(1, 200), (1, 200), (1, 200)]
+
+
+def test_fetch_products_page_retries_server_errors_then_succeeds(monkeypatch):
+    monkeypatch.setattr("app.odoo_migration.service.time.sleep", lambda _s: None)
+    client = StubClientApiError()
+    service = OdooMigrationService(client=client)
+
+    rows, effective_size = service._fetch_products_page_with_fallback(page=2, page_size=120)
+
+    assert rows == [{"id": "P-2", "codigo": "SKU-2"}]
+    assert effective_size == 120
+    assert client.calls == [(2, 120), (2, 120)]
+
+
+def test_fetch_products_page_raises_non_retriable_api_errors():
+    service = OdooMigrationService(client=StubClientNonRetriable())
+
+    try:
+        service._fetch_products_page_with_fallback(page=1, page_size=200)
+    except ContificoAPIError as exc:
+        assert exc.status_code == 400
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected ContificoAPIError")
+
+
+def test_fetch_products_resumes_from_last_successful_page(tmp_path):
+    class ResumeClient:
+        def __init__(self):
+            self.calls = []
+
+        def list_products(self, *, page: int, page_size: int):
+            self.calls.append((page, page_size))
+            if page == 3:
+                return []
+            return [{"id": f"P-{page}", "codigo": f"SKU-{page}"}]
+
+    output_root = tmp_path / "odoo_migration"
+    output_root.mkdir(parents=True, exist_ok=True)
+    state_path = output_root / "products_fetch_resume_state.json"
+    items_path = output_root / "products_fetch_resume_items.jsonl"
+    state_path.write_text('{"last_successful_page": 2, "page_size": 200, "max_pages": 5}', encoding="utf-8")
+    items_path.write_text('{"id":"P-1","codigo":"SKU-1"}\n{"id":"P-2","codigo":"SKU-2"}\n', encoding="utf-8")
+
+    client = ResumeClient()
+    service = OdooMigrationService(client=client, output_root=output_root)
+
+    items, pages, _ = service._fetch_products(page_size=200, max_pages=5)
+
+    assert client.calls[0] == (3, 200)
+    assert items == [
+        {"id": "P-1", "codigo": "SKU-1"},
+        {"id": "P-2", "codigo": "SKU-2"},
+    ]
+    assert pages == 3
+    assert not state_path.exists()
+    assert not items_path.exists()

--- a/backend/tests/test_odoo_migration_fetch_resilience.py
+++ b/backend/tests/test_odoo_migration_fetch_resilience.py
@@ -95,3 +95,27 @@ def test_fetch_products_resumes_from_last_successful_page(tmp_path):
     assert pages == 3
     assert not state_path.exists()
     assert not items_path.exists()
+
+
+def test_fetch_products_page_does_not_change_page_size_on_retries(monkeypatch):
+    monkeypatch.setattr("app.odoo_migration.service.time.sleep", lambda _s: None)
+
+    class SameSizeOnlyClient:
+        def __init__(self):
+            self.calls = []
+
+        def list_products(self, *, page: int, page_size: int):
+            self.calls.append((page, page_size))
+            raise ContificoTransportError("network down")
+
+    client = SameSizeOnlyClient()
+    service = OdooMigrationService(client=client)
+
+    try:
+        service._fetch_products_page_with_fallback(page=4, page_size=200)
+    except ContificoTransportError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected ContificoTransportError")
+
+    assert client.calls == [(4, 200), (4, 200), (4, 200)]


### PR DESCRIPTION
### Motivation
- Improve robustness of product pagination against transient network and server errors when fetching from Contífico API.
- Allow long-running fetches to resume after interruptions to avoid re-downloading large result sets.
- Bump project version in `README.MD`.

### Description
- Added retry and exponential backoff configuration via `PRODUCT_PAGE_SERVER_RETRIES` and `PRODUCT_PAGE_RETRY_BACKOFF_BASE_SECONDS` in `OdooMigrationService` and added `time` import. 
- Enhanced `_fetch_products_page_with_fallback` to retry on `ContificoTransportError` and retry on retriable `ContificoAPIError` (HTTP 429, 5xx) with exponential backoff, and to re-raise non-retriable `ContificoAPIError` responses. 
- Implemented resume support for product fetches by persisting state and items to `products_fetch_resume_state.json` and `products_fetch_resume_items.jsonl` and added helpers `_load_fetch_resume_state`, `_save_fetch_resume_state`, and `_clear_fetch_resume_state`, and wired them into `_fetch_products`. 
- Added unit tests `backend/tests/test_odoo_migration_fetch_resilience.py` covering transport retries, API error retries, non-retriable API error propagation, and resume-from-last-successful-page behavior. 
- Updated `README.MD` version from `Versión 1.0.31` to `Versión 1.0.33`.

### Testing
- Added and executed unit tests in `backend/tests/test_odoo_migration_fetch_resilience.py` including `test_fetch_products_page_retries_transport_errors_then_succeeds`, `test_fetch_products_page_retries_server_errors_then_succeeds`, `test_fetch_products_page_raises_non_retriable_api_errors`, and `test_fetch_products_resumes_from_last_successful_page`.
- Tests mock `time.sleep` where needed and validate retry counts, effective page sizes, exception propagation, and resume state cleanup; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f812a3247c8332958db677e16bbcb0)