### PR TITLE
Interpretar 400 "Pagina fuera del rango" de Contífico como fin de paginación

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -287,6 +287,7 @@ Si necesitas cambiar la URL del backend para el frontend, define `API_BASE_URL` 
 
 ## Historial de cambios
 
+- **1.0.32 (2026-05-04)**: El fetch paginado de productos ahora interpreta el 400 de Contífico `{"code":"400","error":"Pagina fuera del rango"}` como fin de paginación (no como error fatal), evitando cancelar corridas cuando se solicita una página inexistente.
 - **1.0.31 (2026-05-04)**: Se corrigió el corte prematuro del fetch paginado cuando entraba fallback de `page_size`; ahora la condición de fin usa el tamaño efectivo de página y evita truncar resultados (ej. alrededor de ~6600 ítems).
 - **1.0.30 (2026-05-04)**: Se añadió procesamiento directo de `raw.log`/JSON subido desde frontend para generar la corrida de migración sin fetchear nuevamente Contífico mientras se diagnostican límites/timeouts de paginación.
 - **1.0.29 (2026-05-04)**: Se añadió fallback de `page_size` al fetchear productos de Contífico (ej. 200→100→50→25) cuando hay `ContificoTransportError`, para reducir fallas por timeout en páginas pesadas.

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -436,6 +436,8 @@ class OdooMigrationService:
                 except ContificoTransportError as exc:
                     last_exc = exc
                 except ContificoAPIError as exc:
+                    if self._is_page_out_of_range_error(exc):
+                        return [], size
                     if exc.status_code not in {429, 500, 502, 503, 504}:
                         raise
                     last_exc = exc
@@ -448,6 +450,21 @@ class OdooMigrationService:
         if last_exc:
             raise last_exc
         return [], page_size
+
+    @staticmethod
+    def _is_page_out_of_range_error(exc: ContificoAPIError) -> bool:
+        if int(getattr(exc, "status_code", 0) or 0) != 400:
+            return False
+        payload = getattr(exc, "payload", None)
+        message = str(getattr(exc, "detail", "") or "")
+        if isinstance(payload, dict):
+            for key in ("error", "mensaje", "message", "detail"):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    message = f"{message} {value}".strip()
+                    break
+        normalized = message.lower()
+        return "pagina fuera del rango" in normalized or "página fuera del rango" in normalized
 
     @staticmethod
     def _base_group_key(sku: str, name: str) -> str:

--- a/backend/tests/test_odoo_migration_fetch_resilience.py
+++ b/backend/tests/test_odoo_migration_fetch_resilience.py
@@ -203,3 +203,19 @@ def test_fetch_products_tracks_expected_total_from_v2_count(tmp_path):
     assert pages == 3
     assert hit_max is False
     assert expected_min == 24605
+
+
+def test_fetch_products_page_out_of_range_is_treated_as_end_of_pagination():
+    class OutOfRangeClient:
+        def list_products(self, *, page: int, page_size: int):
+            raise ContificoAPIError(
+                400,
+                'Error: {"code":"400","error":"Pagina fuera del rango"}',
+                payload={"code": "400", "error": "Pagina fuera del rango"},
+            )
+
+    service = OdooMigrationService(client=OutOfRangeClient())
+    rows, effective_size = service._fetch_products_page_with_fallback(page=999, page_size=200)
+
+    assert rows == []
+    assert effective_size == 200


### PR DESCRIPTION
### Motivation
- La API de Contífico responde `400` con `{"code":"400","error":"Pagina fuera del rango"}` cuando se solicita una página inexistente y eso debe significar que no hay más páginas en lugar de abortar la corrida de migración.  
- Evitar que un error de este tipo detenga la exportación paginada de productos y permitir completar la generación de CSVs cuando la paginación se agota.

### Description
- En `backend/app/odoo_migration/service.py` se modificó `_fetch_products_page_with_fallback` para detectar el caso específico de `400` “Pagina fuera del rango” y devolver un lote vacío (fin de paginación) en vez de propagarlo como error fatal.  
- Se añadió el helper estático `_is_page_out_of_range_error(exc: ContificoAPIError) -> bool` que inspecciona `exc.status_code`, `exc.detail` y `exc.payload` buscando variantes de los campos `error/mensaje/message/detail` y normaliza el texto para detectar la frase `pagina fuera del rango`.  
- Se agregó una prueba de regresión en `backend/tests/test_odoo_migration_fetch_resilience.py` que verifica que un `ContificoAPIError(400, ...)` con `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d2bec9b88332a78437fb2de7585b)