### PR TITLE
Corregir clasificación SKU ZP/PT/CH y normalizar marcas (v1.0.49)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.48
+Versión 1.0.49
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 
@@ -287,6 +287,7 @@ Si necesitas cambiar la URL del backend para el frontend, define `API_BASE_URL` 
 
 ## Historial de cambios
 
+- **1.0.49 (2026-05-05)**: Se corrigió clasificación por prefijo SKU para evitar que `ZP-`/`PT-`/`CH-` salgan como `Terno` en productos madre/variantes; ahora `ZP` genera nombre `Zapato`, `PT` genera `Pantalon`, `CH` genera `Chaleco`, y además se agrega categoría `Ropa / Hombres / Chaleco`. También se normalizan marcas en formato título (ej. `Bruno Cassini`) en exportaciones.
 - **1.0.45 (2026-05-04)**: Se movió el filtrado de stock 0 a Fase 1 (manteniendo la regla de grupo por variantes con stock), y se incorporó mapeo explícito 100% determinístico `categoria_id Contífico -> categoría Odoo` mediante configuración (`config/contifico_category_to_odoo.json`) para evitar heurísticas cuando la categoría viene solo por ID.
 - **1.0.44 (2026-05-04)**: Se agregó mapeo explícito de categorías de Contífico por `categoria_id` para detectar categoría Odoo con mayor precisión cuando el listado de productos no trae nombre de categoría, y se añadió salida `unmapped_categories.csv` por run para revisión manual de IDs no mapeados.
 - **1.0.34 (2026-05-04)**: Se corrigió el caso real de Contífico donde la respuesta HTTP puede venir con `status=404` pero body `{"code":"400","error":"Pagina fuera del rango"}`; ahora también se interpreta como fin de paginación para no cancelar la exportación.

--- a/backend/app/migration/product_mapper.py
+++ b/backend/app/migration/product_mapper.py
@@ -51,6 +51,19 @@ def parse_sku(sku: str) -> tuple[str, str, str]:
     return f"Producto {sku}", "", ""
 
 
+def format_brand_name(value: str) -> str:
+    words = re.split(r"\s+", str(value or "").strip())
+    formatted = []
+    for word in words:
+        if not word:
+            continue
+        if len(word) <= 3:
+            formatted.append(word.upper())
+        else:
+            formatted.append(word[0].upper() + word[1:].lower())
+    return " ".join(formatted)
+
+
 def map_contifico_product(item: dict[str, Any]) -> ExportProductRow:
     sku = str(item.get("sku") or "").strip()
     producto_madre, talla, manga = parse_sku(sku)
@@ -64,7 +77,7 @@ def map_contifico_product(item: dict[str, Any]) -> ExportProductRow:
         categoria_odoo=str(item.get("categoria_odoo") or "Ropa / Accesorios"),
         talla=talla,
         manga=manga,
-        marca=str(item.get("marca") or "BRUNO CASSINI"),
+        marca=format_brand_name(str(item.get("marca") or "Bruno Cassini")),
         color=str(item.get("color") or ""),
         precio_venta=float(item.get("precio_venta") or 0),
         costo=float(item.get("costo") or 0),

--- a/backend/app/odoo_migration/odoo19_variants.py
+++ b/backend/app/odoo_migration/odoo19_variants.py
@@ -49,6 +49,19 @@ def normalize_product_name(name: str) -> str:
     return re.sub(r"\s+", " ", (name or "").strip())
 
 
+def normalize_brand_name(name: str) -> str:
+    cleaned = normalize_product_name(name)
+    if not cleaned:
+        return ""
+    parts = []
+    for token in cleaned.split(" "):
+        if len(token) <= 3:
+            parts.append(token.upper())
+        else:
+            parts.append(token[:1].upper() + token[1:].lower())
+    return " ".join(parts)
+
+
 def _natural_key(val: str):
     s = str(val or "")
     return [int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", s)]
@@ -67,7 +80,7 @@ def build_attributes_values(products: list[dict[str, Any]]) -> list[dict[str, st
         base, size = parse_base_code_and_variant(str(p.get("codigo") or ""))
         if base and size:
             sizes.add(size)
-        brand = normalize_product_name(str(p.get("marca_nombre") or ""))
+        brand = normalize_brand_name(str(p.get("marca_nombre") or ""))
         if brand:
             brands.add(brand)
     rows = [{"Attribute": "Talla", "Display Type": "Selection", "Variant Creation Mode": "Instantly", "Values / Value": s} for s in sorted(sizes, key=_natural_key)]
@@ -99,7 +112,7 @@ def build_products_with_variants(products: list[dict[str, Any]], warnings: list[
             warnings.append(f"Precios distintos en variantes: {base}")
         cost = normalize_price(items[0].get("costo_maximo"))
         barcode = "" if any(parse_base_code_and_variant(str(i.get("codigo") or ""))[1] for i in items) else str(items[0].get("codigo_barra") or "")
-        marcas = sorted({normalize_product_name(str(i.get("marca_nombre") or "")) for i in items if str(i.get("marca_nombre") or "").strip()}, key=_natural_key)
+        marcas = sorted({normalize_brand_name(str(i.get("marca_nombre") or "")) for i in items if str(i.get("marca_nombre") or "").strip()}, key=_natural_key)
         if len(marcas) > 1:
             warnings.append(f"Marcas distintas en mismo base: {base}")
         talla_vals = sorted({parse_base_code_and_variant(str(i.get("codigo") or ""))[1] for i in items if parse_base_code_and_variant(str(i.get("codigo") or ""))[1]}, key=_natural_key)

--- a/backend/app/odoo_migration/rules.py
+++ b/backend/app/odoo_migration/rules.py
@@ -27,8 +27,23 @@ def detect_brand(marca_nombre: str, nombre: str = '') -> str:
     normalized = normalize_text(marca_nombre or nombre)
     for alias, brand in BRAND_ALIASES.items():
         if alias in normalized:
-            return brand
+            return format_brand_name(brand)
     return ''
+
+
+def format_brand_name(value: str) -> str:
+    words = re.split(r"\s+", str(value or "").strip())
+    if not words:
+        return ""
+    formatted = []
+    for word in words:
+        if not word:
+            continue
+        if len(word) <= 3:
+            formatted.append(word.upper())
+        else:
+            formatted.append(word[0].upper() + word[1:].lower())
+    return " ".join(formatted)
 
 
 def detect_color(nombre: str) -> str:
@@ -51,6 +66,12 @@ def detect_category(nombre: str, categoria_raw: str = '', sku: str = '') -> str:
         if "MUJER" in source or "DAMA" in source:
             return "Ropa / Mujeres / Zapatos"
         return "Ropa / Hombres / Zapatos"
+    if sku_norm.startswith("PT-") or " PT-" in sku_norm:
+        if "MUJER" in source or "DAMA" in source:
+            return "Ropa / Mujeres / Pantalones"
+        return "Ropa / Hombres / Pantalones"
+    if sku_norm.startswith("CH-") or " CH-" in sku_norm:
+        return "Ropa / Hombres / Chaleco"
 
     woman_hint = "MUJER" in source or "DAMA" in source
     men_hint = "HOMBRE" in source or "HOMBRES" in source
@@ -114,6 +135,13 @@ def parse_suit_sku(sku: str):
     m = PATTERNS['suit'].match(sku)
     if not m:
         return None
+    sku_norm = normalize_text(sku)
+    if sku_norm.startswith("ZP-"):
+        return {'product_name': f"Zapato {m.group('base')}", 'talla': m.group('size'), 'parser_rule': 'shoe'}
+    if sku_norm.startswith("PT-"):
+        return {'product_name': f"Pantalon {m.group('base')}", 'talla': m.group('size'), 'parser_rule': 'pants'}
+    if sku_norm.startswith("CH-"):
+        return {'product_name': f"Chaleco {m.group('base')}", 'talla': m.group('size'), 'parser_rule': 'vest'}
     return {'product_name': f"Terno {m.group('base')}", 'talla': m.group('size'), 'parser_rule': 'suit'}
 
 

--- a/backend/tests/test_migration_product_mapper.py
+++ b/backend/tests/test_migration_product_mapper.py
@@ -28,7 +28,7 @@ def test_map_contifico_product_stocks_and_defaults():
 
     assert row.producto_madre == "Camisa 17601"
     assert row.manga == "S2 - 34/35"
-    assert row.marca == "BRUNO CASSINI"
+    assert row.marca == "Bruno Cassini"
     assert row.stock_bpu == 5
     assert row.stock_tur == 2
     assert row.stock_bat == 1

--- a/backend/tests/test_odoo_migration_rules.py
+++ b/backend/tests/test_odoo_migration_rules.py
@@ -44,7 +44,7 @@ from app.odoo_migration.rules import detect_category, detect_brand
 
 def test_detect_women_category_and_brands():
     assert detect_category('PANTALON DAMA NEGRO', '').startswith('Ropa / Mujeres')
-    assert detect_brand('TED LAPIDUS') == "TED LAPIDUS"
+    assert detect_brand('TED LAPIDUS') == "TED Lapidus"
     assert detect_brand('BFL') == "BFL"
 
 
@@ -52,6 +52,14 @@ def test_detect_shoes_prefix_zp():
     from app.odoo_migration.rules import detect_category
     assert detect_category('H. ZAPATOS', '', sku='ZP-LOAFER-H-BRW/8.5') == 'Ropa / Hombres / Zapatos'
     assert detect_category('ZAPATO DAMA', '', sku='ZP-ABC/38') == 'Ropa / Mujeres / Zapatos'
+
+
+def test_detect_pants_and_vest_prefixes():
+    from app.odoo_migration.rules import detect_category, parse_suit_sku
+    assert detect_category('PANTALON FORMAL', '', sku='PT-ABC/34') == 'Ropa / Hombres / Pantalones'
+    assert detect_category('CHALECO CLASICO', '', sku='CH-XYZ/48') == 'Ropa / Hombres / Chaleco'
+    assert parse_suit_sku('PT-ABC/34')['product_name'].startswith('Pantalon')
+    assert parse_suit_sku('CH-XYZ/48')['product_name'].startswith('Chaleco')
 
 
 def test_bg_group_normalization():


### PR DESCRIPTION
### Motivation
- Evitar que SKU con prefijos `ZP-`/`PT-`/`CH-` sean detectados como `Terno` y que las marcas en mayúsculas no coincidan con los valores en Odoo. 
- Garantizar nombres de producto y categorías más precisos para la exportación a Odoo (productos madre/variantes). 
- Mantener el control de versiones y documentar el cambio en el historial del proyecto. 

### Description
- Añade detección por prefijo SKU en `detect_category` para `PT-` → `Ropa / ... / Pantalones` y `CH-` → `Ropa / Hombres / Chaleco` en `backend/app/odoo_migration/rules.py`. 
- Ajusta el parser de SKU tipo "suit" (`parse_suit_sku`) para devolver `Zapato`, `Pantalon` o `Chaleco` según prefijo (`ZP-`, `PT-`, `CH-`) en `backend/app/odoo_migration/rules.py`. 
- Normaliza el formato de marcas a estilo título (ej. `Bruno Cassini`) añadiendo `format_brand_name`/`normalize_brand_name` y aplicándolo en `backend/app/odoo_migration/rules.py`, `backend/app/migration/product_mapper.py` y `backend/app/odoo_migration/odoo19_variants.py`. 
- Actualiza pruebas en `backend/tests/test_odoo_migration_rules.py` y `backend/tests/test_migration_product_mapper.py` para reflejar el nuevo formato de marca y la clasificación por prefijo. 
- Sube la versión en `README.MD` a `1.0.49` y documenta los cambios en el historial. 

### Testing
- Ejecuté las pruebas unitarias focalizadas con `PYTHONPATH=backend pytest -q backend/tests/test_migration_product_mapper.py backend/tests/test_odoo_migration_rules.py backend/tests/test_odoo19_variants_export.py`. 
- Resultado: todas las pruebas seleccionadas pasaron (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93919c2d083329b4bf608c8f9e0e3)