### PR TITLE
Add conservative pacing/retry controls to reduce Contífico v2 timeouts

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.31
+Versión 1.0.40
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 
@@ -47,12 +47,26 @@ SECRET_KEY="pon-aqui-una-clave-de-al-menos-32-caracteres"
 # Credenciales de Contífico
 CONTIFICO_API_KEY="tu-api-key"
 CONTIFICO_API_TOKEN="tu-api-token"
+# Opcional: usar API v2 solo para productos
+# CONTIFICO_PRODUCTS_API_BASE_URL="https://api.contifico.com/sistema/api/v2"
 EOF
 # También puedes exportarla directamente:
 export SECRET_KEY="pon-aqui-una-clave-de-al-menos-32-caracteres"
 # export CONTIFICO_API_KEY="tu-api-key"
 # export CONTIFICO_API_TOKEN="tu-api-token"
+# export CONTIFICO_PRODUCTS_API_BASE_URL="https://api.contifico.com/sistema/api/v2"
 ```
+
+Nota: en API v2 de productos la paginación documentada usa `page` (100 ítems por página),
+por lo que el cliente evita enviar `page_size/result_page/result_size` en ese modo.
+Además, la respuesta de v2 puede venir envuelta en `{count,next,previous,results}` y el
+cliente ya consume `results` automáticamente.
+
+Parámetros recomendados para mitigar throttling/timeouts en descargas largas:
+- `CONTIFICO_PRODUCTS_PAGE_DELAY_SECONDS` (default `1.0`)
+- `CONTIFICO_PRODUCTS_PAGE_RETRY_ATTEMPTS` (default `5`)
+- `CONTIFICO_PRODUCTS_PAGE_RETRY_BACKOFF_BASE_SECONDS` (default `1.5`)
+- `CONTIFICO_PRODUCTS_PAGE_RETRY_JITTER_SECONDS` (default `0.4`)
 
 #### Límites para la búsqueda de facturas en Contífico
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.40
+Versión 1.0.41
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 
@@ -67,6 +67,10 @@ Parámetros recomendados para mitigar throttling/timeouts en descargas largas:
 - `CONTIFICO_PRODUCTS_PAGE_RETRY_ATTEMPTS` (default `5`)
 - `CONTIFICO_PRODUCTS_PAGE_RETRY_BACKOFF_BASE_SECONDS` (default `1.5`)
 - `CONTIFICO_PRODUCTS_PAGE_RETRY_JITTER_SECONDS` (default `0.4`)
+
+En modo API v2 también se registra en el resumen el `count` reportado por Contífico como
+`expected_min_items_from_api`, para comparar rápidamente si la corrida trajo un mínimo
+coherente de ítems (`fetched_items_meet_expected_min`).
 
 #### Límites para la búsqueda de facturas en Contífico
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -55,10 +55,38 @@ class Settings(BaseSettings):
         default="https://api.contifico.com/sistema/api/v1",
         description="URL base para la API de Contífico.",
     )
+    contifico_products_api_base_url: str | None = Field(
+        default=None,
+        description=(
+            "URL base opcional para catálogo de productos (por ejemplo API v2). "
+            "Si no se define, se usa contifico_api_base_url."
+        ),
+    )
     contifico_timeout_seconds: float = Field(
         default=30.0,
         ge=1.0,
         description="Tiempo máximo de espera (en segundos) para peticiones a Contífico.",
+    )
+    contifico_products_page_delay_seconds: float = Field(
+        default=1.0,
+        ge=0.0,
+        description="Pausa entre páginas al descargar productos (útil para evitar throttling).",
+    )
+    contifico_products_page_retry_attempts: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Intentos máximos por página de productos ante errores transitorios.",
+    )
+    contifico_products_page_retry_backoff_base_seconds: float = Field(
+        default=1.5,
+        ge=0.1,
+        description="Base del backoff exponencial para reintentos de páginas de productos.",
+    )
+    contifico_products_page_retry_jitter_seconds: float = Field(
+        default=0.4,
+        ge=0.0,
+        description="Jitter aleatorio agregado al backoff de reintentos de páginas.",
     )
     contifico_invoice_cache_path: str | None = Field(
         default="./data/contifico_invoice_cache.json",

--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -136,6 +136,7 @@ class ContificoClient:
             if invoice_catalog_stop_on_first_match is None
             else bool(invoice_catalog_stop_on_first_match)
         )
+        self.last_products_total_count: int | None = None
 
         self._load_persistent_cache()
 
@@ -596,8 +597,11 @@ class ContificoClient:
         if data is None:
             return []
         if isinstance(data, list):
+            self.last_products_total_count = None
             return data
         if isinstance(data, dict):
+            total = data.get("count")
+            self.last_products_total_count = int(total) if isinstance(total, int) else None
             results = data.get("results")
             if isinstance(results, list):
                 return results

--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -76,6 +76,7 @@ class ContificoClient:
     }
     REQUEST_MAX_RETRIES = 3
     REQUEST_RETRY_BACKOFF_BASE = 0.8
+    REQUEST_TIMEOUT_RETRY_BACKOFF_BASE = 2.0
 
     def __init__(
         self,
@@ -83,6 +84,7 @@ class ContificoClient:
         api_token: str,
         *,
         base_url: str | None = None,
+        products_base_url: str | None = None,
         timeout: float = 30.0,
         transport: httpx.BaseTransport | None = None,
         invoice_cache_path: str | Path | None = None,
@@ -102,6 +104,7 @@ class ContificoClient:
         self.api_key = api_key.strip()
         self.api_token = api_token.strip()
         self.base_url = (base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        self.products_base_url = (products_base_url or self.base_url).rstrip("/")
         self.timeout = timeout
         self._transport = transport
         self._cache_path: Path | None = (
@@ -141,10 +144,12 @@ class ContificoClient:
         method: str,
         endpoint: str,
         *,
+        base_url: str | None = None,
         params: Optional[Dict[str, Any]] = None,
         json: Optional[Any] = None,
     ) -> Any:
-        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        request_base_url = (base_url or self.base_url).rstrip("/")
+        url = f"{request_base_url}/{endpoint.lstrip('/')}"
         headers = {
             "Authorization": self.api_key,
             "X-Api-Token": self.api_token,
@@ -183,7 +188,7 @@ class ContificoClient:
                     raise ContificoTransportError(
                         f"Timeout leyendo respuesta de Contífico tras {attempts} intentos: {exc}"
                     ) from exc
-                backoff = self.REQUEST_RETRY_BACKOFF_BASE * (2 ** (attempts - 1))
+                backoff = self.REQUEST_TIMEOUT_RETRY_BACKOFF_BASE * (2 ** (attempts - 1))
                 logger.warning(
                     "Contifico read timeout %s %s intento=%s/%s. Reintentando en %.2fs",
                     method, url, attempts, self.REQUEST_MAX_RETRIES, backoff,
@@ -566,23 +571,36 @@ class ContificoClient:
     ) -> Iterable[Dict[str, Any]]:
         """Devuelve un lote de productos desde Contífico."""
 
-        params: Dict[str, Any] = {
-            "page": page,
-            "page_size": page_size,
-            # Algunos entornos aún utilizan los parámetros históricos de paginación.
-            "result_page": page,
-            "result_size": page_size,
-        }
+        is_products_v2 = "/api/v2" in self.products_base_url.lower()
+        params: Dict[str, Any] = {"page": page}
+        if not is_products_v2:
+            params.update(
+                {
+                    "page_size": page_size,
+                    # Algunos entornos aún utilizan los parámetros históricos de paginación.
+                    "result_page": page,
+                    "result_size": page_size,
+                }
+            )
         if category_id is not None:
             category_value = str(category_id).strip()
             if not category_value:
                 raise ValueError("El identificador de la categoría no puede estar vacío.")
             params["categoria_id"] = category_value
-        data = self._request("GET", "producto/", params=params)
+        data = self._request(
+            "GET",
+            "producto/",
+            base_url=self.products_base_url,
+            params=params,
+        )
         if data is None:
             return []
         if isinstance(data, list):
             return data
+        if isinstance(data, dict):
+            results = data.get("results")
+            if isinstance(results, list):
+                return results
         raise ContificoAPIError(
             status_code=200,
             detail="El formato de respuesta para productos no es el esperado.",

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -46,6 +46,7 @@ def get_contifico_client() -> ContificoClient:
             settings.contifico_api_key,
             settings.contifico_api_token,
             base_url=settings.contifico_api_base_url,
+            products_base_url=settings.contifico_products_api_base_url,
             timeout=settings.contifico_timeout_seconds,
             invoice_cache_path=settings.contifico_invoice_cache_path,
             invoice_catalog_page_size=settings.contifico_invoice_catalog_page_size,

--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -10,6 +10,7 @@ from fastapi.responses import FileResponse
 
 from ..contifico import ContificoClient
 from ..dependencies import get_contifico_client
+from ..config import get_settings
 from .rules import CATEGORY_ALIASES
 from .service import OdooMigrationService
 from .stock_worker import StockWorker
@@ -53,6 +54,17 @@ def _build_files(run_id: str) -> dict[str, str]:
         "debug_log": f"/odoo-migration/runs/{run_id}/files/debug.log",
         "raw_log": f"/odoo-migration/runs/{run_id}/files/raw.log",
     }
+
+
+def _build_service(contifico_client: ContificoClient) -> OdooMigrationService:
+    settings = get_settings()
+    return OdooMigrationService(
+        contifico_client,
+        page_delay_seconds=settings.contifico_products_page_delay_seconds,
+        page_retry_attempts=settings.contifico_products_page_retry_attempts,
+        page_retry_backoff_base_seconds=settings.contifico_products_page_retry_backoff_base_seconds,
+        page_retry_jitter_seconds=settings.contifico_products_page_retry_jitter_seconds,
+    )
 
 
 def _snapshot_path() -> Path:
@@ -152,7 +164,7 @@ def export_products_stock(
     include_brand_color_attributes: bool = Query(default=False),
     contifico_client: ContificoClient = Depends(get_contifico_client),
 ):
-    service = OdooMigrationService(contifico_client)
+    service = _build_service(contifico_client)
     output = service.generate_products_and_stock_csv(
         page_size=page_size,
         max_pages=max_pages,
@@ -198,7 +210,7 @@ async def process_raw_upload(
             products.append(payload)
     if not products:
         raise HTTPException(status_code=400, detail="No se detectaron productos válidos en el archivo.")
-    service = OdooMigrationService(contifico_client)
+    service = _build_service(contifico_client)
     output = service.generate_products_and_stock_csv_from_items(
         products=products,
         export_stock=export_stock,
@@ -233,7 +245,7 @@ def start_export_job(
 
     def worker() -> None:
         try:
-            service = OdooMigrationService(contifico_client)
+            service = _build_service(contifico_client)
             output = service.generate_products_and_stock_csv(
                 page_size=page_size,
                 max_pages=max_pages,

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -61,9 +61,10 @@ class OdooMigrationService:
         product_csv=folder/'product_product.csv'; stock_csv=folder/'initial_stock.csv'; stock_quant_csv=folder/'stock_quant.csv'; errors_csv=folder/'migration_errors.csv'; mapping_csv=folder/'mapping_report.csv'; excluded_zero_csv=folder/'excluded_zero_stock.csv'; debug_log=folder/'debug.log'; raw_log=folder/'raw.log'
         snapshot_path = folder / 'products_snapshot.jsonl'; state_path = folder / 'stock_state.json'
         debug_lines=[f'start={datetime.utcnow().isoformat()}Z',f'page_size={page_size}',f'max_pages={max_pages}',f'export_stock={export_stock}']; raw_lines=[]
-        products,pages_fetched,hit_max_pages=self._fetch_products(page_size=page_size,max_pages=max_pages,progress_callback=progress_callback,debug_lines=debug_lines,raw_lines=raw_lines)
+        products,pages_fetched,hit_max_pages,expected_min_items=self._fetch_products(page_size=page_size,max_pages=max_pages,progress_callback=progress_callback,debug_lines=debug_lines,raw_lines=raw_lines)
         return self._generate_from_products(
             products=products, folder=folder, pages_fetched=pages_fetched, hit_max_pages=hit_max_pages,
+            expected_min_items=expected_min_items,
             export_stock=export_stock, include_additional_attributes=include_additional_attributes,
             progress_callback=progress_callback, debug_lines=debug_lines, raw_lines=raw_lines,
         )
@@ -73,12 +74,12 @@ class OdooMigrationService:
         ts = datetime.utcnow().strftime('%Y%m%d_%H%M%S'); folder = self.output_root / ts; folder.mkdir(parents=True, exist_ok=True)
         debug_lines=[f'start={datetime.utcnow().isoformat()}Z',f'source=uploaded_raw_json',f'export_stock={export_stock}']; raw_lines=[json.dumps({"uploaded_items": len(products)})]
         return self._generate_from_products(
-            products=products, folder=folder, pages_fetched=0, hit_max_pages=False,
+            products=products, folder=folder, pages_fetched=0, hit_max_pages=False, expected_min_items=None,
             export_stock=export_stock, include_additional_attributes=include_additional_attributes,
             progress_callback=progress_callback, debug_lines=debug_lines, raw_lines=raw_lines,
         )
 
-    def _generate_from_products(self, *, products: list[dict[str, Any]], folder: Path, pages_fetched: int, hit_max_pages: bool, export_stock: bool, include_additional_attributes: bool, progress_callback=None, debug_lines=None, raw_lines=None) -> MigrationOutput:
+    def _generate_from_products(self, *, products: list[dict[str, Any]], folder: Path, pages_fetched: int, hit_max_pages: bool, expected_min_items: int | None, export_stock: bool, include_additional_attributes: bool, progress_callback=None, debug_lines=None, raw_lines=None) -> MigrationOutput:
         product_csv=folder/'product_product.csv'; stock_csv=folder/'initial_stock.csv'; stock_quant_csv=folder/'stock_quant.csv'; errors_csv=folder/'migration_errors.csv'; mapping_csv=folder/'mapping_report.csv'; excluded_zero_csv=folder/'excluded_zero_stock.csv'; debug_log=folder/'debug.log'; raw_log=folder/'raw.log'
         snapshot_path = folder / 'products_snapshot.jsonl'; state_path = folder / 'stock_state.json'
         phase1 = self._phase1_prepare_products(products=products, folder=folder, snapshot_path=snapshot_path, errors_csv=errors_csv, mapping_csv=mapping_csv, excluded_zero_csv=excluded_zero_csv, product_csv=product_csv, include_additional_attributes=include_additional_attributes, export_stock=export_stock, progress_callback=progress_callback)
@@ -97,7 +98,7 @@ class OdooMigrationService:
         counts = phase1['counts']
         debug_lines += [f"summary={json.dumps(counts)}", f"pages_fetched={pages_fetched}", f"hit_max_pages={hit_max_pages}", f"snapshot={snapshot_path.name}", f"state={state_path.name}"]
         debug_log.write_text("\n".join(debug_lines)+"\n", encoding='utf-8'); raw_log.write_text("\n".join(raw_lines)+"\n", encoding='utf-8')
-        summary={"total_products":len(phase1['prows']),"total_skus_unicos_product_product":len({r.get('Internal Reference') for r in phase1['prows']}),"total_lineas_initial_stock":0,"total_lineas_stock_quant":0,"total_skus_stock_match_producto":0,"total_skus_stock_no_match_producto":0,"total_ubicaciones_mapeadas":0,"total_ubicaciones_no_mapeadas":0,"total_productos_excluidos_stock_0":len(phase1['zrows']),"total_errores_reales":len(phase1['erows']),"stock_export_enabled": export_stock, "phase_1_completed": True, "phase_2_completed": export_stock, "include_additional_attributes": include_additional_attributes, "include_brand_color_attributes": include_additional_attributes}
+        summary={"total_products":len(phase1['prows']),"total_skus_unicos_product_product":len({r.get('Internal Reference') for r in phase1['prows']}),"total_lineas_initial_stock":0,"total_lineas_stock_quant":0,"total_skus_stock_match_producto":0,"total_skus_stock_no_match_producto":0,"total_ubicaciones_mapeadas":0,"total_ubicaciones_no_mapeadas":0,"total_productos_excluidos_stock_0":len(phase1['zrows']),"total_errores_reales":len(phase1['erows']),"stock_export_enabled": export_stock, "phase_1_completed": True, "phase_2_completed": export_stock, "include_additional_attributes": include_additional_attributes, "include_brand_color_attributes": include_additional_attributes, "expected_min_items_from_api": expected_min_items, "fetched_items_meet_expected_min": (len(products) >= expected_min_items) if expected_min_items is not None else None}
         if export_stock:
             stock_rows = self._read_csv_rows(stock_csv)
             stock_quant_rows = self._read_csv_rows(stock_quant_csv)
@@ -350,6 +351,7 @@ class OdooMigrationService:
         )
         pages = start_page - 1
         products_v2_mode = "/api/v2" in str(getattr(self.client, "products_base_url", "")).lower()
+        expected_min_items = None
         for page in range(start_page, max_pages + 1):
             if progress_callback: progress_callback({"stage":"fetching","page":page,"max_pages":max_pages,"found_items":len(items)})
             batch, effective_page_size = self._fetch_products_page_with_fallback(page=page, page_size=page_size); pages=page
@@ -358,6 +360,9 @@ class OdooMigrationService:
             if not batch: break
             page_items = [b for b in batch if isinstance(b,dict)]
             items.extend(page_items)
+            api_total = getattr(self.client, "last_products_total_count", None)
+            if isinstance(api_total, int) and api_total > 0:
+                expected_min_items = api_total
             self._save_fetch_resume_state(
                 resume_state_path=resume_state_path,
                 resume_items_path=resume_items_path,
@@ -372,7 +377,7 @@ class OdooMigrationService:
             if self.page_delay_seconds > 0:
                 time.sleep(self.page_delay_seconds)
         self._clear_fetch_resume_state(resume_state_path=resume_state_path, resume_items_path=resume_items_path)
-        return items, pages, pages>=max_pages
+        return items, pages, pages>=max_pages, expected_min_items
 
     def _load_fetch_resume_state(self, *, resume_state_path: Path, resume_items_path: Path, page_size: int, max_pages: int) -> tuple[list[dict[str, Any]], int]:
         if not resume_state_path.exists() or not resume_items_path.exists():

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import csv
+import random
 import re
 from dataclasses import dataclass
 from datetime import datetime
@@ -7,7 +8,9 @@ from pathlib import Path
 from typing import Any, Callable
 import json
 
-from ..contifico import ContificoClient, ContificoTransportError
+import time
+
+from ..contifico import ContificoAPIError, ContificoClient, ContificoTransportError
 from .rules import (
     detect_brand, detect_color, detect_category, calculate_total_stock, should_exclude_zero_stock,
     parse_shirt_sku, parse_suit_sku, parse_blazer_sku, parse_tie_sku, parse_bowtie_sku, parse_fajin_sku,
@@ -39,8 +42,15 @@ class MigrationOutput:
 
 
 class OdooMigrationService:
-    def __init__(self, client: ContificoClient, output_root: str | Path = "backend/data/odoo_migration"):
+    PRODUCT_PAGE_SERVER_RETRIES = 3
+    PRODUCT_PAGE_RETRY_BACKOFF_BASE_SECONDS = 0.8
+
+    def __init__(self, client: ContificoClient, output_root: str | Path = "backend/data/odoo_migration", *, page_delay_seconds: float = 1.0, page_retry_attempts: int | None = None, page_retry_backoff_base_seconds: float | None = None, page_retry_jitter_seconds: float = 0.4):
         self.client = client; self.output_root = Path(output_root)
+        self.page_delay_seconds = max(0.0, float(page_delay_seconds))
+        self.page_retry_attempts = int(page_retry_attempts or self.PRODUCT_PAGE_SERVER_RETRIES)
+        self.page_retry_backoff_base_seconds = float(page_retry_backoff_base_seconds or self.PRODUCT_PAGE_RETRY_BACKOFF_BASE_SECONDS)
+        self.page_retry_jitter_seconds = max(0.0, float(page_retry_jitter_seconds))
         self._warehouse_by_id = {w.get("id"): w for w in WAREHOUSE_CATALOG if w.get("id")}
         self._warehouse_by_code = {str(w.get("codigo","")).upper(): w for w in WAREHOUSE_CATALOG}
         self._warehouse_by_name = {str(w.get("nombre","")).upper(): w for w in WAREHOUSE_CATALOG}
@@ -330,33 +340,95 @@ class OdooMigrationService:
         return [c.strip() for c in line.split(',') if c.strip()]
 
     def _fetch_products(self, *, page_size:int, max_pages:int, progress_callback=None, debug_lines=None, raw_lines=None):
-        items=[]; pages=0
-        for page in range(1,max_pages+1):
+        resume_state_path = self.output_root / "products_fetch_resume_state.json"
+        resume_items_path = self.output_root / "products_fetch_resume_items.jsonl"
+        items, start_page = self._load_fetch_resume_state(
+            resume_state_path=resume_state_path,
+            resume_items_path=resume_items_path,
+            page_size=page_size,
+            max_pages=max_pages,
+        )
+        pages = start_page - 1
+        products_v2_mode = "/api/v2" in str(getattr(self.client, "products_base_url", "")).lower()
+        for page in range(start_page, max_pages + 1):
             if progress_callback: progress_callback({"stage":"fetching","page":page,"max_pages":max_pages,"found_items":len(items)})
             batch, effective_page_size = self._fetch_products_page_with_fallback(page=page, page_size=page_size); pages=page
             if debug_lines is not None: debug_lines.append(f"fetch page={page} items={len(batch)}")
             if raw_lines is not None: raw_lines.append(json.dumps({"page":page,"response":batch}, ensure_ascii=False))
             if not batch: break
-            items.extend([b for b in batch if isinstance(b,dict)])
+            page_items = [b for b in batch if isinstance(b,dict)]
+            items.extend(page_items)
+            self._save_fetch_resume_state(
+                resume_state_path=resume_state_path,
+                resume_items_path=resume_items_path,
+                page=page,
+                page_size=page_size,
+                max_pages=max_pages,
+                page_items=page_items,
+            )
             if progress_callback: progress_callback({"stage":"fetched_page","page":page,"fetched":len(batch),"found_items":len(items)})
-            if len(batch)<effective_page_size: break
+            if (not products_v2_mode) and len(batch) < effective_page_size:
+                break
+            if self.page_delay_seconds > 0:
+                time.sleep(self.page_delay_seconds)
+        self._clear_fetch_resume_state(resume_state_path=resume_state_path, resume_items_path=resume_items_path)
         return items, pages, pages>=max_pages
 
+    def _load_fetch_resume_state(self, *, resume_state_path: Path, resume_items_path: Path, page_size: int, max_pages: int) -> tuple[list[dict[str, Any]], int]:
+        if not resume_state_path.exists() or not resume_items_path.exists():
+            return [], 1
+        try:
+            state = json.loads(resume_state_path.read_text(encoding="utf-8"))
+            if int(state.get("page_size") or 0) != int(page_size) or int(state.get("max_pages") or 0) != int(max_pages):
+                return [], 1
+            last_page = int(state.get("last_successful_page") or 0)
+            items = []
+            for line in resume_items_path.read_text(encoding="utf-8").splitlines():
+                payload = json.loads(line)
+                if isinstance(payload, dict):
+                    items.append(payload)
+            return items, max(1, last_page + 1)
+        except Exception:
+            return [], 1
+
+    def _save_fetch_resume_state(self, *, resume_state_path: Path, resume_items_path: Path, page: int, page_size: int, max_pages: int, page_items: list[dict[str, Any]]) -> None:
+        resume_state_path.parent.mkdir(parents=True, exist_ok=True)
+        with resume_items_path.open("a", encoding="utf-8") as fh:
+            for item in page_items:
+                fh.write(json.dumps(item, ensure_ascii=False) + "\n")
+        resume_state_path.write_text(
+            json.dumps({"last_successful_page": page, "page_size": page_size, "max_pages": max_pages}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _clear_fetch_resume_state(*, resume_state_path: Path, resume_items_path: Path) -> None:
+        if resume_state_path.exists():
+            resume_state_path.unlink()
+        if resume_items_path.exists():
+            resume_items_path.unlink()
+
     def _fetch_products_page_with_fallback(self, *, page: int, page_size: int) -> tuple[list[dict[str, Any]], int]:
+        # Importante: no degradar page_size entre reintentos porque el número de página
+        # representa offsets distintos para cada tamaño y puede crear huecos/duplicados.
         sizes = [page_size]
-        if page_size > 100:
-            sizes.extend([100, 50, 25])
-        elif page_size > 50:
-            sizes.extend([50, 25])
-        elif page_size > 25:
-            sizes.append(25)
         last_exc: Exception | None = None
         for size in sizes:
-            try:
-                return list(self.client.list_products(page=page, page_size=size)), size
-            except ContificoTransportError as exc:
-                last_exc = exc
-                continue
+            for attempt in range(1, self.page_retry_attempts + 1):
+                try:
+                    return list(self.client.list_products(page=page, page_size=size)), size
+                except ContificoTransportError as exc:
+                    last_exc = exc
+                except ContificoAPIError as exc:
+                    if exc.status_code not in {429, 500, 502, 503, 504}:
+                        raise
+                    last_exc = exc
+
+                if attempt < self.page_retry_attempts:
+                    base = self.page_retry_backoff_base_seconds * (2 ** (attempt - 1))
+                    jitter = random.uniform(0.0, self.page_retry_jitter_seconds) if self.page_retry_jitter_seconds > 0 else 0.0
+                    time.sleep(base + jitter)
+            continue
         if last_exc:
             raise last_exc
         return [], page_size

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -1776,3 +1776,88 @@ def test_fetch_customer_by_document_falls_back_between_variants(monkeypatch) -> 
 
     assert result == {"identificacion": "0919957423001", "nombre": "Cliente"}
     assert attempts == ["0919957423", "0919957423001"]
+
+
+def test_list_products_uses_products_base_url_when_provided() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json=[])
+
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com/v1",
+        products_base_url="https://api.example.com/v2",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert list(client.list_products(page=1, page_size=5)) == []
+    assert str(captured["url"]).startswith("https://api.example.com/v2/producto/")
+
+
+def test_list_products_falls_back_to_main_base_url_when_products_base_url_missing() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json=[])
+
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com/v1",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert list(client.list_products(page=1, page_size=5)) == []
+    assert str(captured["url"]).startswith("https://api.example.com/v1/producto/")
+
+
+def test_list_products_v2_uses_only_page_pagination_params() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(dict(request.url.params))
+        return httpx.Response(200, json=[])
+
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com/v1",
+        products_base_url="https://api.example.com/api/v2",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert list(client.list_products(page=3, page_size=250, category_id="CAT-9")) == []
+    assert captured.get("page") == "3"
+    assert "page_size" not in captured
+    assert "result_page" not in captured
+    assert "result_size" not in captured
+    assert captured.get("categoria_id") == "CAT-9"
+
+
+def test_list_products_accepts_paginated_results_payload() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "count": 24605,
+                "next": "https://api.contifico.com/sistema/api/v2/producto/?page=2",
+                "previous": None,
+                "results": [{"id": "A1", "codigo": "SKU-1", "nombre": "Producto"}],
+            },
+        )
+
+    client = ContificoClient(
+        "key123",
+        "token-xyz",
+        base_url="https://api.example.com/v1",
+        products_base_url="https://api.example.com/api/v2",
+        transport=httpx.MockTransport(handler),
+    )
+
+    products = list(client.list_products(page=1, page_size=100))
+
+    assert products == [{"id": "A1", "codigo": "SKU-1", "nombre": "Producto"}]

--- a/backend/tests/test_contifico_request_timeouts.py
+++ b/backend/tests/test_contifico_request_timeouts.py
@@ -1,0 +1,49 @@
+import httpx
+
+from app.contifico import ContificoClient
+
+
+class _FakeResponse:
+    status_code = 200
+    content = b"[]"
+    text = "[]"
+    headers = {}
+
+    def json(self):
+        return []
+
+
+class _FakeHttpClient:
+    calls = 0
+
+    def __init__(self, **_kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def request(self, *_args, **_kwargs):
+        self.__class__.calls += 1
+        if self.__class__.calls < 3:
+            raise httpx.ReadTimeout("timeout")
+        return _FakeResponse()
+
+
+def test_request_uses_longer_backoff_for_timeouts(monkeypatch):
+    sleep_calls = []
+
+    monkeypatch.setattr("app.contifico.time.sleep", lambda s: sleep_calls.append(s))
+    monkeypatch.setattr("app.contifico.httpx.Client", _FakeHttpClient)
+
+    client = ContificoClient("key123", "token-xyz", base_url="https://api.example.com")
+
+    data = client.list_products(page=1, page_size=5)
+
+    assert data == []
+    assert sleep_calls == [
+        ContificoClient.REQUEST_TIMEOUT_RETRY_BACKOFF_BASE,
+        ContificoClient.REQUEST_TIMEOUT_RETRY_BACKOFF_BASE * 2,
+    ]

--- a/backend/tests/test_odoo_migration_fetch_resilience.py
+++ b/backend/tests/test_odoo_migration_fetch_resilience.py
@@ -1,0 +1,180 @@
+from app.contifico import ContificoAPIError, ContificoTransportError
+from app.odoo_migration.service import OdooMigrationService
+
+
+class StubClient:
+    def __init__(self):
+        self.calls = []
+
+    def list_products(self, *, page: int, page_size: int):
+        self.calls.append((page, page_size))
+        if len(self.calls) < 3:
+            raise ContificoTransportError("transient network error")
+        return [{"id": "P-1", "codigo": "SKU-1"}]
+
+
+class StubClientApiError:
+    def __init__(self):
+        self.calls = []
+
+    def list_products(self, *, page: int, page_size: int):
+        self.calls.append((page, page_size))
+        if len(self.calls) < 2:
+            raise ContificoAPIError(503, "service unavailable")
+        return [{"id": "P-2", "codigo": "SKU-2"}]
+
+
+class StubClientNonRetriable:
+    def list_products(self, *, page: int, page_size: int):
+        raise ContificoAPIError(400, "bad request")
+
+
+def test_fetch_products_page_retries_transport_errors_then_succeeds(monkeypatch):
+    monkeypatch.setattr("app.odoo_migration.service.time.sleep", lambda _s: None)
+    client = StubClient()
+    service = OdooMigrationService(client=client)
+
+    rows, effective_size = service._fetch_products_page_with_fallback(page=1, page_size=200)
+
+    assert rows == [{"id": "P-1", "codigo": "SKU-1"}]
+    assert effective_size == 200
+    assert client.calls == [(1, 200), (1, 200), (1, 200)]
+
+
+def test_fetch_products_page_retries_server_errors_then_succeeds(monkeypatch):
+    monkeypatch.setattr("app.odoo_migration.service.time.sleep", lambda _s: None)
+    client = StubClientApiError()
+    service = OdooMigrationService(client=client)
+
+    rows, effective_size = service._fetch_products_page_with_fallback(page=2, page_size=120)
+
+    assert rows == [{"id": "P-2", "codigo": "SKU-2"}]
+    assert effective_size == 120
+    assert client.calls == [(2, 120), (2, 120)]
+
+
+def test_fetch_products_page_raises_non_retriable_api_errors():
+    service = OdooMigrationService(client=StubClientNonRetriable())
+
+    try:
+        service._fetch_products_page_with_fallback(page=1, page_size=200)
+    except ContificoAPIError as exc:
+        assert exc.status_code == 400
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected ContificoAPIError")
+
+
+def test_fetch_products_resumes_from_last_successful_page(tmp_path):
+    class ResumeClient:
+        def __init__(self):
+            self.calls = []
+
+        def list_products(self, *, page: int, page_size: int):
+            self.calls.append((page, page_size))
+            if page == 3:
+                return []
+            return [{"id": f"P-{page}", "codigo": f"SKU-{page}"}]
+
+    output_root = tmp_path / "odoo_migration"
+    output_root.mkdir(parents=True, exist_ok=True)
+    state_path = output_root / "products_fetch_resume_state.json"
+    items_path = output_root / "products_fetch_resume_items.jsonl"
+    state_path.write_text('{"last_successful_page": 2, "page_size": 200, "max_pages": 5}', encoding="utf-8")
+    items_path.write_text('{"id":"P-1","codigo":"SKU-1"}\n{"id":"P-2","codigo":"SKU-2"}\n', encoding="utf-8")
+
+    client = ResumeClient()
+    service = OdooMigrationService(client=client, output_root=output_root)
+
+    items, pages, _ = service._fetch_products(page_size=200, max_pages=5)
+
+    assert client.calls[0] == (3, 200)
+    assert items == [
+        {"id": "P-1", "codigo": "SKU-1"},
+        {"id": "P-2", "codigo": "SKU-2"},
+    ]
+    assert pages == 3
+    assert not state_path.exists()
+    assert not items_path.exists()
+
+
+def test_fetch_products_page_does_not_change_page_size_on_retries(monkeypatch):
+    monkeypatch.setattr("app.odoo_migration.service.time.sleep", lambda _s: None)
+
+    class SameSizeOnlyClient:
+        def __init__(self):
+            self.calls = []
+
+        def list_products(self, *, page: int, page_size: int):
+            self.calls.append((page, page_size))
+            raise ContificoTransportError("network down")
+
+    client = SameSizeOnlyClient()
+    service = OdooMigrationService(client=client)
+
+    try:
+        service._fetch_products_page_with_fallback(page=4, page_size=200)
+    except ContificoTransportError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected ContificoTransportError")
+
+    assert client.calls == [(4, 200), (4, 200), (4, 200)]
+
+
+def test_fetch_products_v2_does_not_stop_on_first_short_page(tmp_path):
+    class V2Client:
+        products_base_url = "https://api.contifico.com/sistema/api/v2"
+
+        def __init__(self):
+            self.calls = []
+
+        def list_products(self, *, page: int, page_size: int):
+            self.calls.append((page, page_size))
+            if page == 1:
+                return [{"id": "P-1"}] * 100
+            if page == 2:
+                return [{"id": "P-2"}] * 100
+            return []
+
+    service = OdooMigrationService(client=V2Client(), output_root=tmp_path / "odoo_migration")
+
+    items, pages, hit_max = service._fetch_products(page_size=200, max_pages=10)
+
+    assert len(items) == 200
+    assert pages == 3
+    assert hit_max is False
+
+
+def test_fetch_products_uses_configured_page_delay_and_retry_backoff(monkeypatch, tmp_path):
+    sleep_calls = []
+    monkeypatch.setattr("app.odoo_migration.service.time.sleep", lambda s: sleep_calls.append(s))
+    monkeypatch.setattr("app.odoo_migration.service.random.uniform", lambda _a, _b: 0.0)
+
+    class SlowClient:
+        def __init__(self):
+            self.calls = 0
+            self.products_base_url = "https://api.contifico.com/sistema/api/v2"
+
+        def list_products(self, *, page: int, page_size: int):
+            self.calls += 1
+            if self.calls == 1:
+                raise ContificoTransportError("timeout")
+            if page == 1:
+                return [{"id": "P-1"}]
+            return []
+
+    service = OdooMigrationService(
+        client=SlowClient(),
+        output_root=tmp_path / "odoo_migration",
+        page_delay_seconds=1.2,
+        page_retry_attempts=4,
+        page_retry_backoff_base_seconds=2.0,
+        page_retry_jitter_seconds=0.5,
+    )
+
+    items, pages, _ = service._fetch_products(page_size=200, max_pages=3)
+
+    assert items == [{"id": "P-1"}]
+    assert pages == 2
+    assert 2.0 in sleep_calls  # retry backoff
+    assert 1.2 in sleep_calls  # inter-page pacing

--- a/backend/tests/test_odoo_migration_fetch_resilience.py
+++ b/backend/tests/test_odoo_migration_fetch_resilience.py
@@ -85,7 +85,7 @@ def test_fetch_products_resumes_from_last_successful_page(tmp_path):
     client = ResumeClient()
     service = OdooMigrationService(client=client, output_root=output_root)
 
-    items, pages, _ = service._fetch_products(page_size=200, max_pages=5)
+    items, pages, _, expected_min = service._fetch_products(page_size=200, max_pages=5)
 
     assert client.calls[0] == (3, 200)
     assert items == [
@@ -93,6 +93,7 @@ def test_fetch_products_resumes_from_last_successful_page(tmp_path):
         {"id": "P-2", "codigo": "SKU-2"},
     ]
     assert pages == 3
+    assert expected_min is None
     assert not state_path.exists()
     assert not items_path.exists()
 
@@ -138,11 +139,12 @@ def test_fetch_products_v2_does_not_stop_on_first_short_page(tmp_path):
 
     service = OdooMigrationService(client=V2Client(), output_root=tmp_path / "odoo_migration")
 
-    items, pages, hit_max = service._fetch_products(page_size=200, max_pages=10)
+    items, pages, hit_max, expected_min = service._fetch_products(page_size=200, max_pages=10)
 
     assert len(items) == 200
     assert pages == 3
     assert hit_max is False
+    assert expected_min is None
 
 
 def test_fetch_products_uses_configured_page_delay_and_retry_backoff(monkeypatch, tmp_path):
@@ -172,9 +174,32 @@ def test_fetch_products_uses_configured_page_delay_and_retry_backoff(monkeypatch
         page_retry_jitter_seconds=0.5,
     )
 
-    items, pages, _ = service._fetch_products(page_size=200, max_pages=3)
+    items, pages, _, expected_min = service._fetch_products(page_size=200, max_pages=3)
 
     assert items == [{"id": "P-1"}]
     assert pages == 2
+    assert expected_min is None
     assert 2.0 in sleep_calls  # retry backoff
     assert 1.2 in sleep_calls  # inter-page pacing
+
+
+def test_fetch_products_tracks_expected_total_from_v2_count(tmp_path):
+    class V2CountClient:
+        products_base_url = "https://api.contifico.com/sistema/api/v2"
+
+        def __init__(self):
+            self.last_products_total_count = None
+
+        def list_products(self, *, page: int, page_size: int):
+            self.last_products_total_count = 24605
+            if page <= 2:
+                return [{"id": f"P-{page}-{i}"} for i in range(100)]
+            return []
+
+    service = OdooMigrationService(client=V2CountClient(), output_root=tmp_path / "odoo_migration")
+    items, pages, hit_max, expected_min = service._fetch_products(page_size=200, max_pages=10)
+
+    assert len(items) == 200
+    assert pages == 3
+    assert hit_max is False
+    assert expected_min == 24605


### PR DESCRIPTION
## Summary
Implemented the full stability set requested for long-running product fetches (Phase 1), focused on reducing throttling/timeouts without proxies.

### What was added
- New configurable controls in settings (`.env`):
  - `CONTIFICO_PRODUCTS_PAGE_DELAY_SECONDS` (default `1.0`)
  - `CONTIFICO_PRODUCTS_PAGE_RETRY_ATTEMPTS` (default `5`)
  - `CONTIFICO_PRODUCTS_PAGE_RETRY_BACKOFF_BASE_SECONDS` (default `1.5`)
  - `CONTIFICO_PRODUCTS_PAGE_RETRY_JITTER_SECONDS` (default `0.4`)
- `OdooMigrationService` now supports:
  - inter-page pacing delay,
  - configurable retry attempts,
  - exponential backoff + jitter for transient page failures.
- Router now builds `OdooMigrationService` using those settings (applies to sync export, async export-jobs, and raw upload processing path where service is instantiated).
- Existing v2 pagination behavior remains intact (continue until empty page / max_pages).

### Why
This is the conservative mode for API stability: slower but steadier, which is typically better when the provider silently throttles under load.

## Docs / Version
- Bumped README version to `1.0.40`.
- Documented the new environment knobs and defaults.

## Testing
- `cd backend && PYTHONPATH=. pytest -q tests/test_odoo_migration_fetch_resilience.py tests/test_contifico_client.py -k "list_products or configured_page_delay"`
- Result: all selected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f812a3247c8332958db677e16bbcb0)