### PR TITLE
Treat Contífico "page out of range" as end of pagination and add resilience + tests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -287,6 +287,9 @@ Si necesitas cambiar la URL del backend para el frontend, define `API_BASE_URL` 
 
 ## Historial de cambios
 
+- **1.0.34 (2026-05-04)**: Se corrigió el caso real de Contífico donde la respuesta HTTP puede venir con `status=404` pero body `{"code":"400","error":"Pagina fuera del rango"}`; ahora también se interpreta como fin de paginación para no cancelar la exportación.
+- **1.0.33 (2026-05-04)**: Se robusteció el manejo de paginación agotada de Contífico también en `ContificoClient.list_products` (no solo en el servicio de migración), interpretando el `400` con `Pagina fuera del rango` como lista vacía para evitar abortos en exportaciones.
+- **1.0.32 (2026-05-04)**: El fetch paginado de productos ahora interpreta el 400 de Contífico `{"code":"400","error":"Pagina fuera del rango"}` como fin de paginación (no como error fatal), evitando cancelar corridas cuando se solicita una página inexistente.
 - **1.0.31 (2026-05-04)**: Se corrigió el corte prematuro del fetch paginado cuando entraba fallback de `page_size`; ahora la condición de fin usa el tamaño efectivo de página y evita truncar resultados (ej. alrededor de ~6600 ítems).
 - **1.0.30 (2026-05-04)**: Se añadió procesamiento directo de `raw.log`/JSON subido desde frontend para generar la corrida de migración sin fetchear nuevamente Contífico mientras se diagnostican límites/timeouts de paginación.
 - **1.0.29 (2026-05-04)**: Se añadió fallback de `page_size` al fetchear productos de Contífico (ej. 200→100→50→25) cuando hay `ContificoTransportError`, para reducir fallas por timeout en páginas pesadas.

--- a/backend/app/contifico.py
+++ b/backend/app/contifico.py
@@ -563,6 +563,26 @@ class ContificoClient:
             return target.startswith(candidate)
         return False
 
+    @staticmethod
+    def _is_page_out_of_range_error(exc: ContificoAPIError) -> bool:
+        status_code = int(getattr(exc, "status_code", 0) or 0)
+        if status_code not in {400, 404}:
+            return False
+        payload = getattr(exc, "payload", None)
+        message_parts: list[str] = [str(getattr(exc, "detail", "") or "")]
+        if isinstance(payload, dict):
+            for key in ("error", "mensaje", "message", "detail"):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    message_parts.append(value)
+            code_value = str(payload.get("code") or "").strip()
+            if code_value and code_value != "400":
+                return False
+        elif status_code == 404:
+            return False
+        message = " ".join(message_parts).lower()
+        return "fuera del rango" in message and "pagina" in message.replace("á", "a")
+
     def list_products(
         self,
         *,
@@ -588,12 +608,18 @@ class ContificoClient:
             if not category_value:
                 raise ValueError("El identificador de la categoría no puede estar vacío.")
             params["categoria_id"] = category_value
-        data = self._request(
-            "GET",
-            "producto/",
-            base_url=self.products_base_url,
-            params=params,
-        )
+        try:
+            data = self._request(
+                "GET",
+                "producto/",
+                base_url=self.products_base_url,
+                params=params,
+            )
+        except ContificoAPIError as exc:
+            if self._is_page_out_of_range_error(exc):
+                self.last_products_total_count = None
+                return []
+            raise
         if data is None:
             return []
         if isinstance(data, list):

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -436,6 +436,8 @@ class OdooMigrationService:
                 except ContificoTransportError as exc:
                     last_exc = exc
                 except ContificoAPIError as exc:
+                    if self._is_page_out_of_range_error(exc):
+                        return [], size
                     if exc.status_code not in {429, 500, 502, 503, 504}:
                         raise
                     last_exc = exc
@@ -448,6 +450,27 @@ class OdooMigrationService:
         if last_exc:
             raise last_exc
         return [], page_size
+
+    @staticmethod
+    def _is_page_out_of_range_error(exc: ContificoAPIError) -> bool:
+        status_code = int(getattr(exc, "status_code", 0) or 0)
+        if status_code not in {400, 404}:
+            return False
+        payload = getattr(exc, "payload", None)
+        message = str(getattr(exc, "detail", "") or "")
+        if isinstance(payload, dict):
+            for key in ("error", "mensaje", "message", "detail"):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    message = f"{message} {value}".strip()
+                    break
+            code_value = str(payload.get("code") or "").strip()
+            if code_value and code_value != "400":
+                return False
+        elif status_code == 404:
+            return False
+        normalized = message.lower()
+        return "pagina fuera del rango" in normalized or "página fuera del rango" in normalized
 
     @staticmethod
     def _base_group_key(sku: str, name: str) -> str:

--- a/backend/tests/test_contifico_client.py
+++ b/backend/tests/test_contifico_client.py
@@ -1861,3 +1861,33 @@ def test_list_products_accepts_paginated_results_payload() -> None:
     products = list(client.list_products(page=1, page_size=100))
 
     assert products == [{"id": "A1", "codigo": "SKU-1", "nombre": "Producto"}]
+
+
+def test_list_products_returns_empty_when_page_is_out_of_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = ContificoClient("key123", "token-xyz", base_url="https://api.example.com")
+
+    def fake_request(method, endpoint, *, base_url=None, params=None, json=None):
+        raise ContificoAPIError(
+            400,
+            'Error: {"code":"400","error":"Pagina fuera del rango"}',
+            payload={"code": "400", "error": "Pagina fuera del rango"},
+        )
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert list(client.list_products(page=999, page_size=100)) == []
+
+
+def test_list_products_returns_empty_when_page_is_out_of_range_status_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = ContificoClient("key123", "token-xyz", base_url="https://api.example.com")
+
+    def fake_request(method, endpoint, *, base_url=None, params=None, json=None):
+        raise ContificoAPIError(
+            404,
+            'not found',
+            payload={"code": "400", "error": "Pagina fuera del rango"},
+        )
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert list(client.list_products(page=248, page_size=100)) == []

--- a/backend/tests/test_odoo_migration_fetch_resilience.py
+++ b/backend/tests/test_odoo_migration_fetch_resilience.py
@@ -203,3 +203,35 @@ def test_fetch_products_tracks_expected_total_from_v2_count(tmp_path):
     assert pages == 3
     assert hit_max is False
     assert expected_min == 24605
+
+
+def test_fetch_products_page_out_of_range_is_treated_as_end_of_pagination():
+    class OutOfRangeClient:
+        def list_products(self, *, page: int, page_size: int):
+            raise ContificoAPIError(
+                400,
+                'Error: {"code":"400","error":"Pagina fuera del rango"}',
+                payload={"code": "400", "error": "Pagina fuera del rango"},
+            )
+
+    service = OdooMigrationService(client=OutOfRangeClient())
+    rows, effective_size = service._fetch_products_page_with_fallback(page=999, page_size=200)
+
+    assert rows == []
+    assert effective_size == 200
+
+
+def test_fetch_products_page_out_of_range_404_payload_400_is_treated_as_end_of_pagination():
+    class OutOfRangeClient404:
+        def list_products(self, *, page: int, page_size: int):
+            raise ContificoAPIError(
+                404,
+                "not found",
+                payload={"code": "400", "error": "Pagina fuera del rango"},
+            )
+
+    service = OdooMigrationService(client=OutOfRangeClient404())
+    rows, effective_size = service._fetch_products_page_with_fallback(page=248, page_size=200)
+
+    assert rows == []
+    assert effective_size == 200


### PR DESCRIPTION
### Motivation
- Handle real Contífico responses where the HTTP status may be `404` or `400` but the payload contains `{"code":"400","error":"Pagina fuera del rango"}`, which should be interpreted as end of pagination instead of a fatal error.
- Make the paginated product fetch resilient so exports don't abort when a client returns that specific out-of-range message.
- Document the release and behavior change in `README.MD` history.

### Description
- Added `_is_page_out_of_range_error` to `ContificoClient` to detect `400`/`404` responses whose payload or detail indicates a "pagina fuera del rango" condition and treat them as non-fatal pagination end.
- Updated `ContificoClient.list_products` to catch `ContificoAPIError` and return an empty list when `_is_page_out_of_range_error` is true, clearing `last_products_total_count` accordingly.
- Added equivalent `_is_page_out_of_range_error` helper to `OdooMigrationService` and updated `_fetch_products_page_with_fallback` to return `([], size)` when the error is detected so fetch retries/fallback logic treats it as end of pages.
- Updated `README.MD` changelog with new release notes describing the fix and related robustness improvements.

### Testing
- Added unit tests `test_list_products_returns_empty_when_page_is_out_of_range` and `test_list_products_returns_empty_when_page_is_out_of_range_status_404` in `backend/tests/test_contifico_client.py`, and these tests passed.
- Added unit tests `test_fetch_products_page_out_of_range_is_treated_as_end_of_pagination` and `test_fetch_products_page_out_of_range_404_payload_400_is_treated_as_end_of_pagination` in `backend/tests/test_odoo_migration_fetch_resilience.py`, and these tests passed.
- Ran the backend unit test suite for the modified areas and the new tests succeeded without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d2bec9b88332a78437fb2de7585b)