### PR TITLE
Eliminar particionado de CSVs: volver a archivo único por fase

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -337,11 +337,7 @@ def download_file(run_id: str, filename: str):
         "product_internal_reference_update.csv",
         "product_internal_reference_barcode_conflicts.csv",
     }
-    is_part_file = (
-        filename.startswith("odoo_product_templates_simple_part") or
-        filename.startswith("odoo_product_templates_with_attributes_part")
-    ) and filename.endswith(".csv")
-    if filename not in allowed and not is_part_file:
+    if filename not in allowed:
         raise HTTPException(status_code=400, detail="Archivo no permitido")
     file_path = _output_root() / run_id / filename
     if not file_path.exists() or not file_path.is_file():

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -240,8 +240,6 @@ class OdooMigrationService:
         attr_columns = ["External ID","Name","Product Type","Product Category","Sales Price","Cost","Can be Sold","Can be Purchased","is_storable","available_in_pos","Product Attributes / Attribute","Product Attributes / Values","Product Attributes / Create Variants"]
         self._write_csv(folder / "odoo_product_templates_simple.csv", simple_columns, simple_rows)
         self._write_csv(folder / "odoo_product_templates_with_attributes.csv", attr_columns, with_attr_rows)
-        simple_part_files = self._split_into_parts(folder=folder, filename_stem="odoo_product_templates_simple", columns=simple_columns, rows=simple_rows, group_key="External ID")
-        attr_part_files = self._split_into_parts(folder=folder, filename_stem="odoo_product_templates_with_attributes", columns=attr_columns, rows=with_attr_rows, group_key="External ID")
         self._write_csv(folder / "odoo_attribute_rejections.csv", ["source_sku","source_id","source_name","attempted_attribute","attempted_value","reason"], rejection_rows)
         mapping_skus = {r.get("Internal Reference", "") for r in o19_variant_map_rows}
         simple_skus = {r.get("Internal Reference", "") for r in simple_rows}
@@ -306,9 +304,6 @@ class OdooMigrationService:
             "total_missing_from_stock": len(missing_rows),
             "total_duplicate_variant_combinations": len(duplicate_combinations),
             "total_phase2_orphan_variant_skus": phase2_orphan_count,
-            # --- Partes para importar en lotes ---
-            "simple_part_files": simple_part_files,
-            "attr_part_files": attr_part_files,
             # --- Meta ---
             "stock_export_enabled": export_stock,
             "phase_1_completed": True,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -163,20 +163,6 @@ function renderMigrationLinks(files, summary) {
   const runIdMatch = anyPath.match(/\/runs\/([^/]+)\//);
   const runId = runIdMatch ? runIdMatch[1] : null;
 
-  // Inject part files into Phase 1 section
-  if (runId && summary) {
-    const phase1key = 'Fase 1 · Importar en Odoo';
-    if (!byPhase[phase1key]) byPhase[phase1key] = [];
-    (summary.simple_part_files || []).forEach((fname, i) => {
-      const path = `/odoo-migration/runs/${runId}/files/${fname}`;
-      byPhase[phase1key].push({ label: `① Simples — parte ${i + 1} (${fname})`, path, import: true, partOrder: i });
-    });
-    (summary.attr_part_files || []).forEach((fname, i) => {
-      const path = `/odoo-migration/runs/${runId}/files/${fname}`;
-      byPhase[phase1key].push({ label: `② Con atributos — parte ${i + 1} (${fname})`, path, import: true, partOrder: i });
-    });
-  }
-
   Object.entries(byPhase).forEach(([phase, items]) => {
     const section = document.createElement('div');
     section.className = 'phase-section';


### PR DESCRIPTION
El particionado causaba que Odoo agregara (no reemplazara) líneas de atributos en cada importación parcial, resultando en 196 variantes duplicadas (Talla×Talla×Manga×Manga). Un solo archivo por fase evita este problema.

https://claude.ai/code/session_01JdpCmu6VNYnf1WQ6R3EyDn