### PR TITLE
Split odoo_product_templates en partes de 500 filas para evitar timeo…

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -337,7 +337,11 @@ def download_file(run_id: str, filename: str):
         "product_internal_reference_update.csv",
         "product_internal_reference_barcode_conflicts.csv",
     }
-    if filename not in allowed:
+    is_part_file = (
+        filename.startswith("odoo_product_templates_simple_part") or
+        filename.startswith("odoo_product_templates_with_attributes_part")
+    ) and filename.endswith(".csv")
+    if filename not in allowed and not is_part_file:
         raise HTTPException(status_code=400, detail="Archivo no permitido")
     file_path = _output_root() / run_id / filename
     if not file_path.exists() or not file_path.is_file():

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -236,8 +236,12 @@ class OdooMigrationService:
             if not row.get("Internal Reference"):
                 row["Internal Reference"] = str(row.get("source_sku") or "")
             row["Barcode"] = str(row.get("Barcode") or row.get("barcode") or row.get("Internal Reference") or "")
-        self._write_csv(folder / "odoo_product_templates_simple.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Internal Reference","Barcode"], simple_rows)
-        self._write_csv(folder / "odoo_product_templates_with_attributes.csv", ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Product Attributes / Attribute","Product Attributes / Values"], with_attr_rows)
+        simple_columns = ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Internal Reference","Barcode"]
+        attr_columns = ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Product Attributes / Attribute","Product Attributes / Values"]
+        self._write_csv(folder / "odoo_product_templates_simple.csv", simple_columns, simple_rows)
+        self._write_csv(folder / "odoo_product_templates_with_attributes.csv", attr_columns, with_attr_rows)
+        simple_part_files = self._split_into_parts(folder=folder, filename_stem="odoo_product_templates_simple", columns=simple_columns, rows=simple_rows, group_key="External ID")
+        attr_part_files = self._split_into_parts(folder=folder, filename_stem="odoo_product_templates_with_attributes", columns=attr_columns, rows=with_attr_rows, group_key="External ID")
         self._write_csv(folder / "odoo_attribute_rejections.csv", ["source_sku","source_id","source_name","attempted_attribute","attempted_value","reason"], rejection_rows)
         mapping_skus = {r.get("Internal Reference", "") for r in o19_variant_map_rows}
         simple_skus = {r.get("Internal Reference", "") for r in simple_rows}
@@ -302,6 +306,9 @@ class OdooMigrationService:
             "total_missing_from_stock": len(missing_rows),
             "total_duplicate_variant_combinations": len(duplicate_combinations),
             "total_phase2_orphan_variant_skus": phase2_orphan_count,
+            # --- Partes para importar en lotes ---
+            "simple_part_files": simple_part_files,
+            "attr_part_files": attr_part_files,
             # --- Meta ---
             "stock_export_enabled": export_stock,
             "phase_1_completed": True,
@@ -947,6 +954,59 @@ class OdooMigrationService:
         if '/' in normalized: return normalized.rsplit('/', 1)[0]
         if '-' in sku: return sku.rsplit('-', 1)[0]
         return sku or name
+
+    def _split_into_parts(
+        self,
+        *,
+        folder: Path,
+        filename_stem: str,
+        columns: list[str],
+        rows: list[dict[str, str]],
+        group_key: str,
+        max_rows_per_file: int = 500,
+    ) -> list[str]:
+        """Split rows into numbered part files keeping all rows for the same group_key together.
+
+        Returns list of generated filenames (not full paths).
+        """
+        if not rows:
+            return []
+
+        # Group consecutive rows by group_key so a template's rows stay together
+        groups: list[list[dict[str, str]]] = []
+        current_key: str | None = None
+        current_group: list[dict[str, str]] = []
+        for row in rows:
+            key = str(row.get(group_key) or "")
+            if key != current_key:
+                if current_group:
+                    groups.append(current_group)
+                current_group = [row]
+                current_key = key
+            else:
+                current_group.append(row)
+        if current_group:
+            groups.append(current_group)
+
+        # Pack groups into parts without exceeding max_rows_per_file
+        parts: list[list[dict[str, str]]] = []
+        current_part: list[dict[str, str]] = []
+        for group in groups:
+            if current_part and len(current_part) + len(group) > max_rows_per_file:
+                parts.append(current_part)
+                current_part = list(group)
+            else:
+                current_part.extend(group)
+        if current_part:
+            parts.append(current_part)
+
+        total = len(parts)
+        filenames: list[str] = []
+        for i, part_rows in enumerate(parts, start=1):
+            fname = f"{filename_stem}_part{i:02d}_of_{total:02d}.csv"
+            self._write_csv(folder / fname, columns, part_rows)
+            filenames.append(fname)
+        return filenames
 
     @staticmethod
     def _write_csv(path: Path, columns: list[str], rows: list[dict[str, Any]]):

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -138,7 +138,17 @@ const FILE_PHASES = {
   run_summary_json:                         { phase: 'Logs', label: 'run_summary.json', import: false },
 };
 
-function renderMigrationLinks(files) {
+function makeLink(href, label, isImport) {
+  const a = document.createElement('a');
+  a.href = href;
+  a.textContent = `↓ ${label}`;
+  a.target = '_blank';
+  a.rel = 'noopener';
+  a.className = isImport ? 'download-link download-link--import' : 'download-link download-link--report';
+  return a;
+}
+
+function renderMigrationLinks(files, summary) {
   const container = $('migrationLinks');
   container.innerHTML = '';
   const byPhase = {};
@@ -147,6 +157,26 @@ function renderMigrationLinks(files) {
     if (!byPhase[meta.phase]) byPhase[meta.phase] = [];
     byPhase[meta.phase].push({ label: meta.label, path, import: meta.import });
   });
+
+  // Extract run_id from any path (e.g. /odoo-migration/runs/20260506_123456/files/foo.csv)
+  const anyPath = Object.values(files || {})[0] || '';
+  const runIdMatch = anyPath.match(/\/runs\/([^/]+)\//);
+  const runId = runIdMatch ? runIdMatch[1] : null;
+
+  // Inject part files into Phase 1 section
+  if (runId && summary) {
+    const phase1key = 'Fase 1 · Importar en Odoo';
+    if (!byPhase[phase1key]) byPhase[phase1key] = [];
+    (summary.simple_part_files || []).forEach((fname, i) => {
+      const path = `/odoo-migration/runs/${runId}/files/${fname}`;
+      byPhase[phase1key].push({ label: `① Simples — parte ${i + 1} (${fname})`, path, import: true, partOrder: i });
+    });
+    (summary.attr_part_files || []).forEach((fname, i) => {
+      const path = `/odoo-migration/runs/${runId}/files/${fname}`;
+      byPhase[phase1key].push({ label: `② Con atributos — parte ${i + 1} (${fname})`, path, import: true, partOrder: i });
+    });
+  }
+
   Object.entries(byPhase).forEach(([phase, items]) => {
     const section = document.createElement('div');
     section.className = 'phase-section';
@@ -155,13 +185,7 @@ function renderMigrationLinks(files) {
     title.textContent = phase;
     section.appendChild(title);
     items.forEach(({ label, path, import: isImport }) => {
-      const a = document.createElement('a');
-      a.href = `${base()}${path}`;
-      a.textContent = `↓ ${label}`;
-      a.target = '_blank';
-      a.rel = 'noopener';
-      a.className = isImport ? 'download-link download-link--import' : 'download-link download-link--report';
-      section.appendChild(a);
+      section.appendChild(makeLink(`${base()}${path}`, label, isImport));
     });
     container.appendChild(section);
   });
@@ -236,7 +260,7 @@ $('generateMigrationCsv').addEventListener('click', async () => {
         done = true;
         show('migrationSummaryOut', job);
         renderWarnings(job.summary || {});
-        renderMigrationLinks(job.files);
+        renderMigrationLinks(job.files, job.summary);
         const summaryExpected = Number((job.summary || {}).expected_min_items_from_api || 0);
         const summaryFound = Number(job.found_items || (job.summary || {}).total_products || 0);
         const summaryCoverage = summaryExpected > 0 ? ` Cobertura vs count API: ${summaryFound}/${summaryExpected} (${Math.min(100, ((summaryFound / summaryExpected) * 100)).toFixed(2)}%).` : '';
@@ -289,7 +313,7 @@ $('processRawJson').addEventListener('click', async () => {
     });
     show('migrationSummaryOut', data);
     renderWarnings(data.summary || {});
-    renderMigrationLinks(data.files);
+    renderMigrationLinks(data.files, data.summary);
     setMigrationStatus(`Archivo procesado. Productos detectados: ${data.detected_products}.`);
   } catch (e) { showErr(e); }
 });


### PR DESCRIPTION
…ut en Odoo

- _split_into_parts(): agrupa por External ID (los atributos de un mismo template siempre quedan en el mismo archivo) y genera archivos odoo_product_templates_simple_partXX_of_YY.csv y odoo_product_templates_with_attributes_partXX_of_YY.csv
- run_summary incluye simple_part_files y attr_part_files con los nombres generados
- router.py: permite descarga de archivos part por prefijo (sin hardcodear nombres)
- frontend: renderMigrationLinks recibe summary y añade links de partes en Fase 1
- Con 3600 filas con atributos → ~7 partes de ≤500 filas cada una
- 143/143 tests pasan

https://claude.ai/code/session_01JdpCmu6VNYnf1WQ6R3EyDn