### PR TITLE
Fix encoding: CSVs con UTF-8 BOM para evitar corrupción de ñ en Odoo

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -346,7 +346,7 @@ def download_file(run_id: str, filename: str):
     file_path = _output_root() / run_id / filename
     if not file_path.exists() or not file_path.is_file():
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
-    media_type = "text/plain" if filename.endswith(('.log', '.md')) else "text/csv"
+    media_type = "text/plain; charset=utf-8" if filename.endswith(('.log', '.md')) else "text/csv; charset=utf-8"
     return FileResponse(path=file_path, filename=filename, media_type=media_type)
 
 

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -669,12 +669,12 @@ class OdooMigrationService:
     def _validate_phase2_variant_internal_reference_csv(*, csv_path: Path, errors_path: Path) -> None:
         expected_header = ["Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost"]
         errors: list[dict[str, str]] = []
-        lines = csv_path.read_text(encoding="utf-8").splitlines()
+        lines = csv_path.read_text(encoding="utf-8-sig").splitlines()
 
         if not lines:
             errors.append({"row_number": "1", "raw_line": "", "parsed_column_count": "0", "reason": "Empty CSV"})
         else:
-            with csv_path.open("r", newline="", encoding="utf-8") as f:
+            with csv_path.open("r", newline="", encoding="utf-8-sig") as f:
                 reader = csv.reader(f, delimiter=",", quotechar='"')
                 for row_number, parsed in enumerate(reader, start=1):
                     raw_line = lines[row_number - 1] if row_number - 1 < len(lines) else ""
@@ -814,7 +814,7 @@ class OdooMigrationService:
 
     @staticmethod
     def _read_header(path: Path):
-        with path.open('r', encoding='utf-8') as f: line=f.readline().strip()
+        with path.open('r', encoding='utf-8-sig') as f: line=f.readline().strip()
         return [c.strip() for c in line.split(',') if c.strip()]
 
     def _fetch_products(self, *, page_size:int, max_pages:int, run_folder: Path, progress_callback=None, debug_lines=None, raw_lines=None):
@@ -1010,7 +1010,7 @@ class OdooMigrationService:
 
     @staticmethod
     def _write_csv(path: Path, columns: list[str], rows: list[dict[str, Any]]):
-        with path.open('w', newline='', encoding='utf-8') as f:
+        with path.open('w', newline='', encoding='utf-8-sig') as f:
             w = csv.DictWriter(
                 f,
                 fieldnames=columns,
@@ -1037,5 +1037,5 @@ class OdooMigrationService:
     def _read_csv_rows(path: Path) -> list[dict[str, str]]:
         if not path.exists():
             return []
-        with path.open('r', newline='', encoding='utf-8') as f:
+        with path.open('r', newline='', encoding='utf-8-sig') as f:
             return list(csv.DictReader(f))

--- a/backend/tests/test_odoo_phase2_variant_internal_refs.py
+++ b/backend/tests/test_odoo_phase2_variant_internal_refs.py
@@ -4,7 +4,7 @@ from app.odoo_migration.service import OdooMigrationService
 
 
 def _read_csv(path: Path):
-    with path.open('r', newline='', encoding='utf-8') as f:
+    with path.open('r', newline='', encoding='utf-8-sig') as f:
         return list(csv.DictReader(f, delimiter=','))
 
 


### PR DESCRIPTION
Sin BOM, Odoo interpreta los bytes UTF-8 como Mac Roman y convierte ñ (0xC3 0xB1) en √± causando errores como 'Ropa / Ni√±os' al importar.

Cambios:
- _write_csv: utf-8 → utf-8-sig (agrega BOM 0xEF 0xBB 0xBF)
- _read_csv_rows, _read_header, _validate_phase2_variant_internal_reference_csv: utf-8-sig
- router download_file: Content-Type incluye charset=utf-8
- test _read_csv: utf-8-sig para consistencia con producción

https://claude.ai/code/session_01JdpCmu6VNYnf1WQ6R3EyDn