### PR TITLE
Fase 2: excluir Color y Marca de Variant Values (son no_variant)

### DIFF
--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -475,7 +475,8 @@ class OdooMigrationService:
         (run_folder / "import_products_and_variants_report.md").write_text("\n".join(report) + "\n", encoding="utf-8")
 
     def _write_phase2_variant_internal_reference_outputs(self, folder: Path, variant_map_rows: list[dict[str, str]], with_attr_rows: list[dict[str, str]], simple_rows: list[dict[str, str]], stock_rows: list[dict[str, str]]) -> None:
-        attr_order = ["Talla", "Color", "Manga de Camisa", "Ancho Corbata", "Marca"]
+        # Solo atributos que crean variantes (always). Color y Marca son no_variant → no aparecen en Variant Values
+        attr_order = ["Talla", "Manga de Camisa", "Ancho Corbata"]
         template_names = {str(r.get("Name") or "").strip() for r in with_attr_rows if str(r.get("Name") or "").strip()}
         variant_rows: list[dict[str, str]] = []
         validation_rows: list[dict[str, str]] = []
@@ -578,7 +579,8 @@ class OdooMigrationService:
         (never creates new ones). Barcodes that appear on multiple SKUs are cleared and reported
         separately so the import is not forced through a conflict.
         """
-        attr_order = ["Talla", "Color", "Manga de Camisa", "Ancho Corbata", "Marca"]
+        # Solo atributos que crean variantes (always). Color y Marca son no_variant → no aparecen en Variant Values
+        attr_order = ["Talla", "Manga de Camisa", "Ancho Corbata"]
 
         # Build para_pos lookup from raw phase-1 variant rows
         para_pos_by_sku: dict[str, Any] = {

--- a/backend/tests/test_odoo_phase2_variant_internal_refs.py
+++ b/backend/tests/test_odoo_phase2_variant_internal_refs.py
@@ -228,4 +228,4 @@ def test_phase2_variant_values_dedupe_and_internal_reference_fallback(tmp_path: 
     out = _read_csv(tmp_path / "odoo_product_variant_internal_references.csv")
     assert out[0]["Internal Reference"] == "BLU-34-AZ-XS"
     assert out[0]["Barcode"] == "BLU-34-AZ-XS"
-    assert out[0]["Variant Values"] == "Talla: XS, Color: Azul"
+    assert out[0]["Variant Values"] == "Talla: XS"


### PR DESCRIPTION
Odoo solo puede hacer match de variantes por atributos que crean variantes (always). Color y Marca son no_variant → incluirlos en Variant Values hace que Odoo no encuentre la variante correcta.

attr_order queda: Talla, Manga de Camisa, Ancho Corbata.

https://claude.ai/code/session_01JdpCmu6VNYnf1WQ6R3EyDn