### PR TITLE
Fix duplicate Talla values and missing Internal Reference in phase 2 variant export

### DIFF
--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -46,7 +46,7 @@ TEMPLATE_ATTR_COLUMNS = ["External ID","Name","Product Type","Sales Price","Cost
 VARIANT_MAP_COLUMNS = ["Template External ID","Template Name","Source Variant External ID","Variant Attributes Key","Internal Reference","Barcode","Sales Price","Cost","Weight","Original Product Values"]
 STOCK_BY_VARIANT_COLUMNS = ["Product External ID","Location","Quantity"]
 MISSING_ATTR_COLUMNS = ["Attribute","Value","Product Count","Example Product","Example Internal Reference"]
-EXPORTER_VERSION = "1.5.1"
+EXPORTER_VERSION = "1.5.2"
 
 
 def _to_odoo_bool(value: Any) -> str:
@@ -434,13 +434,28 @@ class OdooMigrationService:
         variant_rows: list[dict[str, str]] = []
         validation_rows: list[dict[str, str]] = []
 
+        def _normalize_variant_attr_value(attr: str, raw_value: str) -> str:
+            parts = [normalize.strip() for normalize in re.split(r"\s*,\s*", str(raw_value or "")) if normalize.strip()]
+            cleaned: list[str] = []
+            seen: set[str] = set()
+            for part in parts or [str(raw_value or "").strip()]:
+                value = re.sub(r"^\s*[^:]+:\s*", "", part).strip()
+                if not value:
+                    continue
+                key = value.casefold()
+                if key in seen:
+                    continue
+                seen.add(key)
+                cleaned.append(value)
+            return ", ".join(cleaned)
+
         for row in variant_map_rows:
-            sku = str(row.get("Internal Reference") or "").strip()
+            sku = str(row.get("Internal Reference") or row.get("source_sku") or row.get("Source SKU") or row.get("Barcode") or "").strip()
             barcode = str(row.get("Barcode") or "").strip() or sku
             name = str(row.get("Product Template Name") or "").strip()
             values = []
             for attr in attr_order:
-                v = str(row.get(attr) or "").strip()
+                v = _normalize_variant_attr_value(attr, str(row.get(attr) or ""))
                 if v:
                     values.append(f"{attr}: {v}")
             variant_values = ", ".join(values)

--- a/backend/tests/test_odoo_phase2_variant_internal_refs.py
+++ b/backend/tests/test_odoo_phase2_variant_internal_refs.py
@@ -76,3 +76,31 @@ def test_phase2_variant_csv_format_validation_has_no_errors_for_valid_output(tmp
 
     errors = _read_csv(tmp_path / "odoo_phase2_csv_format_errors.csv")
     assert errors == []
+
+
+def test_phase2_variant_values_dedupe_and_internal_reference_fallback(tmp_path: Path):
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    variant_map_rows = [{
+        "Product Template External ID": "product_template_blusa",
+        "Product Template Name": "BLUSA M/3/4 P/DAMA BLANCA AZUL",
+        "Internal Reference": "",
+        "source_sku": "BLU-34-AZ-XS",
+        "Barcode": "",
+        "Talla": "XS,Talla: XS",
+        "Color": "Azul",
+        "Sales Price": "19.90",
+        "Cost": "9.50",
+    }]
+
+    service._write_phase2_variant_internal_reference_outputs(
+        folder=tmp_path,
+        variant_map_rows=variant_map_rows,
+        with_attr_rows=[{"Name": "BLUSA M/3/4 P/DAMA BLANCA AZUL"}],
+        simple_rows=[],
+        stock_rows=[],
+    )
+
+    out = _read_csv(tmp_path / "odoo_product_variant_internal_references.csv")
+    assert out[0]["Internal Reference"] == "BLU-34-AZ-XS"
+    assert out[0]["Barcode"] == "BLU-34-AZ-XS"
+    assert out[0]["Variant Values"] == "Talla: XS, Color: Azul"


### PR DESCRIPTION
## Summary
- sanitize per-attribute values when generating `Variant Values` in phase 2 output
- deduplicate repeated tokens such as `Talla: XS,Talla: XS` to a single `Talla: XS`
- add fallback for missing `Internal Reference` using `source_sku`/`Source SKU`/`Barcode`
- bump exporter version from `1.5.1` to `1.5.2`

## Details
In `_write_phase2_variant_internal_reference_outputs`:
- introduced normalization logic to split comma-separated attribute values, strip embedded `Attr:` prefixes, and remove duplicates case-insensitively
- preserved valid multi-value behavior while preventing duplicated textual fragments
- prevented blank SKU exports by using fallback source keys before validation

## Tests
- added `test_phase2_variant_values_dedupe_and_internal_reference_fallback` in `backend/tests/test_odoo_phase2_variant_internal_refs.py`
  - verifies `Internal Reference` falls back to `source_sku`
  - verifies barcode fallback follows SKU
  - verifies duplicated Talla input is emitted once in `Variant Values`

## Impact
This addresses import rows where variant attributes were duplicated and where most products were missing Internal Code due to absent `Internal Reference` in the intermediate row.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7f79815483329d01fff75502a141)