### PR TITLE
Tighten size/tie parsing, split template rows for Odoo import, and add export version

### DIFF
--- a/backend/app/odoo_migration/odoo19_variants.py
+++ b/backend/app/odoo_migration/odoo19_variants.py
@@ -19,6 +19,7 @@ STOCK_QUANT_SIMPLE_COLUMNS = ["Product / Internal Reference", "Location", "Inven
 VALIDATION_COLUMNS = ["level", "rule", "entity", "message"]
 STOCK_COLUMNS = ["Product", "Lot/Serial Number", "Quantity", "Counted Quantity", "Difference", "Scheduled Date", "Assigned To"]
 SLEEVE_MAP = {"S1": "S1 - 32/33", "S2": "S2 - 34/35"}
+ODOO_CSV_EXPORT_VERSION = "1.2.0"
 
 
 def parse_base_code_and_variant(codigo: str) -> tuple[str, str]:
@@ -292,7 +293,10 @@ def build_products_with_variants_from_variant_rows(variant_rows: list[dict[str, 
             result.append({**common, "Product Attributes / Attribute": "", "Product Attributes / Values": ""})
         else:
             for attr_name, values in attr_values.items():
-                result.append({**common, "Product Attributes / Attribute": attr_name, "Product Attributes / Values": ",".join(values)})
+                unique_values = sorted({normalize_product_name(v) for v in values if normalize_product_name(v)}, key=_natural_key)
+                if not attr_name or not unique_values:
+                    continue
+                result.append({**common, "Product Attributes / Attribute": attr_name, "Product Attributes / Values": ",".join(unique_values)})
     return result
 
 
@@ -323,6 +327,15 @@ def _format_cm_value(value: str) -> str:
     return f"{num} cm"
 
 
+def _is_reasonable_tie_width_cm(value: str) -> bool:
+    raw = normalize_product_name(value).lower().replace("cm", "").strip().replace(",", ".")
+    try:
+        width = float(raw)
+    except Exception:
+        return False
+    return 5.0 <= width <= 10.0
+
+
 def _apply_tie_attribute_rules(attrs: dict[str, Any], name: str, category: str) -> dict[str, str]:
     normalized = {
         "Talla": attrs.get("Talla", ""),
@@ -338,10 +351,10 @@ def _apply_tie_attribute_rules(attrs: dict[str, Any], name: str, category: str) 
             if not ancho:
                 ancho = talla
             normalized["Talla"] = ""
-        normalized["Ancho Corbata"] = _format_cm_value(ancho)
+        normalized["Ancho Corbata"] = _format_cm_value(ancho) if _is_reasonable_tie_width_cm(ancho) else ""
         normalized["Talla"] = ""
     else:
-        normalized["Ancho Corbata"] = _format_cm_value(normalized["Ancho Corbata"]) if normalized["Ancho Corbata"] else ""
+        normalized["Ancho Corbata"] = _format_cm_value(normalized["Ancho Corbata"]) if normalized["Ancho Corbata"] and _is_reasonable_tie_width_cm(normalized["Ancho Corbata"]) else ""
     return normalized
 
 
@@ -352,11 +365,27 @@ def _looks_like_valid_size(value: str) -> bool:
     return bool(re.match(r"^(XS|S|M|L|XL|XXL|XXXL|SL|ML|\d+(?:\.\d+)?)$", v))
 
 
+def _is_reasonable_size_value(value: str) -> bool:
+    v = normalize_product_name(value).upper()
+    if v in {"XS", "S", "M", "L", "XL", "XXL", "XXXL", "SL", "ML"}:
+        return True
+    if not re.match(r"^\d+(?:\.\d+)?$", v):
+        return False
+    try:
+        num = float(v)
+    except Exception:
+        return False
+    # Restrict to realistic apparel sizes and avoid long numeric codes treated as sizes.
+    if "." in v and not v.endswith(".5"):
+        return False
+    return 4 <= num <= 70 and len(v.split(".")[0]) <= 2
+
+
 def _clean_candidate_attrs(sku: str, parsed_attrs: dict[str, Any], raw_attrs: dict[str, Any]) -> dict[str, Any]:
     sku_u = normalize_product_name(sku).upper()
     talla = normalize_product_name(str(parsed_attrs.get("Talla") or raw_attrs.get("Talla") or ""))
     ancho = normalize_product_name(str(parsed_attrs.get("Ancho Corbata") or raw_attrs.get("Ancho Corbata") or ""))
-    if not _looks_like_valid_size(talla) or normalize_product_name(talla).upper() == sku_u or "/" in talla:
+    if (not _looks_like_valid_size(talla)) or (not _is_reasonable_size_value(talla)) or normalize_product_name(talla).upper() == sku_u or "/" in talla:
         talla = ""
     # Ancho Corbata only accepts numeric-ish values, never full SKUs/codes
     if ancho and not re.match(r"^\d+(?:[\.,]\d+)?(?:\s*cm)?$", ancho, flags=re.IGNORECASE):

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -16,6 +16,7 @@ from .odoo19_variants import (
     build_variant_sku_mapping,
     dedupe_variant_mapping_rows,
     PRODUCTS_COLUMNS as ODOO_TEMPLATE_COLUMNS,
+    ODOO_CSV_EXPORT_VERSION,
     VARIANT_MAPPING_COLUMNS,
     STOCK_QUANT_SIMPLE_COLUMNS,
 )
@@ -156,7 +157,12 @@ class OdooMigrationService:
                 if any(m.get("Internal Reference", "") in stock_positive_skus for m in matches):
                     duplicate_skus_with_stock.update({m.get("Internal Reference", "") for m in matches})
         self._validate_template_attribute_consistency(o19_product_rows=o19_product_rows, o19_variant_map_rows=o19_variant_map_rows)
+        self._validate_template_external_id_conflicts(o19_product_rows)
+        simple_cols = [c for c in ODOO_TEMPLATE_COLUMNS if c not in {"Product Attributes / Attribute", "Product Attributes / Values"}]
+        simple_rows, with_attr_rows = self._split_template_rows_for_odoo_import(o19_product_rows)
         self._write_csv(folder / "odoo_product_templates.csv", ODOO_TEMPLATE_COLUMNS, o19_product_rows)
+        self._write_csv(folder / "odoo_product_templates_simple.csv", simple_cols, simple_rows)
+        self._write_csv(folder / "odoo_product_templates_with_attributes.csv", ODOO_TEMPLATE_COLUMNS, with_attr_rows)
         self._write_csv(folder / "odoo_variant_sku_mapping.csv", VARIANT_MAPPING_COLUMNS, o19_variant_map_rows)
         self._write_csv(folder / "odoo_stock_quant.csv", STOCK_QUANT_SIMPLE_COLUMNS, o19_stock_rows)
         self._write_csv(folder / "odoo_import_validation_report.csv", ["level", "rule", "entity", "message"], validation_rows)
@@ -178,7 +184,7 @@ class OdooMigrationService:
         debug_lines += [f"summary={json.dumps(counts)}", f"pages_fetched={pages_fetched}", f"hit_max_pages={hit_max_pages}", f"snapshot={snapshot_path.name}", f"state={state_path.name}"]
         debug_log.write_text("\n".join(debug_lines)+"\n", encoding='utf-8'); raw_log.write_text("\n".join(raw_lines)+"\n", encoding='utf-8')
         duration_seconds = round((datetime.utcnow() - started_at).total_seconds(), 2)
-        summary={"total_products":len(phase1['prows']),"total_categorias_no_mapeadas":len(phase1['unmapped_category_rows']),"total_skus_unicos_product_product":len({r.get('Internal Reference') for r in phase1['prows']}),"total_lineas_initial_stock":0,"total_lineas_stock_quant":0,"total_skus_stock_match_producto":0,"total_skus_stock_no_match_producto":0,"total_ubicaciones_mapeadas":0,"total_ubicaciones_no_mapeadas":0,"total_productos_excluidos_stock_0":len(phase1['zrows']),"total_errores_reales":len(phase1['erows']),"stock_export_enabled": export_stock, "phase_1_completed": True, "phase_2_completed": export_stock, "include_additional_attributes": include_additional_attributes, "include_brand_color_attributes": include_additional_attributes, "expected_min_items_from_api": expected_min_items, "fetched_items_meet_expected_min": (len(products) >= expected_min_items) if expected_min_items is not None else None, "duration_seconds": duration_seconds}
+        summary={"total_products":len(phase1['prows']),"total_categorias_no_mapeadas":len(phase1['unmapped_category_rows']),"total_skus_unicos_product_product":len({r.get('Internal Reference') for r in phase1['prows']}),"total_lineas_initial_stock":0,"total_lineas_stock_quant":0,"total_skus_stock_match_producto":0,"total_skus_stock_no_match_producto":0,"total_ubicaciones_mapeadas":0,"total_ubicaciones_no_mapeadas":0,"total_productos_excluidos_stock_0":len(phase1['zrows']),"total_errores_reales":len(phase1['erows']),"stock_export_enabled": export_stock, "phase_1_completed": True, "phase_2_completed": export_stock, "include_additional_attributes": include_additional_attributes, "include_brand_color_attributes": include_additional_attributes, "expected_min_items_from_api": expected_min_items, "fetched_items_meet_expected_min": (len(products) >= expected_min_items) if expected_min_items is not None else None, "duration_seconds": duration_seconds, "odoo_csv_export_version": ODOO_CSV_EXPORT_VERSION}
         if export_stock:
             stock_rows = self._read_csv_rows(stock_csv)
             stock_quant_rows = self._read_csv_rows(stock_quant_csv)
@@ -380,6 +386,54 @@ class OdooMigrationService:
 
         if violations:
             raise ValueError("Inconsistencia template/variantes detectada: " + " | ".join(violations[:10]))
+
+    @staticmethod
+    def _split_template_rows_for_odoo_import(rows: list[dict[str, str]]) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+        simple_rows: list[dict[str, str]] = []
+        with_attr_rows: list[dict[str, str]] = []
+        grouped_by_external_id: dict[str, list[dict[str, str]]] = {}
+        for row in rows:
+            grouped_by_external_id.setdefault(str(row.get("External ID") or ""), []).append(row)
+
+        for external_id, same_template_rows in grouped_by_external_id.items():
+            attr_pairs: dict[str, set[str]] = {}
+            for row in same_template_rows:
+                attr = str(row.get("Product Attributes / Attribute") or "").strip()
+                values = [v.strip() for v in str(row.get("Product Attributes / Values") or "").split(",") if v.strip()]
+                if not attr and not values:
+                    continue
+                if attr and not values:
+                    continue
+                if values and not attr:
+                    continue
+                attr_pairs.setdefault(attr, set()).update(values)
+
+            base_row = dict(same_template_rows[0]) if same_template_rows else {"External ID": external_id}
+            if not attr_pairs:
+                clean = {k: v for k, v in base_row.items() if k not in {"Product Attributes / Attribute", "Product Attributes / Values"}}
+                simple_rows.append(clean)
+                continue
+
+            for attr, values in sorted(attr_pairs.items()):
+                with_attr_rows.append({**base_row, "Product Attributes / Attribute": attr, "Product Attributes / Values": ",".join(sorted(values))})
+        return simple_rows, with_attr_rows
+
+    @staticmethod
+    def _validate_template_external_id_conflicts(rows: list[dict[str, str]]) -> None:
+        by_ext: dict[str, set[tuple[str, str, str]]] = {}
+        for row in rows:
+            ext = str(row.get("External ID") or "").strip()
+            if not ext:
+                continue
+            signature = (
+                str(row.get("Name") or "").strip(),
+                str(row.get("Sales Price") or "").strip(),
+                str(row.get("Product Category") or "").strip(),
+            )
+            by_ext.setdefault(ext, set()).add(signature)
+        conflicts = [ext for ext, sigs in by_ext.items() if len(sigs) > 1]
+        if conflicts:
+            raise ValueError(f"External ID conflictivo detectado en templates: {', '.join(conflicts[:10])}")
 
     @staticmethod
     def _slugify(text: str) -> str:

--- a/backend/tests/test_odoo19_variants_export.py
+++ b/backend/tests/test_odoo19_variants_export.py
@@ -107,3 +107,21 @@ def test_tie_slash_non_width_is_not_forced_to_ancho():
     assert rows[0]["Ancho Corbata"] == ""
     assert rows[0]["Talla"] == ""
     assert rows[0]["Parse Status"] == "UNPARSED"
+
+
+def test_unreasonable_size_codes_are_not_exported_as_talla():
+    rows = build_variant_sku_mapping([
+        {"sku": "ABC-9002", "name": "PANTALON", "barcode": "", "price": "1", "cost": "1", "category": "ROPA", "attrs": {"Talla": "9002"}},
+        {"sku": "ABC-0036", "name": "PANTALON", "barcode": "", "price": "1", "cost": "1", "category": "ROPA", "attrs": {"Talla": "0036"}},
+    ])
+    assert rows[0]["Talla"] == ""
+    assert rows[1]["Talla"] == ""
+
+
+def test_unreasonable_tie_widths_are_not_exported():
+    rows = build_variant_sku_mapping([
+        {"sku": "BW-1", "name": "CORBATA BW", "barcode": "", "price": "1", "cost": "1", "category": "ROPA / HOMBRES / CORBATAS", "attrs": {"Ancho Corbata": "1"}},
+        {"sku": "BW-84", "name": "CORBATA BW", "barcode": "", "price": "1", "cost": "1", "category": "ROPA / HOMBRES / CORBATAS", "attrs": {"Ancho Corbata": "84"}},
+    ])
+    assert rows[0]["Ancho Corbata"] == ""
+    assert rows[1]["Ancho Corbata"] == ""

--- a/backend/tests/test_odoo_migration_templates.py
+++ b/backend/tests/test_odoo_migration_templates.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.odoo_migration.service import (
     OdooMigrationService,
     PRODUCT_COLUMNS,
@@ -18,3 +20,36 @@ def test_stock_template_columns_match_service_columns():
     service = OdooMigrationService(client=None)  # type: ignore[arg-type]
     header = service._read_header(TEMPLATE_STOCK_PATH)
     assert header == STOCK_QUANT_COLUMNS
+
+
+def test_split_template_rows_for_odoo_import():
+    rows = [
+        {"External ID": "product_template_100", "Name": "Camisa 100", "Sales Price": "10.00", "Product Category": "Ropa", "Product Attributes / Attribute": "", "Product Attributes / Values": ""},
+        {"External ID": "product_template_200", "Name": "Camisa 200", "Sales Price": "20.00", "Product Category": "Ropa", "Product Attributes / Attribute": "Talla", "Product Attributes / Values": "M"},
+        {"External ID": "product_template_200", "Name": "Camisa 200", "Sales Price": "20.00", "Product Category": "Ropa", "Product Attributes / Attribute": "Talla", "Product Attributes / Values": "L,M"},
+        {"External ID": "product_template_200", "Name": "Camisa 200", "Sales Price": "20.00", "Product Category": "Ropa", "Product Attributes / Attribute": "Color", "Product Attributes / Values": "Azul"},
+    ]
+    simple_rows, with_attr_rows = OdooMigrationService._split_template_rows_for_odoo_import(rows)
+    assert len(simple_rows) == 1
+    assert simple_rows[0]["External ID"] == "product_template_100"
+    talla_rows = [r for r in with_attr_rows if r["Product Attributes / Attribute"] == "Talla"]
+    assert len(talla_rows) == 1
+    assert talla_rows[0]["Product Attributes / Values"] == "L,M"
+    assert all(r["Product Attributes / Attribute"] and r["Product Attributes / Values"] for r in with_attr_rows)
+
+
+def test_validate_template_external_id_conflicts():
+    rows = [
+        {"External ID": "product_template_ok", "Name": "Producto", "Sales Price": "10.00", "Product Category": "Ropa"},
+        {"External ID": "product_template_ok", "Name": "Producto", "Sales Price": "10.00", "Product Category": "Ropa"},
+    ]
+    OdooMigrationService._validate_template_external_id_conflicts(rows)
+
+
+def test_validate_template_external_id_conflicts_raises():
+    rows = [
+        {"External ID": "product_template_conflict", "Name": "Producto A", "Sales Price": "10.00", "Product Category": "Ropa"},
+        {"External ID": "product_template_conflict", "Name": "Producto B", "Sales Price": "11.00", "Product Category": "Ropa"},
+    ]
+    with pytest.raises(ValueError):
+        OdooMigrationService._validate_template_external_id_conflicts(rows)


### PR DESCRIPTION
### Motivation
- Prevent invalid numeric codes and unreasonable tie widths from being treated as sizes or tie widths in variant exports and to surface template export metadata.
- Produce Odoo-ready template CSVs (simple vs with attributes) and detect conflicting template `External ID` signatures before export.

### Description
- Add `ODOO_CSV_EXPORT_VERSION` constant and include it in the run `summary` JSON as `odoo_csv_export_version`.
- Improve attribute value normalization when building product templates to dedupe, normalize and skip empty values before joining export values.
- Add `_is_reasonable_tie_width_cm` and `_is_reasonable_size_value` helpers and apply them in `_apply_tie_attribute_rules` and `_clean_candidate_attrs` to reject implausible tie widths and size codes.
- Update `service.py` to validate template external ID consistency via `_validate_template_external_id_conflicts` and to split template rows into simple and attribute-bearing rows with `_split_template_rows_for_odoo_import`, and write `odoo_product_templates_simple.csv` and `odoo_product_templates_with_attributes.csv` alongside the original export.

### Testing
- Ran unit tests under `backend/tests`, including new tests `test_unreasonable_size_codes_are_not_exported_as_talla`, `test_unreasonable_tie_widths_are_not_exported`, `test_split_template_rows_for_odoo_import`, `test_validate_template_external_id_conflicts`, and `test_validate_template_external_id_conflicts_raises` using `pytest`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabd4d1eb483329e33f36ef16180e8)