### PR TITLE
Fix: usar nombre canónico del template para variantes con nombres dis…

### DIFF
--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -453,6 +453,16 @@ class OdooMigrationService:
         # Solo atributos que crean variantes (always). Color y Marca son no_variant → no aparecen en Variant Values
         attr_order = ["Talla", "Manga de Camisa", "Ancho Corbata"]
         template_names = {str(r.get("Name") or "").strip() for r in with_attr_rows if str(r.get("Name") or "").strip()}
+        # ext_id → canonical name: cuando distintas variantes del mismo template
+        # tienen nombres distintos en Contifico (ej. "CAMISA X 32-33" vs "CAMISA X 34-35"),
+        # la búsqueda por nombre falla para las variantes no-seed. Usamos el External ID
+        # para resolver el nombre canónico importado en Fase 1.
+        ext_id_to_canonical_name: dict[str, str] = {}
+        for r in with_attr_rows:
+            ext_id = str(r.get("External ID") or "").strip()
+            name = str(r.get("Name") or "").strip()
+            if ext_id and name and ext_id not in ext_id_to_canonical_name:
+                ext_id_to_canonical_name[ext_id] = name
         variant_rows: list[dict[str, str]] = []
         validation_rows: list[dict[str, str]] = []
 
@@ -491,11 +501,14 @@ class OdooMigrationService:
                 validation_rows.append({"issue_type":"Empty Variant Values","product_template_external_id":str(row.get("Product Template External ID") or ""),"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":"","source_sku":sku,"reason":"Variant has no valid attributes"})
                 validation_rows.append({"issue_type":"Variant has no valid attributes","product_template_external_id":str(row.get("Product Template External ID") or ""),"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":"","source_sku":sku,"reason":"Excluded from phase 2 variant import"})
                 continue
-            if name and name not in template_names:
-                validation_rows.append({"issue_type":"Product Template Name not found in Fase 1 with attributes","product_template_external_id":str(row.get("Product Template External ID") or ""),"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":variant_values,"source_sku":sku,"reason":"Template name not present in odoo_product_templates_with_attributes.csv"})
+            ext_id = str(row.get("Product Template External ID") or "").strip()
+            canonical_name = ext_id_to_canonical_name.get(ext_id, "")
+            if not canonical_name and name not in template_names:
+                validation_rows.append({"issue_type":"Product Template Name not found in Fase 1 with attributes","product_template_external_id":ext_id,"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":variant_values,"source_sku":sku,"reason":"Template name not present in odoo_product_templates_with_attributes.csv"})
                 continue
 
-            variant_rows.append({"Internal Reference":sku,"Barcode":barcode,"Name":name,"Variant Values":variant_values,"Sales Price":sales_price,"Cost":cost})
+            import_name = canonical_name or name
+            variant_rows.append({"Internal Reference":sku,"Barcode":barcode,"Name":import_name,"Variant Values":variant_values,"Sales Price":sales_price,"Cost":cost})
 
         sku_counts = {}
         barcode_counts = {}

--- a/backend/tests/test_odoo_phase2_variant_internal_refs.py
+++ b/backend/tests/test_odoo_phase2_variant_internal_refs.py
@@ -262,7 +262,7 @@ def test_phase2_variant_with_junk_talla_excluded_from_import(tmp_path: Path):
             "Cost": "8.00",
         },
     ]
-    with_attr_rows = [{"Name": "H. CAMISA D/P BLACK, BRUNO CASSINI"}]
+    with_attr_rows = [{"External ID": "product_template_17605dc", "Name": "H. CAMISA D/P BLACK, BRUNO CASSINI"}]
     simple_rows = [{"Internal Reference": "CEBAT-7568"}]
 
     service._write_phase2_variant_internal_reference_outputs(
@@ -281,3 +281,59 @@ def test_phase2_variant_with_junk_talla_excluded_from_import(tmp_path: Path):
     validation = _read_csv(tmp_path / "odoo_phase2_variant_internal_reference_validation.csv")
     battery_warnings = [r for r in validation if r["internal_reference"] == "CEBAT-7568"]
     assert any(r["issue_type"] == "Product Template Name not found in Fase 1 with attributes" for r in battery_warnings)
+
+
+def test_phase2_variant_canonical_name_used_when_contifico_names_differ_by_sleeve(tmp_path: Path):
+    """En Contifico, las variantes S1 y S2 de una misma camisa pueden tener nombres
+    distintos (ej. 'CAMISA X 32-33' vs 'CAMISA X 34-35'). El seed del template usa
+    el nombre S1, por lo que las variantes S2 no coinciden por nombre. El fix resuelve
+    el nombre canónico via External ID y lo usa en el CSV de importación."""
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    variant_map_rows = [
+        {
+            "Product Template External ID": "product_template_17605dc",
+            "Product Template Name": "H. CAMISA D/P BLACK BRUNO CASSINI 32-33",
+            "Internal Reference": "17605DC-16.5-S1",
+            "Barcode": "BC1",
+            "Talla": "16.5",
+            "Manga de Camisa": "S1 - 32/33",
+            "Ancho Corbata": "",
+            "Sales Price": "82.52",
+            "Cost": "0.00",
+        },
+        {
+            "Product Template External ID": "product_template_17605dc",
+            "Product Template Name": "H. CAMISA D/P BLACK BRUNO CASSINI 34-35",
+            "Internal Reference": "17605DC-16.5-S2",
+            "Barcode": "BC2",
+            "Talla": "16.5",
+            "Manga de Camisa": "S2 - 34/35",
+            "Ancho Corbata": "",
+            "Sales Price": "82.52",
+            "Cost": "0.00",
+        },
+    ]
+    # with_attr_rows tiene el nombre del seed (S1), no el S2
+    with_attr_rows = [{"External ID": "product_template_17605dc", "Name": "H. CAMISA D/P BLACK BRUNO CASSINI 32-33"}]
+
+    service._write_phase2_variant_internal_reference_outputs(
+        folder=tmp_path,
+        variant_map_rows=variant_map_rows,
+        with_attr_rows=with_attr_rows,
+        simple_rows=[],
+        stock_rows=[],
+    )
+
+    out = _read_csv(tmp_path / "odoo_product_variant_internal_references.csv")
+    assert len(out) == 2, "Ambas variantes (S1 y S2) deben estar en el CSV"
+
+    s1 = next(r for r in out if r["Internal Reference"] == "17605DC-16.5-S1")
+    s2 = next(r for r in out if r["Internal Reference"] == "17605DC-16.5-S2")
+
+    # Ambas deben usar el nombre canónico del seed (S1)
+    assert s1["Name"] == "H. CAMISA D/P BLACK BRUNO CASSINI 32-33"
+    assert s2["Name"] == "H. CAMISA D/P BLACK BRUNO CASSINI 32-33", \
+        "La variante S2 debe usar el nombre canónico del template, no su nombre propio de Contifico"
+
+    assert "Manga de Camisa: S1 - 32/33" in s1["Variant Values"]
+    assert "Manga de Camisa: S2 - 34/35" in s2["Variant Values"]


### PR DESCRIPTION
…tintos por manga

En Contifico, las variantes S1 y S2 de una misma camisa pueden tener nombres diferentes (ej. 'CAMISA X 32-33' vs 'CAMISA X 34-35'). El seed del template usa el nombre S1, pero las filas S2 en o19_variant_map_rows tienen su propio nombre → la búsqueda por nombre fallaba y las S2 quedaban fuera del CSV de Fase 2.

Ahora se construye un índice ext_id → nombre canónico desde with_attr_rows. Si el External ID del template está en with_attr_rows, se usa su nombre canónico en el CSV de importación (independientemente del nombre que tenga cada variante en Contifico). Los templates sin External ID en with_attr_rows siguen excluyéndose.

Afecta: 17605DC, HT8811-2, HT1739-5, HT1965-2, HT2082-3, 17601BG-DC,
        17604BG-DC, 17604DC, 17604BG, 17605BG-DC y cualquier camisa similar.

https://claude.ai/code/session_01JdpCmu6VNYnf1WQ6R3EyDn