### PR TITLE
Normalizar Ancho Corbata agregando sufijo cm

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -287,6 +287,7 @@ Si necesitas cambiar la URL del backend para el frontend, define `API_BASE_URL` 
 
 ## Historial de cambios
 
+- **1.0.50 (2026-05-05)**: Se normalizó `Ancho Corbata` agregando sufijo `cm` (ej. `7` -> `7 cm`, `7.5` -> `7.5 cm`) en parsing y exportación de variantes, manteniendo `Talla` sin unidades.
 - **1.0.49 (2026-05-05)**: Se corrigió clasificación por prefijo SKU para evitar que `ZP-`/`PT-`/`CH-` salgan como `Terno` en productos madre/variantes; ahora `ZP` genera nombre `Zapato`, `PT` genera `Pantalon`, `CH` genera `Chaleco`, y además se agrega categoría `Ropa / Hombres / Chaleco`. También se normalizan marcas en formato título (ej. `Bruno Cassini`) en exportaciones.
 - **1.0.45 (2026-05-04)**: Se movió el filtrado de stock 0 a Fase 1 (manteniendo la regla de grupo por variantes con stock), y se incorporó mapeo explícito 100% determinístico `categoria_id Contífico -> categoría Odoo` mediante configuración (`config/contifico_category_to_odoo.json`) para evitar heurísticas cuando la categoría viene solo por ID.
 - **1.0.44 (2026-05-04)**: Se agregó mapeo explícito de categorías de Contífico por `categoria_id` para detectar categoría Odoo con mayor precisión cuando el listado de productos no trae nombre de categoría, y se añadió salida `unmapped_categories.csv` por run para revisión manual de IDs no mapeados.

--- a/backend/app/odoo_migration/odoo19_variants.py
+++ b/backend/app/odoo_migration/odoo19_variants.py
@@ -5,6 +5,8 @@ from datetime import datetime
 import re
 from typing import Any
 
+from .rules import normalize_tie_width
+
 ATTR_COLUMNS = ["Attribute", "Display Type", "Variant Creation Mode", "Values / Value"]
 PRODUCTS_COLUMNS = [
     "External ID", "Name", "Product Type", "Product Category", "Sales Price", "Cost", "Can be Sold",
@@ -206,7 +208,7 @@ def build_products_with_variants_from_variant_rows(variant_rows: list[dict[str, 
         manga_values = sorted({normalize_product_name(str((i.get("attrs") or {}).get("Manga de Camisa") or "")) for i in items if normalize_product_name(str((i.get("attrs") or {}).get("Manga de Camisa") or ""))}, key=_natural_key)
         if manga_values:
             attr_values["Manga de Camisa"] = manga_values
-        ancho_values = sorted({normalize_product_name(str((i.get("attrs") or {}).get("Ancho Corbata") or "")) for i in items if normalize_product_name(str((i.get("attrs") or {}).get("Ancho Corbata") or ""))}, key=_natural_key)
+        ancho_values = sorted({normalize_tie_width(normalize_product_name(str((i.get("attrs") or {}).get("Ancho Corbata") or ""))) for i in items if normalize_tie_width(normalize_product_name(str((i.get("attrs") or {}).get("Ancho Corbata") or "")))}, key=_natural_key)
         if ancho_values:
             attr_values["Ancho Corbata"] = ancho_values
 

--- a/backend/app/odoo_migration/rules.py
+++ b/backend/app/odoo_migration/rules.py
@@ -152,11 +152,20 @@ def parse_blazer_sku(sku: str):
     return {'product_name': f"Leva {m.group('base')}", 'talla': m.group('size'), 'parser_rule': 'blazer'}
 
 
+def normalize_tie_width(value: str) -> str:
+    cleaned = re.sub(r"\s+", " ", str(value or "").strip())
+    if not cleaned:
+        return ""
+    if cleaned.lower().endswith("cm"):
+        return cleaned
+    return f"{cleaned} cm"
+
+
 def parse_tie_sku(sku: str):
     m = PATTERNS['tie_width'].match(sku)
     if not m:
         return None
-    return {'product_name': f"Corbata {m.group('base')}", 'ancho_corbata': m.group('width'), 'parser_rule': 'tie_width'}
+    return {'product_name': f"Corbata {m.group('base')}", 'ancho_corbata': normalize_tie_width(m.group('width')), 'parser_rule': 'tie_width'}
 
 
 def parse_bowtie_sku(sku: str):

--- a/backend/tests/test_odoo19_variants_export.py
+++ b/backend/tests/test_odoo19_variants_export.py
@@ -15,8 +15,8 @@ def _sample():
         "attrs": {"Marca": "ADAMS", "Color": "Azul", "Manga de Camisa": "L"},
     }
     return [
-        {**base, "sku": "007-51BC-2/54", "barcode": "007-51BC-2/O54", "attrs": {"Marca": "ADAMS", "Talla": "54", "Color": "Azul", "Manga de Camisa": "L", "Ancho Corbata": "7"}},
-        {**base, "sku": "007-51BC-2/56", "barcode": "007-51BC-2/O56", "attrs": {"Marca": "ADAMS", "Talla": "56", "Color": "Azul", "Manga de Camisa": "L", "Ancho Corbata": "7"}},
+        {**base, "sku": "007-51BC-2/54", "barcode": "007-51BC-2/O54", "attrs": {"Marca": "ADAMS", "Talla": "54", "Color": "Azul", "Manga de Camisa": "L", "Ancho Corbata": "7 cm"}},
+        {**base, "sku": "007-51BC-2/56", "barcode": "007-51BC-2/O56", "attrs": {"Marca": "ADAMS", "Talla": "56", "Color": "Azul", "Manga de Camisa": "L", "Ancho Corbata": "7 cm"}},
     ]
 
 
@@ -32,7 +32,7 @@ def test_variant_csv_builders():
     assert by_attr["Marca"]["Product Attributes / Values"] == "ADAMS"
     assert by_attr["Color"]["Product Attributes / Values"] == "Azul"
     assert by_attr["Manga de Camisa"]["Product Attributes / Values"] == "L"
-    assert by_attr["Ancho Corbata"]["Product Attributes / Values"] == "7"
+    assert by_attr["Ancho Corbata"]["Product Attributes / Values"] == "7 cm"
     assert by_attr["Talla"]["Product Category"] == "Ropa / Camisas"
 
     stock = build_stock_quant(products_raw, scheduled_date="2026-05-04")

--- a/backend/tests/test_odoo_migration_rules.py
+++ b/backend/tests/test_odoo_migration_rules.py
@@ -11,9 +11,9 @@ def test_real_patterns():
     assert parse_suit_sku('210001/46')['talla'] == '46'
     assert parse_suit_sku('007-13BC-2/46')['talla'] == '46'
     assert parse_blazer_sku('007-51/68')['talla'] == '68'
-    assert parse_tie_sku('MF11812/4-6')['ancho_corbata'] == '6'
-    assert parse_tie_sku('MF11887/20-7.5')['ancho_corbata'] == '7.5'
-    assert parse_tie_sku('#0050/23-7.5')['ancho_corbata'] == '7.5'
+    assert parse_tie_sku('MF11812/4-6')['ancho_corbata'] == '6 cm'
+    assert parse_tie_sku('MF11887/20-7.5')['ancho_corbata'] == '7.5 cm'
+    assert parse_tie_sku('#0050/23-7.5')['ancho_corbata'] == '7.5 cm'
     assert parse_bowtie_sku('MF11829/1-CO')['product_name'].startswith('Corbatín')
     assert parse_fajin_sku('MF11829/1-FJ')['product_name'].startswith('Set Corbatín + Faja')
     assert parse_generic_size('006-ZOLEY-PANT/L') == 'L'


### PR DESCRIPTION
### Motivation
- Normalizar la representación de `Ancho Corbata` para que los valores exportados incluyan la unidad `cm` y así coincidan con el formato esperado en Odoo. 
- Mantener `Talla` sin unidades para no romper las equivalencias actuales de tallas en el flujo de migración. 

### Description
- Se añadió el helper `normalize_tie_width` en `backend/app/odoo_migration/rules.py` que normaliza valores y añade `cm` cuando falta. 
- `parse_tie_sku` ahora devuelve `ancho_corbata` normalizado usando `normalize_tie_width`. 
- Se importó y aplicó `normalize_tie_width` en `backend/app/odoo_migration/odoo19_variants.py` al consolidar valores de `Ancho Corbata` para exportaciones de variantes. 
- Se actualizaron pruebas y documentación: se ajustaron `backend/tests/test_odoo_migration_rules.py` y `backend/tests/test_odoo19_variants_export.py`, y se incrementó el historial de versiones a `1.0.50` en `README.MD`. 

### Testing
- Ejecuté `pytest` sobre los tests modificados con entorno correcto mediante `PYTHONPATH=backend pytest -q backend/tests/test_odoo_migration_rules.py backend/tests/test_odoo19_variants_export.py` y todos los tests pasaron (`12 passed`). 
- Una ejecución inicial de `pytest` sin `PYTHONPATH` falló en la fase de colección por `ModuleNotFoundError: No module named 'app'`, que es un problema de entorno y no del cambio en sí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95ebd2e1c8332bbb31b333abdf5d3)