### PR TITLE
Add Odoo 19 variant export (attributes, products with variants and stock) and integrate into export pipeline

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.45
+Versión 1.0.47
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 
@@ -366,3 +366,16 @@ El módulo Odoo de staging/importación se mantiene en un repositorio independie
 - https://github.com/IlPicasso/Modulo-Odoo-A-Contifico
 
 Este repositorio (`ContificoToOdoo`) queda dedicado al pipeline de extracción y generación de CSV revisables.
+
+
+## Exportación Odoo 19 (productos con variantes)
+
+Desde la versión 1.0.46 se generan adicionalmente tres CSV en cada RUN:
+1. `attributes_values.csv`
+2. `products_with_variants.csv`
+3. `stock_quant.csv`
+
+Orden de importación recomendado en Odoo:
+1) Attributes/Values, 2) Products with variants, 3) Stock por ajuste físico.
+
+Nota: si necesitas controlar SKU/barcode/precio estrictamente por variante en Odoo, puede requerirse una cuarta importación futura específica de variantes.

--- a/backend/app/odoo_migration/odoo19_variants.py
+++ b/backend/app/odoo_migration/odoo19_variants.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime
+import re
+from typing import Any
+
+ATTR_COLUMNS = ["Attribute", "Display Type", "Variant Creation Mode", "Values / Value"]
+PRODUCTS_COLUMNS = [
+    "External ID", "Name", "Product Type", "Product Category", "Sales Price", "Cost", "Can be Sold",
+    "Can be Purchased", "Available in POS", "Internal Reference", "Barcode", "Sales Description", "Customer Taxes",
+    "Product Attributes / Attribute", "Product Attributes / Values",
+]
+STOCK_COLUMNS = ["Product", "Lot/Serial Number", "Quantity", "Counted Quantity", "Difference", "Scheduled Date", "Assigned To"]
+
+
+def parse_base_code_and_variant(codigo: str) -> tuple[str, str]:
+    value = (codigo or "").strip()
+    if "/" not in value:
+        return value, ""
+    base, variant = value.rsplit("/", 1)
+    return base.strip(), variant.strip()
+
+
+def normalize_external_id(value: str, prefix: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", (value or "").lower()).strip("_")
+    return f"{prefix}_{slug}" if slug else prefix
+
+
+def normalize_price(value: Any) -> str:
+    try:
+        return f"{float(value or 0):.2f}"
+    except Exception:
+        return "0.00"
+
+
+def normalize_bool(value: Any, default: bool = True) -> str:
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    text = str(value or "").strip().lower()
+    if text in {"1", "true", "t", "yes", "si", "sí", "a", "pro"}:
+        return "True"
+    if text in {"0", "false", "f", "no", "n"}:
+        return "False"
+    return "True" if default else "False"
+
+
+def normalize_product_name(name: str) -> str:
+    return re.sub(r"\s+", " ", (name or "").strip())
+
+
+def _natural_key(val: str):
+    s = str(val or "")
+    return [int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", s)]
+
+
+def _tax_name(iva: Any) -> str:
+    try:
+        return "IVA 15%" if float(iva or 0) == 15 else "IVA 0%"
+    except Exception:
+        return "IVA 0%"
+
+
+def build_attributes_values(products: list[dict[str, Any]]) -> list[dict[str, str]]:
+    sizes, brands = set(), set()
+    for p in products:
+        base, size = parse_base_code_and_variant(str(p.get("codigo") or ""))
+        if base and size:
+            sizes.add(size)
+        brand = normalize_product_name(str(p.get("marca_nombre") or ""))
+        if brand:
+            brands.add(brand)
+    rows = [{"Attribute": "Talla", "Display Type": "Selection", "Variant Creation Mode": "Instantly", "Values / Value": s} for s in sorted(sizes, key=_natural_key)]
+    rows += [{"Attribute": "Marca", "Display Type": "Selection", "Variant Creation Mode": "Never", "Values / Value": b} for b in sorted(brands, key=_natural_key)]
+    return rows
+
+
+def build_products_with_variants(products: list[dict[str, Any]], warnings: list[str] | None = None) -> list[dict[str, str]]:
+    warnings = warnings if warnings is not None else []
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for p in products:
+        code = str(p.get("codigo") or "").strip()
+        if not code:
+            warnings.append("Producto sin codigo")
+            continue
+        base, _ = parse_base_code_and_variant(code)
+        grouped.setdefault(base or code, []).append(p)
+
+    rows: list[dict[str, str]] = []
+    for base, items in grouped.items():
+        names = [normalize_product_name(str(i.get("nombre") or "")) for i in items if str(i.get("nombre") or "").strip()]
+        if not names:
+            warnings.append(f"Producto sin nombre: {base}")
+            continue
+        name = Counter(names).most_common(1)[0][0]
+        prices = [normalize_price(i.get("pvp1")) for i in items]
+        price = min(prices, key=lambda x: float(x or 0)) if prices else "0.00"
+        if len(set(prices)) > 1:
+            warnings.append(f"Precios distintos en variantes: {base}")
+        cost = normalize_price(items[0].get("costo_maximo"))
+        barcode = "" if any(parse_base_code_and_variant(str(i.get("codigo") or ""))[1] for i in items) else str(items[0].get("codigo_barra") or "")
+        marcas = sorted({normalize_product_name(str(i.get("marca_nombre") or "")) for i in items if str(i.get("marca_nombre") or "").strip()}, key=_natural_key)
+        if len(marcas) > 1:
+            warnings.append(f"Marcas distintas en mismo base: {base}")
+        talla_vals = sorted({parse_base_code_and_variant(str(i.get("codigo") or ""))[1] for i in items if parse_base_code_and_variant(str(i.get("codigo") or ""))[1]}, key=_natural_key)
+        common = {
+            "External ID": normalize_external_id(base, "product_template"), "Name": name, "Product Type": "Goods",
+            "Product Category": "All / ADAMS / Sin categoría", "Sales Price": price, "Cost": cost,
+            "Can be Sold": "True", "Can be Purchased": "True", "Available in POS": normalize_bool(items[0].get("para_pos")),
+            "Internal Reference": base, "Barcode": barcode, "Sales Description": str(items[0].get("descripcion") or ""), "Customer Taxes": _tax_name(items[0].get("porcentaje_iva")),
+        }
+        if talla_vals:
+            rows.append({**common, "Product Attributes / Attribute": "Talla", "Product Attributes / Values": ",".join(talla_vals)})
+            if not talla_vals:
+                warnings.append(f"Tallas no detectables: {base}")
+        else:
+            rows.append({**common, "Product Attributes / Attribute": "", "Product Attributes / Values": ""})
+        if marcas:
+            rows.append({**common, "Product Attributes / Attribute": "Marca", "Product Attributes / Values": marcas[0]})
+    return rows
+
+
+def build_stock_quant(products: list[dict[str, Any]], scheduled_date: str | None = None, include_inactive: bool = False) -> list[dict[str, str]]:
+    date_value = scheduled_date or datetime.utcnow().date().isoformat()
+    rows = []
+    for p in products:
+        if not include_inactive and str(p.get("estado") or "").upper() not in {"", "A"}:
+            continue
+        code = str(p.get("codigo") or "").strip()
+        if not code:
+            continue
+        base, variant = parse_base_code_and_variant(code)
+        name = normalize_product_name(str(p.get("nombre") or code))
+        qty = normalize_price(p.get("cantidad_stock"))
+        label = f"[{code}] {name} ({variant})" if variant else f"[{base}] {name}"
+        rows.append({"Product": label, "Lot/Serial Number": "", "Quantity": qty, "Counted Quantity": qty, "Difference": "0", "Scheduled Date": date_value, "Assigned To": ""})
+    return rows
+
+
+def build_products_with_variants_from_variant_rows(variant_rows: list[dict[str, Any]], warnings: list[str] | None = None) -> list[dict[str, str]]:
+    """Build Odoo19 template rows using normalized phase1 rows (category/brand already resolved)."""
+    warnings = warnings if warnings is not None else []
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in variant_rows:
+        sku = str(row.get("sku") or "").strip()
+        if not sku:
+            warnings.append("Producto sin codigo")
+            continue
+        base, _ = parse_base_code_and_variant(sku)
+        grouped.setdefault(base or sku, []).append(row)
+
+    result: list[dict[str, str]] = []
+    for base, items in grouped.items():
+        names = [normalize_product_name(str(i.get("name") or "")) for i in items if str(i.get("name") or "").strip()]
+        if not names:
+            warnings.append(f"Producto sin nombre: {base}")
+            continue
+        name = Counter(names).most_common(1)[0][0]
+        prices = [normalize_price(i.get("price")) for i in items]
+        if len(set(prices)) > 1:
+            warnings.append(f"Precios distintos en variantes: {base}")
+        price = min(prices, key=lambda x: float(x or 0)) if prices else "0.00"
+        category = normalize_product_name(str(items[0].get("category") or "All / ADAMS / Sin categoría"))
+        brand_values = sorted({normalize_product_name(str((i.get("attrs") or {}).get("Marca") or "")) for i in items if normalize_product_name(str((i.get("attrs") or {}).get("Marca") or ""))}, key=_natural_key)
+        if len(brand_values) > 1:
+            warnings.append(f"Marcas distintas en mismo base: {base}")
+        sizes = sorted({normalize_product_name(str((i.get("attrs") or {}).get("Talla") or "")) for i in items if normalize_product_name(str((i.get("attrs") or {}).get("Talla") or ""))}, key=_natural_key)
+        barcode = "" if sizes else str(items[0].get("barcode") or "")
+        common = {
+            "External ID": normalize_external_id(base, "product_template"),
+            "Name": name,
+            "Product Type": "Goods",
+            "Product Category": category,
+            "Sales Price": price,
+            "Cost": normalize_price(items[0].get("cost")),
+            "Can be Sold": "True",
+            "Can be Purchased": "True",
+            "Available in POS": "True",
+            "Internal Reference": base,
+            "Barcode": barcode,
+            "Sales Description": "",
+            "Customer Taxes": "IVA 0%",
+        }
+        if sizes:
+            result.append({**common, "Product Attributes / Attribute": "Talla", "Product Attributes / Values": ",".join(sizes)})
+        else:
+            result.append({**common, "Product Attributes / Attribute": "", "Product Attributes / Values": ""})
+        if brand_values:
+            result.append({**common, "Product Attributes / Attribute": "Marca", "Product Attributes / Values": brand_values[0]})
+    return result

--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -42,7 +42,10 @@ def _build_files(run_id: str) -> dict[str, str]:
     return {
         "product_product_csv": f"/odoo-migration/runs/{run_id}/files/product_product.csv",
         "initial_stock_csv": f"/odoo-migration/runs/{run_id}/files/initial_stock.csv",
-        "stock_quant_csv": f"/odoo-migration/runs/{run_id}/files/stock_quant.csv",
+        "stock_quant_csv": f"/odoo-migration/runs/{run_id}/files/stock_quant_legacy.csv",
+        "attributes_values_csv": f"/odoo-migration/runs/{run_id}/files/attributes_values.csv",
+        "products_with_variants_csv": f"/odoo-migration/runs/{run_id}/files/products_with_variants.csv",
+        "stock_quant_odoo19_csv": f"/odoo-migration/runs/{run_id}/files/stock_quant.csv",
         "migration_errors_csv": f"/odoo-migration/runs/{run_id}/files/migration_errors.csv",
         "mapping_report_csv": f"/odoo-migration/runs/{run_id}/files/mapping_report.csv",
         "excluded_zero_stock_csv": f"/odoo-migration/runs/{run_id}/files/excluded_zero_stock.csv",

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -11,6 +11,14 @@ import json
 import time
 
 from ..contifico import ContificoAPIError, ContificoClient, ContificoTransportError
+from .odoo19_variants import (
+    ATTR_COLUMNS as O19_ATTR_COLUMNS,
+    PRODUCTS_COLUMNS as O19_PRODUCTS_COLUMNS,
+    STOCK_COLUMNS as O19_STOCK_COLUMNS,
+    build_attributes_values,
+    build_products_with_variants_from_variant_rows,
+    build_stock_quant,
+)
 from .rules import (
     detect_brand, detect_color, detect_category, calculate_total_stock, should_exclude_zero_stock,
     parse_shirt_sku, parse_suit_sku, parse_blazer_sku, parse_tie_sku, parse_bowtie_sku, parse_fajin_sku,
@@ -61,7 +69,7 @@ class OdooMigrationService:
     def generate_products_and_stock_csv(self, *, page_size=200, max_pages=200, export_stock: bool = False, include_additional_attributes: bool = False, progress_callback: Callable[[dict[str, Any]], None] | None = None) -> MigrationOutput:
         self._validate_templates()
         ts = datetime.utcnow().strftime('%Y%m%d_%H%M%S'); folder = self.output_root / ts; folder.mkdir(parents=True, exist_ok=True)
-        product_csv=folder/'product_product.csv'; stock_csv=folder/'initial_stock.csv'; stock_quant_csv=folder/'stock_quant.csv'; errors_csv=folder/'migration_errors.csv'; mapping_csv=folder/'mapping_report.csv'; excluded_zero_csv=folder/'excluded_zero_stock.csv'; unmapped_categories_csv=folder/'unmapped_categories.csv'; debug_log=folder/'debug.log'; raw_log=folder/'raw.log'
+        product_csv=folder/'product_product.csv'; stock_csv=folder/'initial_stock.csv'; stock_quant_csv=folder/'stock_quant_legacy.csv'; errors_csv=folder/'migration_errors.csv'; mapping_csv=folder/'mapping_report.csv'; excluded_zero_csv=folder/'excluded_zero_stock.csv'; unmapped_categories_csv=folder/'unmapped_categories.csv'; debug_log=folder/'debug.log'; raw_log=folder/'raw.log'
         snapshot_path = folder / 'products_snapshot.jsonl'; state_path = folder / 'stock_state.json'
         debug_lines=[f'start={datetime.utcnow().isoformat()}Z',f'page_size={page_size}',f'max_pages={max_pages}',f'export_stock={export_stock}']; raw_lines=[]
         started_at = datetime.utcnow()
@@ -84,7 +92,7 @@ class OdooMigrationService:
         )
 
     def _generate_from_products(self, *, products: list[dict[str, Any]], folder: Path, pages_fetched: int, hit_max_pages: bool, expected_min_items: int | None, started_at: datetime, export_stock: bool, include_additional_attributes: bool, progress_callback=None, debug_lines=None, raw_lines=None) -> MigrationOutput:
-        product_csv=folder/'product_product.csv'; stock_csv=folder/'initial_stock.csv'; stock_quant_csv=folder/'stock_quant.csv'; errors_csv=folder/'migration_errors.csv'; mapping_csv=folder/'mapping_report.csv'; excluded_zero_csv=folder/'excluded_zero_stock.csv'; unmapped_categories_csv=folder/'unmapped_categories.csv'; debug_log=folder/'debug.log'; raw_log=folder/'raw.log'
+        product_csv=folder/'product_product.csv'; stock_csv=folder/'initial_stock.csv'; stock_quant_csv=folder/'stock_quant_legacy.csv'; errors_csv=folder/'migration_errors.csv'; mapping_csv=folder/'mapping_report.csv'; excluded_zero_csv=folder/'excluded_zero_stock.csv'; unmapped_categories_csv=folder/'unmapped_categories.csv'; debug_log=folder/'debug.log'; raw_log=folder/'raw.log'
         snapshot_path = folder / 'products_snapshot.jsonl'; state_path = folder / 'stock_state.json'
         phase1 = self._phase1_prepare_products(products=products, folder=folder, snapshot_path=snapshot_path, errors_csv=errors_csv, mapping_csv=mapping_csv, excluded_zero_csv=excluded_zero_csv, product_csv=product_csv, include_additional_attributes=include_additional_attributes, export_stock=export_stock, progress_callback=progress_callback)
         self._write_stock_state(state_path, phase1['stock_state'])
@@ -98,7 +106,15 @@ class OdooMigrationService:
         self._write_csv(mapping_csv, MAP_COLUMNS, phase1['mrows'])
         self._write_csv(excluded_zero_csv, EXCLUDED_ZERO_COLUMNS, phase1['zrows'])
         self._write_csv(unmapped_categories_csv, UNMAPPED_CATEGORY_COLUMNS, phase1['unmapped_category_rows'])
+
         self._write_variant_import_outputs(folder, phase1.get("variant_rows", []), include_stock=export_stock)
+        o19_warnings: list[str] = []
+        o19_attr_rows = build_attributes_values(products)
+        o19_product_rows = build_products_with_variants_from_variant_rows(phase1.get("variant_rows", []), warnings=o19_warnings)
+        o19_stock_rows = build_stock_quant(products)
+        self._write_csv(folder / "attributes_values.csv", O19_ATTR_COLUMNS, o19_attr_rows)
+        self._write_csv(folder / "products_with_variants.csv", O19_PRODUCTS_COLUMNS, o19_product_rows)
+        self._write_csv(folder / "stock_quant.csv", O19_STOCK_COLUMNS, o19_stock_rows)
 
         counts = phase1['counts']
         debug_lines += [f"summary={json.dumps(counts)}", f"pages_fetched={pages_fetched}", f"hit_max_pages={hit_max_pages}", f"snapshot={snapshot_path.name}", f"state={state_path.name}"]

--- a/backend/tests/test_odoo19_variants_export.py
+++ b/backend/tests/test_odoo19_variants_export.py
@@ -1,0 +1,35 @@
+from app.odoo_migration.odoo19_variants import (
+    build_attributes_values,
+    build_products_with_variants_from_variant_rows,
+    build_stock_quant,
+)
+
+
+def _sample():
+    base = {
+        "name": "TERNO 2 BOTONES BRUNO CASSINI",
+        "price": "165.13",
+        "cost": "0.00",
+        "stock_map": {"BPU": 0},
+        "category": "Ropa / Ternos",
+        "attrs": {"Marca": "CASSINI TERNOS - CABALLEROS"},
+    }
+    return [{**base, "sku": f"007-51BC-2/{s}", "barcode": f"007-51BC-2/O{s}", "attrs": {"Marca": "CASSINI TERNOS - CABALLEROS", "Talla": s}} for s in ["54", "56", "58", "60", "62"]]
+
+
+def test_variant_csv_builders():
+    products_raw = [{"codigo": f"007-51BC-2/{s}", "marca_nombre": "CASSINI TERNOS - CABALLEROS", "cantidad_stock": 0, "estado": "A", "nombre": "TERNO 2 BOTONES BRUNO CASSINI"} for s in ["54", "56", "58", "60", "62"]]
+    attrs = build_attributes_values(products_raw)
+    assert [r["Values / Value"] for r in attrs if r["Attribute"] == "Talla"] == ["54", "56", "58", "60", "62"]
+    assert any(r["Attribute"] == "Marca" and r["Variant Creation Mode"] == "Never" for r in attrs)
+
+    rows = build_products_with_variants_from_variant_rows(_sample())
+    templates = [r for r in rows if r["Product Attributes / Attribute"] == "Talla"]
+    assert len(templates) == 1
+    assert templates[0]["External ID"] == "product_template_007_51bc_2"
+    assert templates[0]["Product Attributes / Values"] == "54,56,58,60,62"
+    assert templates[0]["Barcode"] == ""
+    assert templates[0]["Product Category"] == "Ropa / Ternos"
+
+    stock = build_stock_quant(products_raw, scheduled_date="2026-05-04")
+    assert len(stock) == 5


### PR DESCRIPTION
### Motivation
- Provide a dedicated export path for Odoo 19 that supports product attributes/values, products-with-variants and per-variant stock while keeping the legacy stock CSV for backwards compatibility.
- Make it possible to import complex variant setups into Odoo in the recommended order and reduce manual transformation steps.

### Description
- Added new module `backend/app/odoo_migration/odoo19_variants.py` implementing helpers and builders: `build_attributes_values`, `build_products_with_variants_from_variant_rows`, and `build_stock_quant` plus normalization and parsing utilities.
- Updated the migration router to announce new output files and renamed the previous `stock_quant.csv` to `stock_quant_legacy.csv` while adding `stock_quant.csv` for the Odoo19 format endpoints.
- Integrated Odoo19 builders into the export flow in `backend/app/odoo_migration/service.py` to write `attributes_values.csv`, `products_with_variants.csv`, and the Odoo19 `stock_quant.csv` during `_generate_from_products`, and preserved legacy behavior using `stock_quant_legacy.csv`.
- Bumped README version to `Versión 1.0.47` and documented the new Odoo 19 export files and recommended import order.
- Added unit tests in `backend/tests/test_odoo19_variants_export.py` that exercise the new CSV builders.

### Testing
- Ran the new unit test with `pytest backend/tests/test_odoo19_variants_export.py` and it passed.
- The new functions were exercised by the test and by the integrated export flow during local runs (no additional failing automated tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f920759c588332a408fb231964078d)