### PR TITLE
Always export products as storable and map Contífico `para_pos` → `available_in_pos` (bump exporter to 1.4.7)

### DIFF
--- a/backend/app/odoo_migration/odoo19_variants.py
+++ b/backend/app/odoo_migration/odoo19_variants.py
@@ -10,7 +10,7 @@ import unicodedata
 ATTR_COLUMNS = ["Attribute", "Display Type", "Variant Creation Mode", "Values / Value"]
 PRODUCTS_COLUMNS = [
     "External ID", "Name", "Product Type", "Product Category", "Sales Price", "Cost", "Can be Sold",
-    "Can be Purchased", "Available in POS", "Customer Taxes", "Product Attributes / Attribute", "Product Attributes / Values",
+    "Can be Purchased", "is_storable", "available_in_pos", "Customer Taxes", "Product Attributes / Attribute", "Product Attributes / Values",
 ]
 VARIANT_MAPPING_COLUMNS = [
     "Product Template External ID", "Product Template Name", "Internal Reference", "Barcode", "Talla", "Color",
@@ -200,7 +200,7 @@ def build_products_with_variants(products: list[dict[str, Any]], warnings: list[
         common = {
             "External ID": normalize_external_id(base, "product_template"), "Name": name, "Product Type": "Goods",
             "Product Category": "All / ADAMS / Sin categoría", "Sales Price": price, "Cost": cost,
-            "Can be Sold": "True", "Can be Purchased": "True", "Available in POS": normalize_bool(items[0].get("para_pos")),
+            "Can be Sold": "True", "Can be Purchased": "True", "is_storable": "True", "available_in_pos": normalize_bool(items[0].get("para_pos"), default=False),
             "Internal Reference": base, "Barcode": barcode, "Sales Description": str(items[0].get("descripcion") or ""), "Customer Taxes": _tax_name(items[0].get("porcentaje_iva")),
         }
         if talla_vals:
@@ -275,7 +275,8 @@ def build_products_with_variants_from_variant_rows(variant_rows: list[dict[str, 
             "Cost": normalize_price(items[0].get("cost")),
             "Can be Sold": "True",
             "Can be Purchased": "True",
-            "Available in POS": "True",
+            "is_storable": "True",
+            "available_in_pos": normalize_bool(items[0].get("para_pos"), default=False),
             "Customer Taxes": "IVA 0%",
         }
         attr_values: dict[str, list[str]] = {}
@@ -499,7 +500,8 @@ def split_templates_by_catalog(
             "Cost": normalize_price(seed.get("cost")),
             "Can be Sold": "True",
             "Can be Purchased": "True",
-            "Available in POS": "True",
+            "is_storable": "True",
+            "available_in_pos": normalize_bool(seed.get("para_pos"), default=False),
             "Customer Taxes": "IVA 0%",
             "Internal Reference": str(seed.get("sku") or ""),
             "Barcode": str(seed.get("barcode") or str(seed.get("sku") or "")),

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -46,7 +46,11 @@ TEMPLATE_ATTR_COLUMNS = ["External ID","Name","Product Type","Sales Price","Cost
 VARIANT_MAP_COLUMNS = ["Template External ID","Template Name","Source Variant External ID","Variant Attributes Key","Internal Reference","Barcode","Sales Price","Cost","Weight","Original Product Values"]
 STOCK_BY_VARIANT_COLUMNS = ["Product External ID","Location","Quantity"]
 MISSING_ATTR_COLUMNS = ["Attribute","Value","Product Count","Example Product","Example Internal Reference"]
-EXPORTER_VERSION = "1.4.6"
+EXPORTER_VERSION = "1.4.7"
+
+
+def _to_odoo_bool(value: Any) -> str:
+    return "True" if value is True else "False"
 
 
 @dataclass
@@ -131,7 +135,8 @@ class OdooMigrationService:
                     "Cost": f"{float(src.get('cost') or 0):.2f}",
                     "Can be Sold": "True",
                     "Can be Purchased": "True",
-                    "Available in POS": "True",
+                    "is_storable": "True",
+                    "available_in_pos": _to_odoo_bool(src.get("para_pos")),
                     "Customer Taxes": "IVA 0%",
                     "Internal Reference": sku,
                     "Barcode": str(src.get("barcode") or sku),
@@ -208,7 +213,8 @@ class OdooMigrationService:
                     "Cost": f"{float(src.get('cost') or 0):.2f}",
                     "Can be Sold": "True",
                     "Can be Purchased": "True",
-                    "Available in POS": "True",
+                    "is_storable": "True",
+                    "available_in_pos": _to_odoo_bool(src.get("para_pos")),
                     "Customer Taxes": "IVA 0%",
                     "Internal Reference": sku,
                     "Barcode": str(src.get("barcode") or sku),
@@ -225,8 +231,8 @@ class OdooMigrationService:
             if not row.get("Internal Reference"):
                 row["Internal Reference"] = str(row.get("source_sku") or "")
             row["Barcode"] = str(row.get("Barcode") or row.get("barcode") or row.get("Internal Reference") or "")
-        self._write_csv(folder / "odoo_product_templates_simple.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","Available in POS","Customer Taxes","Internal Reference","Barcode"], simple_rows)
-        self._write_csv(folder / "odoo_product_templates_with_attributes.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","Available in POS","Customer Taxes","Product Attributes / Attribute","Product Attributes / Values"], with_attr_rows)
+        self._write_csv(folder / "odoo_product_templates_simple.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Customer Taxes","Internal Reference","Barcode"], simple_rows)
+        self._write_csv(folder / "odoo_product_templates_with_attributes.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Customer Taxes","Product Attributes / Attribute","Product Attributes / Values"], with_attr_rows)
         self._write_csv(folder / "odoo_attribute_rejections.csv", ["source_sku","source_id","source_name","attempted_attribute","attempted_value","reason"], rejection_rows)
         mapping_skus = {r.get("Internal Reference", "") for r in o19_variant_map_rows}
         simple_skus = {r.get("Internal Reference", "") for r in simple_rows}
@@ -333,7 +339,7 @@ class OdooMigrationService:
                 mrows.append(build_mapping_report_row(sku=sku,nombre_contifico=name,producto_madre_detectado=prod_name,categoria_odoo_detectada=category,talla_detectada=talla,manga_detectada=manga,ancho_corbata_detectado=ancho,marca_detectada=brand,color_detectado=color,barcode=barcode,precio=f"{price:.2f}",costo=f"{cost:.2f}",stock_bpu=f"{stock_map['BPU']:.2f}",stock_tur=f"{stock_map['TUR']:.2f}",stock_bat=f"{stock_map['BAT']:.2f}",stock_total_contifico=f"{stock_total:.2f}",estado=state,confidence=confidence,parser_rule=parser_rule or 'generic'))
                 variant_rows.append({
                     "sku": sku, "name": prod_name, "barcode": barcode, "price": f"{price:.2f}", "cost": f"{cost:.2f}",
-                    "weight": "0.0", "category": category, "stock_map": stock_map,
+                    "weight": "0.0", "category": category, "stock_map": stock_map, "para_pos": item.get("para_pos"),
                     "attrs": {"Marca": brand, "Color": color, "Talla": talla, "Manga de Camisa": manga, "Ancho Corbata": ancho}
                 })
                 payload = {"id": str(item.get('id') or ''), "sku": sku, "cost": cost, "stock_map": stock_map}

--- a/backend/tests/test_odoo19_variants_export.py
+++ b/backend/tests/test_odoo19_variants_export.py
@@ -35,6 +35,8 @@ def test_variant_csv_builders():
     mapping = build_variant_sku_mapping(_sample())
     assert mapping[0]["Ancho Corbata"] == "7 cm"
     assert by_attr["Talla"]["Product Category"] == "Ropa / Camisas"
+    assert by_attr["Talla"]["is_storable"] == "True"
+    assert by_attr["Talla"]["available_in_pos"] == "False"
 
 
 def test_parent_base_code_extraction_rules():


### PR DESCRIPTION
### Motivation
- Ajustar el generador de archivos de importación para que todos los productos físicos se creen por defecto como inventariables en Odoo y reflejen la disponibilidad en POS según el campo `para_pos` de Contífico.
- Cumplir la nueva regla de migración: no depender de `cantidad_stock` para decidir si un producto es inventariable.
- Incrementar la versión del exportador siguiendo la política de versiones internas (`EXPORTER_VERSION`).

### Description
- Añadidas las columnas técnicas `is_storable` y `available_in_pos` en los CSV de productos generados y en los encabezados de salida; se actualizó la escritura de los archivos `odoo_product_templates_simple.csv` y `odoo_product_templates_with_attributes.csv` para incluir estas columnas (modificaciones en `backend/app/odoo_migration/service.py` y `backend/app/odoo_migration/odoo19_variants.py`).
- Implementado `is_storable = True` por defecto para productos físicos en todos los caminos de construcción (plantillas con y sin atributos) y mapeo de `para_pos` → `available_in_pos` con un default estricto `False` cuando falta o es nulo; se propagó `para_pos` en `variant_rows` para mantener consistencia. (Véase `service.py` y `odoo19_variants.py`).
- Añadida la utilidad `_to_odoo_bool` para normalizar el mapeo booleano y actualizado el `EXPORTER_VERSION` de `1.4.6` a `1.4.7`.
- Actualizadas pruebas para cubrir que los productos exportados incluyen `is_storable` y `available_in_pos` correctamente (`backend/tests/test_odoo19_variants_export.py`).

### Testing
- Ejecutado `pytest` sobre los tests modificados con `PYTHONPATH=backend` y los archivos de prueba `backend/tests/test_odoo19_variants_export.py` y `backend/tests/test_odoo_migration_templates.py`; resultado: `9 passed`.
- Nota: una ejecución inicial sin `PYTHONPATH` falló en la fase de recolección por import error (entorno de ejecución), por lo que se repitió la ejecución con `PYTHONPATH=backend` y las pruebas pasaron exitosamente.
- Las pruebas validadas incluyen los constructores de CSV de variantes y la consistencia de los templates contra los encabezados esperados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb367b958883328d608d209c576cf0)