### PR TITLE
Avoid exporting invented attribute values in legacy variant templates

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -287,6 +287,7 @@ Si necesitas cambiar la URL del backend para el frontend, define `API_BASE_URL` 
 
 ## Historial de cambios
 
+- **1.0.55 (2026-05-06)**: Se dejó de usar `attrs` crudo al generar `01_product_templates_with_existing_attributes.csv` y reportes legacy de variantes; ahora esos artefactos se construyen con atributos saneados desde `odoo_variant_sku_mapping.csv` (solo `Talla/Color/Manga de Camisa/Ancho Corbata/Marca` válidos). Esto evita exportar listas/códigos inventados (ej. `001,002,...`) como valores de atributo y conserva esos casos como código madre sin atributo.
 - **1.0.54 (2026-05-05)**: Se restauró deduplicación determinística en `odoo_variant_sku_mapping.csv` por combinación de atributos dentro del template para evitar errores de Odoo `product_product_combination_unique`; los SKUs repetidos por combinación ahora se reportan en `odoo_duplicate_variant_combinations.csv` con referencias descartadas para revisión.
 - **1.0.53 (2026-05-05)**: Se corrigió el manejo de corbatas con sufijo slash no-ancho (ej. `CORBATA-BC/2013`) para no forzar `Talla`/`Ancho Corbata`; ahora se marcan `UNPARSED` y no contaminan validación template/variantes. También se aplica la misma regla de normalización de corbatas al construir templates para mantener consistencia con variant mapping.
 - **1.0.52 (2026-05-05)**: Se saneó la fusión de atributos parseados/raw para evitar contaminar `Talla` y `Ancho Corbata` con SKUs completos o códigos inválidos (ej. `CIN-C-ML`, `MR-10845-1/7`), corrigiendo fallos de validación `template/variantes` en ejecución de API.

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -263,6 +263,18 @@ class OdooMigrationService:
 
     def _write_variant_import_outputs(self, run_folder: Path, variant_rows: list[dict[str, Any]], include_stock: bool = False) -> None:
         grouped: dict[str, list[dict[str, Any]]] = {}
+        sanitized_attrs_by_sku: dict[str, dict[str, str]] = {}
+        for mapped in build_variant_sku_mapping(variant_rows):
+            sku = str(mapped.get("Internal Reference") or "").strip()
+            if not sku:
+                continue
+            sanitized_attrs_by_sku[sku] = {
+                "Talla": str(mapped.get("Talla") or "").strip(),
+                "Color": str(mapped.get("Color") or "").strip(),
+                "Manga de Camisa": str(mapped.get("Manga de Camisa") or "").strip(),
+                "Ancho Corbata": str(mapped.get("Ancho Corbata") or "").strip(),
+                "Marca": str(mapped.get("Marca") or "").strip(),
+            }
         for row in variant_rows:
             key = self._slugify(row.get("name") or row.get("sku") or "")
             grouped.setdefault(key, []).append(row)
@@ -279,7 +291,8 @@ class OdooMigrationService:
             attr_values: dict[str, set[str]] = {}
             real_combos = set()
             for r in rows:
-                attrs = {k: v for k, v in (r.get("attrs") or {}).items() if v}
+                sku = str(r.get("sku") or "").strip()
+                attrs = {k: v for k, v in (sanitized_attrs_by_sku.get(sku) or {}).items() if v}
                 for a, v in attrs.items():
                     attr_values.setdefault(a, set()).add(v)
                 combo = "|".join([f"{k}={attrs[k]}" for k in sorted(attrs.keys())])
@@ -304,7 +317,7 @@ class OdooMigrationService:
                     "Product Attributes / Attribute": attr, "Product Attributes / Values": values_csv
                 })
                 for v in sorted(values):
-                    missing_rows.append({"Attribute": attr, "Value": v, "Product Count": str(sum(1 for rr in rows if (rr.get('attrs') or {}).get(attr)==v)), "Example Product": first["name"], "Example Internal Reference": rows[0]["sku"]})
+                    missing_rows.append({"Attribute": attr, "Value": v, "Product Count": str(sum(1 for rr in rows if (sanitized_attrs_by_sku.get(str(rr.get('sku') or '').strip()) or {}).get(attr) == v)), "Example Product": first["name"], "Example Internal Reference": rows[0]["sku"]})
             # combinaciones fantasma
             axes = [sorted(vs) for vs in attr_values.values() if vs]
             theoretical = 1
@@ -323,11 +336,11 @@ class OdooMigrationService:
             f"- Total SKUs de origen: {len(variant_rows)}",
             f"- Total productos madre generados: {len({r['External ID'] for r in template_rows})}",
             f"- Total variantes/subproductos reales: {len(variant_map_rows)}",
-            f"- Total productos con Marca: {sum(1 for r in variant_rows if (r.get('attrs') or {}).get('Marca'))}",
-            f"- Total productos con Color: {sum(1 for r in variant_rows if (r.get('attrs') or {}).get('Color'))}",
-            f"- Total productos con Talla: {sum(1 for r in variant_rows if (r.get('attrs') or {}).get('Talla'))}",
-            f"- Total productos con Ancho Corbata: {sum(1 for r in variant_rows if (r.get('attrs') or {}).get('Ancho Corbata'))}",
-            f"- Total productos con Manga de Camisa: {sum(1 for r in variant_rows if (r.get('attrs') or {}).get('Manga de Camisa'))}",
+            f"- Total productos con Marca: {sum(1 for r in variant_rows if (sanitized_attrs_by_sku.get(str(r.get('sku') or '').strip()) or {}).get('Marca'))}",
+            f"- Total productos con Color: {sum(1 for r in variant_rows if (sanitized_attrs_by_sku.get(str(r.get('sku') or '').strip()) or {}).get('Color'))}",
+            f"- Total productos con Talla: {sum(1 for r in variant_rows if (sanitized_attrs_by_sku.get(str(r.get('sku') or '').strip()) or {}).get('Talla'))}",
+            f"- Total productos con Ancho Corbata: {sum(1 for r in variant_rows if (sanitized_attrs_by_sku.get(str(r.get('sku') or '').strip()) or {}).get('Ancho Corbata'))}",
+            f"- Total productos con Manga de Camisa: {sum(1 for r in variant_rows if (sanitized_attrs_by_sku.get(str(r.get('sku') or '').strip()) or {}).get('Manga de Camisa'))}",
             f"- Productos sin barcode: {sum(1 for r in variant_rows if not r.get('barcode'))}",
             f"- Productos sin Internal Reference: {sum(1 for r in variant_rows if not r.get('sku'))}",
             f"- Confirmación: NO se crean atributos/categorías de variante, solo se usan atributos existentes."


### PR DESCRIPTION
### Motivation
- Prevent legacy CSV outputs from exporting invented or malformed attribute values (e.g. comma-separated code lists) that were coming from raw `attrs` on variant rows. 
- Ensure only previously-created/validated attribute values (`Talla`, `Color`, `Manga de Camisa`, `Ancho Corbata`, `Marca`) are propagated to legacy template/mapping outputs. 
- Bump the documented release version to reflect the behavior change in exports.

### Description
- Changed `_write_variant_import_outputs` to derive per-SKU sanitized attributes by calling `build_variant_sku_mapping(variant_rows)` and building a `sanitized_attrs_by_sku` map. 
- Replaced direct use of `row.get('attrs')` with the sanitized attributes when building `01_product_templates_with_existing_attributes.csv`, `02_variant_update_map.csv`, `03_stock_quant_by_variant.csv` and `04_missing_attribute_values_report.csv`. 
- Updated legacy report counters to count presence of attributes using the sanitized map instead of raw `attrs`. 
- Updated `README.MD` changelog to `1.0.55` and documented the rationale for the change.

### Testing
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_odoo_migration_templates.py` and it passed (`2 passed`).
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_odoo19_variants_export.py backend/tests/test_odoo_migration_templates.py` and the run had one failing existing assertion (`test_dedupe_variant_mapping_by_template_and_attributes`) unrelated to this change while the rest passed (`8 passed, 1 failed`).
- A plain `pytest` collection without `PYTHONPATH` initially failed due to import path (`ModuleNotFoundError: No module named 'app'`) which is why `PYTHONPATH=backend` was used for targeted test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faae94473083329d8a52417dfc0470)