### PR TITLE
Auditoría Fase 1: limpiar Customer Taxes, agrupar archivos por fase, …

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -376,14 +376,50 @@ El módulo Odoo de staging/importación se mantiene en un repositorio independie
 Este repositorio (`ContificoToOdoo`) queda dedicado al pipeline de extracción y generación de CSV revisables.
 
 
-## Exportación Odoo 19 (productos con variantes)
+## Archivos generados por corrida y orden de importación en Odoo
 
-Desde la versión 1.0.46 se generan adicionalmente tres CSV en cada RUN:
-1. `attributes_values.csv`
-2. `products_with_variants.csv`
-3. `stock_quant.csv`
+Cada corrida genera los siguientes archivos en `backend/data/odoo_migration/<timestamp>/`.
+El frontend los agrupa por fase y muestra advertencias de calidad antes de descargarlos.
 
-Orden de importación recomendado en Odoo:
-1) Attributes/Values, 2) Products with variants, 3) Stock por ajuste físico.
+### Fase 1 — Importar productos en Odoo
 
-Nota: si necesitas controlar SKU/barcode/precio estrictamente por variante en Odoo, puede requerirse una cuarta importación futura específica de variantes.
+> Prerequisito: verificar en Odoo que los atributos `Talla`, `Color`, `Manga de Camisa` y `Ancho Corbata` existan con sus valores correctos (`Inventario → Configuración → Atributos`).
+
+| Orden | Archivo | Modelo Odoo | Notas |
+|-------|---------|-------------|-------|
+| 1 | `odoo_product_templates_simple.csv` | `product.template` | Productos sin variantes. Incluye `Internal Reference` y `Barcode`. |
+| 2 | `odoo_product_templates_with_attributes.csv` | `product.template` | Templates con variantes. **No** incluye `Internal Reference` ni `Barcode` (se actualizan en Fase 2). |
+
+### Fase 2 — Actualizar Internal Reference / SKU
+
+> Ejecutar **después** de que Odoo haya creado las variantes. Odoo identifica los registros por `Name + Variant Values`.
+
+| Orden | Archivo | Modelo Odoo | Notas |
+|-------|---------|-------------|-------|
+| 3 | `odoo_product_variant_internal_references.csv` | `product.product` | Setea SKU y Barcode en variantes. Identificación: `Name + Variant Values`. |
+| 4 | `product_internal_reference_update.csv` | `product.product` / `product.template` | Update unificado (simples + variantes) con `External ID`. |
+
+### Fase 3 — Stock
+
+> Ejecutar **después** de la Fase 2. Requiere que los `Internal Reference` estén seteados.
+
+| Orden | Archivo | Modelo Odoo | Notas |
+|-------|---------|-------------|-------|
+| 5 | `odoo_stock_quant.csv` | Ajuste físico de inventario | Columna `Product / Internal Reference` identifica el producto. |
+
+### Reportes (solo lectura, no importar en Odoo)
+
+| Archivo | Descripción |
+|---------|-------------|
+| `migration_errors.csv` | SKUs con error (vacío, barcode duplicado en Contifico) |
+| `odoo_attribute_rejections.csv` | SKUs rechazados por atributos fuera del catálogo Odoo → reclasificados como simples |
+| `odoo_barcode_conflicts.csv` | Barcodes compartidos entre varios SKUs |
+| `product_internal_reference_barcode_conflicts.csv` | Barcodes conflictivos en Fase 2 (barcode limpiado) |
+| `odoo_duplicate_variant_combinations.csv` | Combinaciones de variante duplicadas |
+| `odoo_missing_products_for_stock.csv` | SKUs con stock en Contifico sin mapping en Odoo |
+| `odoo_phase2_variant_internal_reference_validation.csv` | Validación cruzada Fase 1 ↔ Fase 2 |
+| `excluded_zero_stock.csv` | Productos excluidos por tener stock total = 0 |
+| `unmapped_categories.csv` | Categorías de Contifico sin mapeo a Odoo |
+| `mapping_report.csv` | Detalle de clasificación por SKU |
+| `debug.log` / `raw.log` | Trazas de fetch paginado |
+| `run_summary.json` | Resumen con conteos de calidad (errores, rechazos, conflictos) |

--- a/backend/app/odoo_migration/odoo19_variants.py
+++ b/backend/app/odoo_migration/odoo19_variants.py
@@ -10,7 +10,7 @@ import unicodedata
 ATTR_COLUMNS = ["Attribute", "Display Type", "Variant Creation Mode", "Values / Value"]
 PRODUCTS_COLUMNS = [
     "External ID", "Name", "Product Type", "Product Category", "Sales Price", "Cost", "Can be Sold",
-    "Can be Purchased", "is_storable", "available_in_pos", "Customer Taxes", "Product Attributes / Attribute", "Product Attributes / Values",
+    "Can be Purchased", "is_storable", "available_in_pos", "Product Attributes / Attribute", "Product Attributes / Values",
 ]
 VARIANT_MAPPING_COLUMNS = [
     "Product Template External ID", "Product Template Name", "Internal Reference", "Barcode", "Talla", "Color",
@@ -277,7 +277,6 @@ def build_products_with_variants_from_variant_rows(variant_rows: list[dict[str, 
             "Can be Purchased": "True",
             "is_storable": "True",
             "available_in_pos": normalize_bool(items[0].get("para_pos"), default=False),
-            "Customer Taxes": "IVA 0%",
         }
         attr_values: dict[str, list[str]] = {}
         if sizes:
@@ -502,7 +501,6 @@ def split_templates_by_catalog(
             "Can be Purchased": "True",
             "is_storable": "True",
             "available_in_pos": normalize_bool(seed.get("para_pos"), default=False),
-            "Customer Taxes": "IVA 0%",
             "Internal Reference": str(seed.get("sku") or ""),
             "Barcode": str(seed.get("barcode") or str(seed.get("sku") or "")),
         }

--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -39,32 +39,31 @@ def _set_job(job_id: str, payload: dict) -> None:
 
 
 def _build_files(run_id: str) -> dict[str, str]:
+    base = f"/odoo-migration/runs/{run_id}/files"
     return {
-        "product_product_csv": f"/odoo-migration/runs/{run_id}/files/product_product.csv",
-        "initial_stock_csv": f"/odoo-migration/runs/{run_id}/files/initial_stock.csv",
-        "stock_quant_csv": f"/odoo-migration/runs/{run_id}/files/stock_quant_legacy.csv",
-        "odoo_product_templates_csv": f"/odoo-migration/runs/{run_id}/files/odoo_product_templates.csv",
-        "odoo_variant_sku_mapping_csv": f"/odoo-migration/runs/{run_id}/files/odoo_variant_sku_mapping.csv",
-        "odoo_stock_quant_csv": f"/odoo-migration/runs/{run_id}/files/odoo_stock_quant.csv",
-        "odoo_product_templates_simple_csv": f"/odoo-migration/runs/{run_id}/files/odoo_product_templates_simple.csv",
-        "odoo_product_templates_with_attributes_csv": f"/odoo-migration/runs/{run_id}/files/odoo_product_templates_with_attributes.csv",
-        "odoo_attribute_rejections_csv": f"/odoo-migration/runs/{run_id}/files/odoo_attribute_rejections.csv",
-        "odoo_external_id_conflicts_csv": f"/odoo-migration/runs/{run_id}/files/odoo_external_id_conflicts.csv",
-        "odoo_barcode_conflicts_csv": f"/odoo-migration/runs/{run_id}/files/odoo_barcode_conflicts.csv",
-        "product_internal_reference_update_csv": f"/odoo-migration/runs/{run_id}/files/product_internal_reference_update.csv",
-        "product_internal_reference_barcode_conflicts_csv": f"/odoo-migration/runs/{run_id}/files/product_internal_reference_barcode_conflicts.csv",
-        "odoo_import_validation_report_csv": f"/odoo-migration/runs/{run_id}/files/odoo_import_validation_report.csv",
-        "migration_errors_csv": f"/odoo-migration/runs/{run_id}/files/migration_errors.csv",
-        "mapping_report_csv": f"/odoo-migration/runs/{run_id}/files/mapping_report.csv",
-        "excluded_zero_stock_csv": f"/odoo-migration/runs/{run_id}/files/excluded_zero_stock.csv",
-        "templates_with_existing_attributes_csv": f"/odoo-migration/runs/{run_id}/files/01_product_templates_with_existing_attributes.csv",
-        "variant_update_map_csv": f"/odoo-migration/runs/{run_id}/files/02_variant_update_map.csv",
-        "stock_quant_by_variant_csv": f"/odoo-migration/runs/{run_id}/files/03_stock_quant_by_variant.csv",
-        "missing_attribute_values_csv": f"/odoo-migration/runs/{run_id}/files/04_missing_attribute_values_report.csv",
-        "products_variants_report_md": f"/odoo-migration/runs/{run_id}/files/import_products_and_variants_report.md",
-        "debug_log": f"/odoo-migration/runs/{run_id}/files/debug.log",
-        "raw_log": f"/odoo-migration/runs/{run_id}/files/raw.log",
-        "run_summary_json": f"/odoo-migration/runs/{run_id}/files/run_summary.json",
+        # === Fase 1: importar en Odoo (en este orden) ===
+        "fase1_1_simple_products_csv": f"{base}/odoo_product_templates_simple.csv",
+        "fase1_2_templates_with_attributes_csv": f"{base}/odoo_product_templates_with_attributes.csv",
+        # === Fase 2: actualizar Internal Reference / SKU ===
+        "fase2_1_variant_internal_references_csv": f"{base}/odoo_product_variant_internal_references.csv",
+        "fase2_2_internal_reference_update_csv": f"{base}/product_internal_reference_update.csv",
+        # === Fase 3: stock ===
+        "fase3_stock_quant_csv": f"{base}/odoo_stock_quant.csv",
+        # === Reportes de calidad (no importar) ===
+        "reporte_errores_csv": f"{base}/migration_errors.csv",
+        "reporte_mapping_csv": f"{base}/mapping_report.csv",
+        "reporte_atributos_rechazados_csv": f"{base}/odoo_attribute_rejections.csv",
+        "reporte_barcode_conflicts_csv": f"{base}/odoo_barcode_conflicts.csv",
+        "reporte_barcode_conflicts_fase2_csv": f"{base}/product_internal_reference_barcode_conflicts.csv",
+        "reporte_duplicados_variantes_csv": f"{base}/odoo_duplicate_variant_combinations.csv",
+        "reporte_missing_stock_csv": f"{base}/odoo_missing_products_for_stock.csv",
+        "reporte_validacion_fase2_csv": f"{base}/odoo_phase2_variant_internal_reference_validation.csv",
+        "reporte_excluded_zero_csv": f"{base}/excluded_zero_stock.csv",
+        "reporte_unmapped_categories_csv": f"{base}/unmapped_categories.csv",
+        # === Logs y resumen ===
+        "debug_log": f"{base}/debug.log",
+        "raw_log": f"{base}/raw.log",
+        "run_summary_json": f"{base}/run_summary.json",
     }
 
 

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -144,7 +144,6 @@ class OdooMigrationService:
                     "Can be Purchased": "True",
                     "is_storable": "True",
                     "available_in_pos": _to_odoo_bool(src.get("para_pos")),
-                    "Customer Taxes": "IVA 0%",
                     "Internal Reference": sku,
                     "Barcode": str(src.get("barcode") or sku),
                 })
@@ -222,7 +221,6 @@ class OdooMigrationService:
                     "Can be Purchased": "True",
                     "is_storable": "True",
                     "available_in_pos": _to_odoo_bool(src.get("para_pos")),
-                    "Customer Taxes": "IVA 0%",
                     "Internal Reference": sku,
                     "Barcode": str(src.get("barcode") or sku),
                 })
@@ -238,8 +236,8 @@ class OdooMigrationService:
             if not row.get("Internal Reference"):
                 row["Internal Reference"] = str(row.get("source_sku") or "")
             row["Barcode"] = str(row.get("Barcode") or row.get("barcode") or row.get("Internal Reference") or "")
-        self._write_csv(folder / "odoo_product_templates_simple.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Customer Taxes","Internal Reference","Barcode"], simple_rows)
-        self._write_csv(folder / "odoo_product_templates_with_attributes.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Customer Taxes","Product Attributes / Attribute","Product Attributes / Values"], with_attr_rows)
+        self._write_csv(folder / "odoo_product_templates_simple.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Internal Reference","Barcode"], simple_rows)
+        self._write_csv(folder / "odoo_product_templates_with_attributes.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Product Attributes / Attribute","Product Attributes / Values"], with_attr_rows)
         self._write_csv(folder / "odoo_attribute_rejections.csv", ["source_sku","source_id","source_name","attempted_attribute","attempted_value","reason"], rejection_rows)
         mapping_skus = {r.get("Internal Reference", "") for r in o19_variant_map_rows}
         simple_skus = {r.get("Internal Reference", "") for r in simple_rows}
@@ -272,11 +270,49 @@ class OdooMigrationService:
         if external_id_conflicts:
             raise ValueError("Se detectaron conflictos reales de External ID. Revisar odoo_external_id_conflicts.csv.")
 
+        # H4: phase2 orphan check — variant SKUs whose template name is not in with_attr templates
+        with_attr_names = {str(r.get("Name") or "").strip() for r in with_attr_rows}
+        phase2_orphan_count = sum(
+            1 for r in o19_variant_map_rows
+            if str(r.get("Product Template Name") or "").strip() not in with_attr_names
+        )
+
         counts = phase1['counts']
         debug_lines += [f"summary={json.dumps(counts)}", f"pages_fetched={pages_fetched}", f"hit_max_pages={hit_max_pages}", f"snapshot={snapshot_path.name}", f"state={state_path.name}"]
         debug_log.write_text("\n".join(debug_lines)+"\n", encoding='utf-8'); raw_log.write_text("\n".join(raw_lines)+"\n", encoding='utf-8')
         duration_seconds = round((datetime.utcnow() - started_at).total_seconds(), 2)
-        summary={"total_products":len(phase1['prows']),"total_categorias_no_mapeadas":len(phase1['unmapped_category_rows']),"total_skus_unicos_product_product":len({r.get('Internal Reference') for r in phase1['prows']}),"total_lineas_initial_stock":0,"total_lineas_stock_quant":0,"total_skus_stock_match_producto":0,"total_skus_stock_no_match_producto":0,"total_ubicaciones_mapeadas":0,"total_ubicaciones_no_mapeadas":0,"total_productos_excluidos_stock_0":len(phase1['zrows']),"total_errores_reales":len(phase1['erows']),"stock_export_enabled": export_stock, "phase_1_completed": True, "phase_2_completed": export_stock, "include_additional_attributes": include_additional_attributes, "include_brand_color_attributes": include_additional_attributes, "expected_min_items_from_api": expected_min_items, "fetched_items_meet_expected_min": (len(products) >= expected_min_items) if expected_min_items is not None else None, "duration_seconds": duration_seconds, "exporter_version": EXPORTER_VERSION}
+        summary = {
+            "total_products": len(phase1['prows']),
+            "total_categorias_no_mapeadas": len(phase1['unmapped_category_rows']),
+            "total_skus_unicos_product_product": len({r.get('Internal Reference') for r in phase1['prows']}),
+            "total_lineas_initial_stock": 0,
+            "total_lineas_stock_quant": 0,
+            "total_skus_stock_match_producto": 0,
+            "total_skus_stock_no_match_producto": 0,
+            "total_ubicaciones_mapeadas": 0,
+            "total_ubicaciones_no_mapeadas": 0,
+            "total_productos_excluidos_stock_0": len(phase1['zrows']),
+            "total_errores_reales": len(phase1['erows']),
+            # --- Auditoría de calidad de datos ---
+            "total_simple_products": len(simple_rows),
+            "total_templates_con_atributos": len({r.get("External ID", "") for r in with_attr_rows}),
+            "total_variant_skus_mapeados": len(o19_variant_map_rows),
+            "total_attribute_rejections": len(rejection_rows),
+            "total_barcode_conflicts": len(barcode_conflicts),
+            "total_missing_from_stock": len(missing_rows),
+            "total_duplicate_variant_combinations": len(duplicate_combinations),
+            "total_phase2_orphan_variant_skus": phase2_orphan_count,
+            # --- Meta ---
+            "stock_export_enabled": export_stock,
+            "phase_1_completed": True,
+            "phase_2_completed": export_stock,
+            "include_additional_attributes": include_additional_attributes,
+            "include_brand_color_attributes": include_additional_attributes,
+            "expected_min_items_from_api": expected_min_items,
+            "fetched_items_meet_expected_min": (len(products) >= expected_min_items) if expected_min_items is not None else None,
+            "duration_seconds": duration_seconds,
+            "exporter_version": EXPORTER_VERSION,
+        }
         if export_stock:
             stock_rows = self._read_csv_rows(stock_csv)
             stock_quant_rows = self._read_csv_rows(stock_quant_csv)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -117,18 +117,87 @@ $('loadInvoiceByNumber').addEventListener('click', async () => {
 })();
 
 
+const FILE_PHASES = {
+  fase1_1_simple_products_csv:              { phase: 'Fase 1 · Importar en Odoo', label: '① Productos simples (odoo_product_templates_simple.csv)', import: true },
+  fase1_2_templates_with_attributes_csv:    { phase: 'Fase 1 · Importar en Odoo', label: '② Templates con atributos (odoo_product_templates_with_attributes.csv)', import: true },
+  fase2_1_variant_internal_references_csv:  { phase: 'Fase 2 · Actualizar SKU en variantes', label: '③ Internal References variantes (odoo_product_variant_internal_references.csv)', import: true },
+  fase2_2_internal_reference_update_csv:    { phase: 'Fase 2 · Actualizar SKU en variantes', label: '④ Update SKU simples+variantes (product_internal_reference_update.csv)', import: true },
+  fase3_stock_quant_csv:                    { phase: 'Fase 3 · Stock', label: '⑤ Ajuste de inventario (odoo_stock_quant.csv)', import: true },
+  reporte_errores_csv:                      { phase: 'Reportes · Solo lectura', label: 'Errores de migración', import: false },
+  reporte_mapping_csv:                      { phase: 'Reportes · Solo lectura', label: 'Mapping report', import: false },
+  reporte_atributos_rechazados_csv:         { phase: 'Reportes · Solo lectura', label: 'Atributos rechazados', import: false },
+  reporte_barcode_conflicts_csv:            { phase: 'Reportes · Solo lectura', label: 'Conflictos de barcode', import: false },
+  reporte_barcode_conflicts_fase2_csv:      { phase: 'Reportes · Solo lectura', label: 'Conflictos barcode Fase 2', import: false },
+  reporte_duplicados_variantes_csv:         { phase: 'Reportes · Solo lectura', label: 'Combinaciones variantes duplicadas', import: false },
+  reporte_missing_stock_csv:                { phase: 'Reportes · Solo lectura', label: 'Productos sin stock asignado', import: false },
+  reporte_validacion_fase2_csv:             { phase: 'Reportes · Solo lectura', label: 'Validación Fase 2', import: false },
+  reporte_excluded_zero_csv:                { phase: 'Reportes · Solo lectura', label: 'Excluidos por stock 0', import: false },
+  reporte_unmapped_categories_csv:          { phase: 'Reportes · Solo lectura', label: 'Categorías sin mapear', import: false },
+  debug_log:                                { phase: 'Logs', label: 'debug.log', import: false },
+  raw_log:                                  { phase: 'Logs', label: 'raw.log', import: false },
+  run_summary_json:                         { phase: 'Logs', label: 'run_summary.json', import: false },
+};
+
 function renderMigrationLinks(files) {
   const container = $('migrationLinks');
   container.innerHTML = '';
-  Object.entries(files || {}).forEach(([label, path]) => {
-    const a = document.createElement('a');
-    a.href = `${base()}${path}`;
-    a.textContent = `Descargar ${label}`;
-    a.target = '_blank';
-    a.rel = 'noopener';
-    a.className = 'download-link';
-    container.appendChild(a);
+  const byPhase = {};
+  Object.entries(files || {}).forEach(([key, path]) => {
+    const meta = FILE_PHASES[key] || { phase: 'Otros', label: key, import: false };
+    if (!byPhase[meta.phase]) byPhase[meta.phase] = [];
+    byPhase[meta.phase].push({ label: meta.label, path, import: meta.import });
   });
+  Object.entries(byPhase).forEach(([phase, items]) => {
+    const section = document.createElement('div');
+    section.className = 'phase-section';
+    const title = document.createElement('div');
+    title.className = 'phase-title';
+    title.textContent = phase;
+    section.appendChild(title);
+    items.forEach(({ label, path, import: isImport }) => {
+      const a = document.createElement('a');
+      a.href = `${base()}${path}`;
+      a.textContent = `↓ ${label}`;
+      a.target = '_blank';
+      a.rel = 'noopener';
+      a.className = isImport ? 'download-link download-link--import' : 'download-link download-link--report';
+      section.appendChild(a);
+    });
+    container.appendChild(section);
+  });
+}
+
+function renderWarnings(summary) {
+  const panel = $('warningsPanel');
+  if (!panel) return;
+  const warnings = [];
+  if ((summary.total_errores_reales || 0) > 0)
+    warnings.push({ level: 'error', msg: `${summary.total_errores_reales} errores de migración (SKU vacío o barcode duplicado en Contifico)` });
+  if ((summary.total_attribute_rejections || 0) > 0)
+    warnings.push({ level: 'warn', msg: `${summary.total_attribute_rejections} SKUs rechazados por atributos fuera del catálogo Odoo → quedan como simples` });
+  if ((summary.total_barcode_conflicts || 0) > 0)
+    warnings.push({ level: 'warn', msg: `${summary.total_barcode_conflicts} conflictos de barcode detectados → barcode limpiado en esos productos` });
+  if ((summary.total_duplicate_variant_combinations || 0) > 0)
+    warnings.push({ level: 'warn', msg: `${summary.total_duplicate_variant_combinations} combinaciones de variante duplicadas → ver odoo_duplicate_variant_combinations.csv` });
+  if ((summary.total_phase2_orphan_variant_skus || 0) > 0)
+    warnings.push({ level: 'warn', msg: `${summary.total_phase2_orphan_variant_skus} variantes sin template en Fase 1 → no se podrá actualizar su SKU en Odoo` });
+  if ((summary.total_missing_from_stock || 0) > 0)
+    warnings.push({ level: 'info', msg: `${summary.total_missing_from_stock} SKUs con stock en Contifico sin mapping en Odoo` });
+  if ((summary.total_categorias_no_mapeadas || 0) > 0)
+    warnings.push({ level: 'info', msg: `${summary.total_categorias_no_mapeadas} categorías de Contifico sin mapeo a Odoo` });
+  panel.innerHTML = '';
+  if (!warnings.length) {
+    panel.innerHTML = '<div class="warning-item warning-item--ok">✓ Sin advertencias críticas. Puedes importar los archivos en Odoo.</div>';
+    panel.classList.remove('hidden');
+    return;
+  }
+  warnings.forEach(({ level, msg }) => {
+    const div = document.createElement('div');
+    div.className = `warning-item warning-item--${level}`;
+    div.textContent = (level === 'error' ? '✗ ' : level === 'warn' ? '⚠ ' : 'ℹ ') + msg;
+    panel.appendChild(div);
+  });
+  panel.classList.remove('hidden');
 }
 
 $('generateMigrationCsv').addEventListener('click', async () => {
@@ -166,6 +235,7 @@ $('generateMigrationCsv').addEventListener('click', async () => {
       if (job.status === 'completed') {
         done = true;
         show('migrationSummaryOut', job);
+        renderWarnings(job.summary || {});
         renderMigrationLinks(job.files);
         const summaryExpected = Number((job.summary || {}).expected_min_items_from_api || 0);
         const summaryFound = Number(job.found_items || (job.summary || {}).total_products || 0);
@@ -218,6 +288,7 @@ $('processRawJson').addEventListener('click', async () => {
       export_stock: false,
     });
     show('migrationSummaryOut', data);
+    renderWarnings(data.summary || {});
     renderMigrationLinks(data.files);
     setMigrationStatus(`Archivo procesado. Productos detectados: ${data.detected_products}.`);
   } catch (e) { showErr(e); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,6 +35,7 @@
         <div id="migrationProgress" class="progress hidden"><div id="migrationProgressBar" class="progress-bar"></div></div>
         <p id="migrationStatus" class="muted"></p>
         <pre id="migrationSummaryOut"></pre>
+        <div id="warningsPanel" class="warnings-panel hidden"></div>
         <div id="migrationLinks"></div>
       </section>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -22,3 +22,19 @@ button:disabled{opacity:.55;cursor:not-allowed}
 .tab-panel.active{display:block}
 .row-btns{display:flex;gap:8px;flex-wrap:wrap}
 .row-btns button{flex:1}
+
+/* Download links grouped by phase */
+.phase-section{margin:10px 0}
+.phase-title{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:#6b7280;margin:10px 0 4px}
+.download-link--import{color:#166534;background:#f0fdf4;border:1px solid #bbf7d0;padding:5px 10px;border-radius:6px;font-size:13px}
+.download-link--import:hover{background:#dcfce7}
+.download-link--report{color:#1e40af;background:#eff6ff;border:1px solid #bfdbfe;padding:4px 10px;border-radius:6px;font-size:12px}
+.download-link--report:hover{background:#dbeafe}
+
+/* Warnings panel */
+.warnings-panel{margin:10px 0;display:flex;flex-direction:column;gap:4px}
+.warning-item{padding:7px 10px;border-radius:6px;font-size:13px;font-weight:500}
+.warning-item--ok{background:#f0fdf4;color:#166534;border:1px solid #bbf7d0}
+.warning-item--error{background:#fef2f2;color:#991b1b;border:1px solid #fecaca}
+.warning-item--warn{background:#fffbeb;color:#92400e;border:1px solid #fde68a}
+.warning-item--info{background:#eff6ff;color:#1e40af;border:1px solid #bfdbfe}


### PR DESCRIPTION
…panel de advertencias

- Elimina Customer Taxes de PRODUCTS_COLUMNS y todos los CSV generados (D5/H2)
- _build_files() reorganizado por fases con nombres descriptivos (D2/H5)
- summary incluye conteos de auditoría: attribute_rejections, barcode_conflicts, missing_from_stock, duplicate_combinations, phase2_orphan_variant_skus (G2/G3/H4)
- Frontend: renderMigrationLinks agrupa por fase con estilos distintos importar/reporte (H-bis)
- Frontend: panel de advertencias con conteos críticos antes de los links de descarga (H-bis)
- README: orden canónico de importación en Odoo con tabla por fase (F)
- 143/143 tests pasan

https://claude.ai/code/session_01JdpCmu6VNYnf1WQ6R3EyDn