### PR TITLE
Phase 2 merger: enrich variant CSV with Odoo product.product External IDs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.51
+Versión 1.0.56
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 
@@ -287,6 +287,7 @@ Si necesitas cambiar la URL del backend para el frontend, define `API_BASE_URL` 
 
 ## Historial de cambios
 
+- **1.0.56 (2026-05-08)**: Se añadió el merger de Fase 2 (`merge_phase2_with_odoo_export`): dado el export de `product.product` de Odoo (con columnas `id | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids`), el merger hace join por `(nombre del template, valores de atributo)` y genera `odoo_phase2_with_odoo_ids.csv` con la columna `id` del `product.product`, garantizando UPDATE en lugar de creación de duplicados. Se añadió endpoint `POST /runs/{run_id}/phase2/merge`, pestaña **Merger Variantes** en el frontend y 7 tests nuevos.
 - **1.0.55 (2026-05-06)**: Se rehizo la lógica conservadora del exportador para separar productos simples y con atributos usando un catálogo maestro fijo Odoo (sin heurísticas ni creación automática), con nuevas salidas `odoo_product_templates_simple.csv`, `odoo_product_templates_with_attributes.csv`, `odoo_attribute_rejections.csv` y `odoo_external_id_conflicts.csv`; además, ahora la corrida falla explícitamente cuando hay conflictos reales de External ID.
 - **1.0.54 (2026-05-05)**: Se restauró deduplicación determinística en `odoo_variant_sku_mapping.csv` por combinación de atributos dentro del template para evitar errores de Odoo `product_product_combination_unique`; los SKUs repetidos por combinación ahora se reportan en `odoo_duplicate_variant_combinations.csv` con referencias descartadas para revisión.
 - **1.0.53 (2026-05-05)**: Se corrigió el manejo de corbatas con sufijo slash no-ancho (ej. `CORBATA-BC/2013`) para no forzar `Talla`/`Ancho Corbata`; ahora se marcan `UNPARSED` y no contaminan validación template/variantes. También se aplica la misma regla de normalización de corbatas al construir templates para mantener consistencia con variant mapping.
@@ -390,14 +391,43 @@ El frontend los agrupa por fase y muestra advertencias de calidad antes de desca
 | 1 | `odoo_product_templates_simple.csv` | `product.template` | Productos sin variantes. Incluye `Internal Reference` y `Barcode`. |
 | 2 | `odoo_product_templates_with_attributes.csv` | `product.template` | Templates con variantes. **No** incluye `Internal Reference` ni `Barcode` (se actualizan en Fase 2). |
 
-### Fase 2 — Actualizar Internal Reference / SKU
+### Fase 2 — Actualizar Internal Reference / SKU en variantes
 
-> Ejecutar **después** de que Odoo haya creado las variantes. Odoo identifica los registros por `Name + Variant Values`.
+> Ejecutar **después** de que Odoo haya importado los templates y auto-creado las variantes.
+>
+> **Flujo recomendado (con merger):**
+> 1. Importa Fase 1 en Odoo.
+> 2. Exporta `product.product` desde Odoo con columnas: `id | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids`.
+> 3. En el frontend (pestaña **Merger Variantes**), sube ese export → el sistema genera `odoo_phase2_with_odoo_ids.csv` con la columna `id` que identifica cada variante en Odoo.
+> 4. Importa en Odoo `odoo_phase2_with_odoo_ids.csv` — Odoo **actualiza** la variante (no crea duplicados).
+>
+> Si no tienes el export de Odoo, puedes importar `odoo_product_variant_internal_references.csv` directamente, pero Odoo intentará hacer match por `Name + Variant Values` y existe riesgo de crear duplicados silenciosos. Prueba primero con 5–10 filas y verifica que el log diga "Updated X records".
 
 | Orden | Archivo | Modelo Odoo | Notas |
 |-------|---------|-------------|-------|
-| 3 | `odoo_product_variant_internal_references.csv` | `product.product` | Setea SKU y Barcode en variantes. Identificación: `Name + Variant Values`. |
+| 3a | `odoo_phase2_with_odoo_ids.csv` ⭐ | `product.product` | **Recomendado.** Generado por el merger. Columna `id` garantiza UPDATE sin duplicados. |
+| 3b | `odoo_product_variant_internal_references.csv` | `product.product` | Alternativa sin merger. Match por `Name + Variant Values`. |
 | 4 | `product_internal_reference_update.csv` | `product.product` / `product.template` | Update unificado (simples + variantes) con `External ID`. |
+
+#### Merger Variantes (paso 3a)
+
+El merger se opera desde el frontend (pestaña **Merger Variantes**) o vía API:
+
+```bash
+# Sube el export de Odoo para el run_id de tu corrida
+curl -X POST "http://127.0.0.1:8000/odoo-migration/runs/<RUN_ID>/phase2/merge" \
+  -F "file=@odoo_product_product_export.csv"
+```
+
+Archivos generados por el merger:
+
+| Archivo | Descripción |
+|---------|-------------|
+| `odoo_phase2_with_odoo_ids.csv` | **Importar en Odoo.** Columna `id` = External ID del `product.product` → UPDATE garantizado. |
+| `odoo_phase2_merger_unmatched.csv` | Variantes de Fase 2 que no encontraron par en el export de Odoo. Revisar antes de importar. |
+| `odoo_phase2_merger_unused_odoo.csv` | Variantes en Odoo que no aparecen en Fase 2 (productos no migrados desde Contifico). |
+
+El join se hace por `(nombre del template, valores de atributo)` con normalización de mayúsculas y espacios.
 
 ### Fase 3 — Stock
 
@@ -418,6 +448,10 @@ El frontend los agrupa por fase y muestra advertencias de calidad antes de desca
 | `odoo_duplicate_variant_combinations.csv` | Combinaciones de variante duplicadas |
 | `odoo_missing_products_for_stock.csv` | SKUs con stock en Contifico sin mapping en Odoo |
 | `odoo_phase2_variant_internal_reference_validation.csv` | Validación cruzada Fase 1 ↔ Fase 2 |
+| `odoo_phase2_merger_unmatched.csv` | Variantes sin par en el export de Odoo (generado por merger) |
+| `odoo_phase2_merger_unused_odoo.csv` | Variantes en Odoo sin par en Fase 2 (generado por merger) |
+| `odoo_phase1_template_renames.csv` | Templates con nombre duplicado que requieren rename en Odoo antes del merger |
+| `odoo_phase2_orphaned_skus.csv` | SKUs con atributos inválidos cuyo template sí existe (candidatos a corrección manual) |
 | `excluded_zero_stock.csv` | Productos excluidos por tener stock total = 0 |
 | `unmapped_categories.csv` | Categorías de Contifico sin mapeo a Odoo |
 | `mapping_report.csv` | Detalle de clasificación por SKU |

--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -49,6 +49,10 @@ def _build_files(run_id: str) -> dict[str, str]:
         "fase2_2_internal_reference_update_csv": f"{base}/product_internal_reference_update.csv",
         # === Fase 3: stock ===
         "fase3_stock_quant_csv": f"{base}/odoo_stock_quant.csv",
+        # === Fase 2 enriquecida con IDs de Odoo (post-merge) ===
+        "fase2_merged_with_odoo_ids_csv": f"{base}/odoo_phase2_with_odoo_ids.csv",
+        "fase2_merged_unmatched_csv": f"{base}/odoo_phase2_merger_unmatched.csv",
+        "fase2_merged_unused_odoo_csv": f"{base}/odoo_phase2_merger_unused_odoo.csv",
         # === Reportes de calidad (no importar) ===
         "reporte_errores_csv": f"{base}/migration_errors.csv",
         "reporte_mapping_csv": f"{base}/mapping_report.csv",
@@ -342,6 +346,11 @@ def download_file(run_id: str, filename: str):
         "odoo_phase2_duplicate_variant_keys.csv",
         "odoo_phase2_missing_stock_references.csv",
         "odoo_phase2_csv_format_errors.csv",
+        "odoo_phase2_with_odoo_ids.csv",
+        "odoo_phase2_merger_unmatched.csv",
+        "odoo_phase2_merger_unused_odoo.csv",
+        "odoo_phase1_template_renames.csv",
+        "odoo_phase2_orphaned_skus.csv",
     }
     if filename not in allowed:
         raise HTTPException(status_code=400, detail="Archivo no permitido")
@@ -350,6 +359,44 @@ def download_file(run_id: str, filename: str):
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
     media_type = "text/plain; charset=utf-8" if filename.endswith(('.log', '.md')) else "text/csv; charset=utf-8"
     return FileResponse(path=file_path, filename=filename, media_type=media_type)
+
+
+@router.post('/runs/{run_id}/phase2/merge')
+async def merge_phase2_with_odoo_export(run_id: str, file: UploadFile = File(...)):
+    """Upload the Odoo product.product export CSV to enrich the Phase 2 variant CSV with
+    the 'id' column (product.product External ID), so Odoo can UPDATE existing variants
+    instead of creating duplicates.
+
+    Expected Odoo export columns:
+      id | id | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids
+    """
+    run_folder = _output_root() / run_id
+    if not run_folder.exists():
+        raise HTTPException(status_code=404, detail="Run no encontrado")
+    phase2_csv = run_folder / "odoo_product_variant_internal_references.csv"
+    if not phase2_csv.exists():
+        raise HTTPException(status_code=404, detail="Phase 2 CSV no encontrado en este run — genera la exportación primero")
+
+    odoo_export_path = run_folder / "odoo_product_product_export.csv"
+    odoo_export_path.write_bytes(await file.read())
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export_path,
+        phase2_csv=phase2_csv,
+        output_folder=run_folder,
+    )
+
+    base = f"/odoo-migration/runs/{run_id}/files"
+    return {
+        "run_id": run_id,
+        **result,
+        "files": {
+            "phase2_with_odoo_ids": f"{base}/odoo_phase2_with_odoo_ids.csv",
+            "unmatched": f"{base}/odoo_phase2_merger_unmatched.csv",
+            "unused_odoo": f"{base}/odoo_phase2_merger_unused_odoo.csv",
+        },
+    }
 
 
 @router.post('/runs/{run_id}/stock/start')

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import csv
 import random
 import re
+import unicodedata
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -1083,6 +1084,91 @@ class OdooMigrationService:
     def _read_stock_state(path: Path) -> list[dict[str, Any]]:
         if not path.exists(): return []
         return json.loads(path.read_text(encoding='utf-8'))
+
+    def merge_phase2_with_odoo_export(
+        self,
+        *,
+        odoo_export_csv: Path,
+        phase2_csv: Path,
+        output_folder: Path,
+    ) -> dict[str, Any]:
+        """Enrich Phase 2 variant CSV with product.product External IDs from Odoo export.
+
+        After Phase 1 import Odoo auto-creates product.product variants. This method
+        matches each variant in our Phase 2 CSV to its Odoo record using
+        (template name, variant values) as the join key, then emits a new CSV with
+        the 'id' column populated so Odoo will UPDATE the record instead of creating
+        a duplicate.
+
+        Odoo export expected columns:
+          id | id (dup) | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids
+
+        Phase 2 CSV expected columns:
+          product_tmpl_id/id | Internal Reference | Barcode | Name | Variant Values | Sales Price | Cost
+        """
+        def _norm_key(name: str, variant_values: str) -> tuple[str, frozenset]:
+            norm_name = unicodedata.normalize("NFC", name.strip().casefold())
+            parts: frozenset = frozenset(
+                unicodedata.normalize("NFC", p.strip().casefold())
+                for p in re.split(r"\s*,\s*", variant_values)
+                if p.strip()
+            )
+            return (norm_name, parts)
+
+        # Build lookup from Odoo export: join key → product.product External ID
+        odoo_lookup: dict[tuple, str] = {}
+        odoo_keys_used: set[tuple] = set()
+        all_odoo_rows: list[dict[str, str]] = []
+
+        with odoo_export_csv.open("r", newline="", encoding="utf-8-sig") as f:
+            for row in csv.DictReader(f):
+                pp_ext_id = str(row.get("id") or "").strip()
+                tmpl_name = str(row.get("product_tmpl_id/name") or "").strip()
+                variant_vals = str(row.get("product_template_variant_value_ids") or "").strip()
+                if not pp_ext_id or not tmpl_name:
+                    continue
+                key = _norm_key(tmpl_name, variant_vals)
+                odoo_lookup[key] = pp_ext_id
+                all_odoo_rows.append({"pp_ext_id": pp_ext_id, "tmpl_name": tmpl_name, "variant_values": variant_vals, "_key": str(key)})
+
+        # Process Phase 2 CSV and match each row
+        matched_rows: list[dict[str, str]] = []
+        unmatched_rows: list[dict[str, str]] = []
+
+        with phase2_csv.open("r", newline="", encoding="utf-8-sig") as f:
+            for row in csv.DictReader(f):
+                name = str(row.get("Name") or "").strip()
+                variant_values = str(row.get("Variant Values") or "").strip()
+                key = _norm_key(name, variant_values)
+                pp_ext_id = odoo_lookup.get(key)
+                if pp_ext_id:
+                    odoo_keys_used.add(key)
+                    matched_rows.append({"id": pp_ext_id, **row})
+                else:
+                    unmatched_rows.append({**row, "match_failure_reason": "No matching variant in Odoo export"})
+
+        # Odoo rows that didn't match any Phase 2 row
+        unused_odoo_rows: list[dict[str, str]] = [
+            {"odoo_ext_id": r["pp_ext_id"], "tmpl_name": r["tmpl_name"], "variant_values": r["variant_values"], "reason": "Not present in Phase 2 CSV"}
+            for r in all_odoo_rows
+            if _norm_key(r["tmpl_name"], r["variant_values"]) not in odoo_keys_used
+        ]
+
+        matched_cols = ["id", "product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost"]
+        unmatched_cols = ["product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost", "match_failure_reason"]
+        unused_cols = ["odoo_ext_id", "tmpl_name", "variant_values", "reason"]
+
+        self._write_csv(output_folder / "odoo_phase2_with_odoo_ids.csv", matched_cols, matched_rows)
+        self._write_csv(output_folder / "odoo_phase2_merger_unmatched.csv", unmatched_cols, unmatched_rows)
+        self._write_csv(output_folder / "odoo_phase2_merger_unused_odoo.csv", unused_cols, unused_odoo_rows)
+
+        return {
+            "total_phase2_rows": len(matched_rows) + len(unmatched_rows),
+            "matched": len(matched_rows),
+            "unmatched": len(unmatched_rows),
+            "total_odoo_rows": len(all_odoo_rows),
+            "unused_odoo_rows": len(unused_odoo_rows),
+        }
 
     @staticmethod
     def _read_csv_rows(path: Path) -> list[dict[str, str]]:

--- a/backend/tests/test_odoo_phase2_merger.py
+++ b/backend/tests/test_odoo_phase2_merger.py
@@ -1,0 +1,288 @@
+import csv
+from pathlib import Path
+import pytest
+from app.odoo_migration.service import OdooMigrationService
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _read_csv(path: Path) -> list[dict]:
+    with path.open("r", newline="", encoding="utf-8-sig") as f:
+        return list(csv.DictReader(f))
+
+
+ODOO_EXPORT_COLS = ["id", "product_tmpl_id/id", "product_tmpl_id/name", "product_template_variant_value_ids"]
+PHASE2_COLS = ["product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost"]
+
+
+def _make_odoo_export(tmp_path: Path, rows: list[dict]) -> Path:
+    path = tmp_path / "odoo_export.csv"
+    _write_csv(path, ODOO_EXPORT_COLS, rows)
+    return path
+
+
+def _make_phase2_csv(tmp_path: Path, rows: list[dict]) -> Path:
+    path = tmp_path / "odoo_product_variant_internal_references.csv"
+    _write_csv(path, PHASE2_COLS, rows)
+    return path
+
+
+def test_merger_basic_match(tmp_path: Path):
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_16_be6c1774",
+            "product_tmpl_id/id": "__export__.product_template_9_90baf1a5",
+            "product_tmpl_id/name": "H. CAMISA D/P BLACK, BRUNO CASSINI",
+            "product_template_variant_value_ids": "Talla: 16.5,Manga de Camisa: S1 - 32/33",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [
+        {
+            "product_tmpl_id/id": "__import__.product_template_17605dc",
+            "Internal Reference": "17605DC-16.5-S1",
+            "Barcode": "17605DC-16.5-S1",
+            "Name": "H. CAMISA D/P BLACK, BRUNO CASSINI",
+            "Variant Values": "Talla: 16.5, Manga de Camisa: S1 - 32/33",
+            "Sales Price": "82.52",
+            "Cost": "0.00",
+        },
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    assert result["matched"] == 1
+    assert result["unmatched"] == 0
+    assert result["unused_odoo_rows"] == 0
+
+    out = _read_csv(tmp_path / "odoo_phase2_with_odoo_ids.csv")
+    assert len(out) == 1
+    assert out[0]["id"] == "__export__.product_product_16_be6c1774"
+    assert out[0]["Internal Reference"] == "17605DC-16.5-S1"
+    assert out[0]["product_tmpl_id/id"] == "__import__.product_template_17605dc"
+
+
+def test_merger_normalizes_whitespace_around_commas(tmp_path: Path):
+    """Odoo export has no space after comma; Phase 2 CSV has space — must still match."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_19_eb949bfb",
+            "product_tmpl_id/id": "__export__.product_template_9_90baf1a5",
+            "product_tmpl_id/name": "CAMISA TEST",
+            "product_template_variant_value_ids": "Talla: 15,Manga de Camisa: S2 - 34/35",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [
+        {
+            "product_tmpl_id/id": "__import__.product_template_camisa_test",
+            "Internal Reference": "CT-15-S2",
+            "Barcode": "",
+            "Name": "CAMISA TEST",
+            "Variant Values": "Talla: 15, Manga de Camisa: S2 - 34/35",
+            "Sales Price": "50.00",
+            "Cost": "20.00",
+        },
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    assert result["matched"] == 1
+    out = _read_csv(tmp_path / "odoo_phase2_with_odoo_ids.csv")
+    assert out[0]["id"] == "__export__.product_product_19_eb949bfb"
+
+
+def test_merger_unmatched_phase2_row_reported(tmp_path: Path):
+    """Phase 2 rows with no matching Odoo variant go to the unmatched report."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_1",
+            "product_tmpl_id/id": "__export__.product_template_1",
+            "product_tmpl_id/name": "CAMISA A",
+            "product_template_variant_value_ids": "Talla: 15",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [
+        {
+            "product_tmpl_id/id": "__import__.product_template_a",
+            "Internal Reference": "CA-15",
+            "Barcode": "",
+            "Name": "CAMISA A",
+            "Variant Values": "Talla: 15",
+            "Sales Price": "50.00",
+            "Cost": "20.00",
+        },
+        {
+            "product_tmpl_id/id": "__import__.product_template_b",
+            "Internal Reference": "CB-M",
+            "Barcode": "",
+            "Name": "CAMISA B",
+            "Variant Values": "Talla: M",
+            "Sales Price": "50.00",
+            "Cost": "20.00",
+        },
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    assert result["matched"] == 1
+    assert result["unmatched"] == 1
+
+    unmatched = _read_csv(tmp_path / "odoo_phase2_merger_unmatched.csv")
+    assert len(unmatched) == 1
+    assert unmatched[0]["Internal Reference"] == "CB-M"
+    assert "No matching" in unmatched[0]["match_failure_reason"]
+
+
+def test_merger_unused_odoo_rows_reported(tmp_path: Path):
+    """Odoo variants not present in Phase 2 are reported as unused."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_1",
+            "product_tmpl_id/id": "__export__.product_template_1",
+            "product_tmpl_id/name": "CAMISA X",
+            "product_template_variant_value_ids": "Talla: 15",
+        },
+        {
+            "id": "__export__.product_product_2",
+            "product_tmpl_id/id": "__export__.product_template_1",
+            "product_tmpl_id/name": "CAMISA X",
+            "product_template_variant_value_ids": "Talla: 16",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [
+        {
+            "product_tmpl_id/id": "__import__.product_template_x",
+            "Internal Reference": "CX-15",
+            "Barcode": "",
+            "Name": "CAMISA X",
+            "Variant Values": "Talla: 15",
+            "Sales Price": "50.00",
+            "Cost": "20.00",
+        },
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    assert result["matched"] == 1
+    assert result["unused_odoo_rows"] == 1
+
+    unused = _read_csv(tmp_path / "odoo_phase2_merger_unused_odoo.csv")
+    assert len(unused) == 1
+    assert unused[0]["odoo_ext_id"] == "__export__.product_product_2"
+    assert "Talla: 16" in unused[0]["variant_values"]
+
+
+def test_merger_output_has_id_as_first_column(tmp_path: Path):
+    """The merged CSV must have 'id' as the first column for Odoo to treat it as an update."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_99",
+            "product_tmpl_id/id": "__export__.product_template_99",
+            "product_tmpl_id/name": "CORBATA NAVY",
+            "product_template_variant_value_ids": "Ancho Corbata: 7 cm",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [
+        {
+            "product_tmpl_id/id": "__import__.product_template_navy",
+            "Internal Reference": "NAV-007",
+            "Barcode": "NAV-007",
+            "Name": "CORBATA NAVY",
+            "Variant Values": "Ancho Corbata: 7 cm",
+            "Sales Price": "21.65",
+            "Cost": "8.00",
+        },
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    merged_path = tmp_path / "odoo_phase2_with_odoo_ids.csv"
+    with merged_path.open("r", newline="", encoding="utf-8-sig") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+    assert header[0] == "id", f"First column must be 'id', got: {header[0]}"
+
+
+def test_merger_case_insensitive_name_match(tmp_path: Path):
+    """Template name matching is case-insensitive."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_5",
+            "product_tmpl_id/id": "__export__.product_template_5",
+            "product_tmpl_id/name": "h. camisa d/p black, bruno cassini",
+            "product_template_variant_value_ids": "Talla: 16.5,Manga de Camisa: S1 - 32/33",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [
+        {
+            "product_tmpl_id/id": "__import__.product_template_17605dc",
+            "Internal Reference": "17605DC-16.5-S1",
+            "Barcode": "",
+            "Name": "H. CAMISA D/P BLACK, BRUNO CASSINI",
+            "Variant Values": "Talla: 16.5, Manga de Camisa: S1 - 32/33",
+            "Sales Price": "82.52",
+            "Cost": "0.00",
+        },
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    assert result["matched"] == 1
+
+
+def test_merger_empty_phase2_produces_empty_output(tmp_path: Path):
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_1",
+            "product_tmpl_id/id": "__export__.product_template_1",
+            "product_tmpl_id/name": "CAMISA X",
+            "product_template_variant_value_ids": "Talla: 15",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    assert result["matched"] == 0
+    assert result["unmatched"] == 0
+    assert result["unused_odoo_rows"] == 1
+    assert _read_csv(tmp_path / "odoo_phase2_with_odoo_ids.csv") == []

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -247,6 +247,11 @@ $('generateMigrationCsv').addEventListener('click', async () => {
         show('migrationSummaryOut', job);
         renderWarnings(job.summary || {});
         renderMigrationLinks(job.files, job.summary);
+        // Pre-fill run_id en Merger y Stock para el siguiente paso
+        if (job.run_id) {
+          if (!$('mergerRunId').value.trim()) $('mergerRunId').value = job.run_id;
+          if (!$('stockRunId').value.trim()) $('stockRunId').value = job.run_id;
+        }
         const summaryExpected = Number((job.summary || {}).expected_min_items_from_api || 0);
         const summaryFound = Number(job.found_items || (job.summary || {}).total_products || 0);
         const summaryCoverage = summaryExpected > 0 ? ` Cobertura vs count API: ${summaryFound}/${summaryExpected} (${Math.min(100, ((summaryFound / summaryExpected) * 100)).toFixed(2)}%).` : '';
@@ -300,6 +305,10 @@ $('processRawJson').addEventListener('click', async () => {
     show('migrationSummaryOut', data);
     renderWarnings(data.summary || {});
     renderMigrationLinks(data.files, data.summary);
+    if (data.run_id) {
+      if (!$('mergerRunId').value.trim()) $('mergerRunId').value = data.run_id;
+      if (!$('stockRunId').value.trim()) $('stockRunId').value = data.run_id;
+    }
     setMigrationStatus(`Archivo procesado. Productos detectados: ${data.detected_products}.`);
   } catch (e) { showErr(e); }
 });
@@ -320,15 +329,72 @@ function activateTab(name) {
 }
 document.querySelectorAll('.tab-btn').forEach((btn)=>btn.addEventListener('click',()=>activateTab(btn.dataset.tab)));
 
+// ── Merger Variantes ────────────────────────────────────────────────────────
+
+function setMergerStatus(msg) { const el=$('mergerStatus'); if(el) el.textContent=msg||''; }
+
+function renderMergerLinks(runId, files) {
+  const container = $('mergerLinks');
+  if (!container || !files) return;
+  container.innerHTML = '';
+  const section = document.createElement('div');
+  section.className = 'phase-section';
+  const title = document.createElement('div');
+  title.className = 'phase-title';
+  title.textContent = 'Archivos generados por el merger';
+  section.appendChild(title);
+  const MERGER_FILES = [
+    { key: 'phase2_with_odoo_ids', label: '⭐ odoo_phase2_with_odoo_ids.csv — importar en Odoo (UPDATE garantizado)', isImport: true },
+    { key: 'unmatched',            label: 'Variantes sin par en Odoo (merger_unmatched)', isImport: false },
+    { key: 'unused_odoo',          label: 'Variantes Odoo sin par en Fase 2 (merger_unused_odoo)', isImport: false },
+  ];
+  MERGER_FILES.forEach(({ key, label, isImport }) => {
+    const path = files[key];
+    if (!path) return;
+    section.appendChild(makeLink(`${base()}${path}`, label, isImport));
+  });
+  container.appendChild(section);
+}
+
+$('executeMerger').addEventListener('click', async () => {
+  try {
+    const runId = $('mergerRunId').value.trim();
+    if (!runId) throw new Error('Debes ingresar el Run ID de la corrida.');
+    const input = $('mergerOdooExportFile');
+    if (!input?.files?.[0]) throw new Error('Debes seleccionar el CSV exportado de Odoo.');
+    $('executeMerger').disabled = true;
+    setMergerStatus('Ejecutando merger...');
+    const url = new URL(`${base()}/odoo-migration/runs/${encodeURIComponent(runId)}/phase2/merge`);
+    const form = new FormData();
+    form.append('file', input.files[0]);
+    const resp = await fetch(url, { method: 'POST', body: form });
+    const text = await resp.text();
+    let data; try { data = JSON.parse(text); } catch { data = text; }
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}: ${typeof data === 'string' ? data : JSON.stringify(data)}`);
+    show('mergerSummaryOut', data);
+    renderMergerLinks(runId, data.files);
+    setMergerStatus(`Merger completado. Matcheados: ${data.matched} · Sin par: ${data.unmatched} · Odoo sin usar: ${data.unused_odoo_rows}`);
+    // Pre-fill run_id en Stock si está vacío
+    if (!$('stockRunId').value.trim()) $('stockRunId').value = runId;
+  } catch(e) {
+    setMergerStatus(`Error: ${e.message}`);
+    showErr(e);
+  } finally {
+    $('executeMerger').disabled = false;
+  }
+});
+
+// ── Stock por bodega ────────────────────────────────────────────────────────
+
 function getRunId(){ return $('stockRunId').value.trim(); }
 function setStockStatus(msg){ const el=$('stockStatusText'); if(el) el.textContent=msg||''; }
 
 $('startStockPhase').addEventListener('click', async ()=>{
   try{
     const runId=getRunId(); if(!runId) throw new Error('Debes ingresar un run_id');
-    setStockStatus('Iniciando Fase 2...');
+    setStockStatus('Iniciando stock...');
     const data=await apiPost(`/odoo-migration/runs/${encodeURIComponent(runId)}/stock/start`);
-    show('stockStatusOut', data); setStockStatus('Fase 2 iniciada.');
+    show('stockStatusOut', data); setStockStatus('Stock iniciado.');
   }catch(e){ showErr(e); }
 });
 
@@ -342,10 +408,10 @@ $('checkStockStatus').addEventListener('click', async ()=>{
 });
 
 $('pauseStockPhase').addEventListener('click', async ()=>{
-  try{ const runId=getRunId(); if(!runId) throw new Error('Debes ingresar un run_id'); show('stockStatusOut', await apiPost(`/odoo-migration/runs/${encodeURIComponent(runId)}/stock/pause`)); setStockStatus('Fase 2 pausada.'); }catch(e){ showErr(e); }
+  try{ const runId=getRunId(); if(!runId) throw new Error('Debes ingresar un run_id'); show('stockStatusOut', await apiPost(`/odoo-migration/runs/${encodeURIComponent(runId)}/stock/pause`)); setStockStatus('Stock pausado.'); }catch(e){ showErr(e); }
 });
 $('resumeStockPhase').addEventListener('click', async ()=>{
-  try{ const runId=getRunId(); if(!runId) throw new Error('Debes ingresar un run_id'); show('stockStatusOut', await apiPost(`/odoo-migration/runs/${encodeURIComponent(runId)}/stock/resume`)); setStockStatus('Fase 2 reanudada.'); }catch(e){ showErr(e); }
+  try{ const runId=getRunId(); if(!runId) throw new Error('Debes ingresar un run_id'); show('stockStatusOut', await apiPost(`/odoo-migration/runs/${encodeURIComponent(runId)}/stock/resume`)); setStockStatus('Stock reanudado.'); }catch(e){ showErr(e); }
 });
 $('retryStockFailed').addEventListener('click', async ()=>{
   try{ const runId=getRunId(); if(!runId) throw new Error('Debes ingresar un run_id'); show('stockStatusOut', await apiPost(`/odoo-migration/runs/${encodeURIComponent(runId)}/stock/retry-failed`)); setStockStatus('Reintento de fallidos iniciado.'); }catch(e){ showErr(e); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,13 +12,14 @@
       </section>
 
       <section class="tabs">
-        <button class="tab-btn active" data-tab="phase1">Fase 1 · Snapshot</button>
-        <button class="tab-btn" data-tab="phase2">Fase 2 · Stock</button>
+        <button class="tab-btn active" data-tab="export">Exportar</button>
+        <button class="tab-btn" data-tab="merger">Merger Variantes</button>
+        <button class="tab-btn" data-tab="stock">Stock</button>
         <button class="tab-btn" data-tab="preview">Preview Contífico</button>
       </section>
 
-      <section id="tab-phase1" class="tab-panel active card">
-        <h2>Fase 1: Migración Odoo (snapshot CSV)</h2>
+      <section id="tab-export" class="tab-panel active card">
+        <h2>Exportar desde Contífico (Fase 1)</h2>
         <input id="exportPageSize" type="number" value="100" min="1" max="500" placeholder="Page size" />
         <input id="exportMaxPages" type="number" value="300" min="1" max="1000" placeholder="Max pages" />
         <h3>Precheck Odoo (Atributos de producto)</h3>
@@ -30,7 +31,7 @@
         <button id="precheckOdooOffline">Precheck offline (sin API Odoo)</button>
         <input id="rawJsonFile" type="file" accept=".log,.json,.txt" />
         <button id="processRawJson">Procesar raw.log / JSON subido</button>
-        <button id="generateMigrationCsv">Generar corrida Fase 1</button>
+        <button id="generateMigrationCsv">Generar corrida</button>
         <button id="loadRuns">Ver últimas corridas</button>
         <div id="migrationProgress" class="progress hidden"><div id="migrationProgressBar" class="progress-bar"></div></div>
         <p id="migrationStatus" class="muted"></p>
@@ -39,11 +40,24 @@
         <div id="migrationLinks"></div>
       </section>
 
-      <section id="tab-phase2" class="tab-panel card">
-        <h2>Fase 2: Enriquecimiento de stock por bodega</h2>
-        <input id="stockRunId" placeholder="Run ID generado en Fase 1" />
+      <section id="tab-merger" class="tab-panel card">
+        <h2>Merger Variantes (Fase 2)</h2>
+        <p class="muted">Después de importar Fase 1 en Odoo, exporta <code>product.product</code> con columnas <code>id | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids</code> y súbelo aquí. El merger genera <strong>odoo_phase2_with_odoo_ids.csv</strong> con el External ID de cada variante para que Odoo haga UPDATE (no crea duplicados).</p>
+        <label>Run ID de la corrida</label>
+        <input id="mergerRunId" placeholder="Run ID generado en Exportar" />
+        <label>Export product.product de Odoo (CSV)</label>
+        <input id="mergerOdooExportFile" type="file" accept=".csv,text/csv" />
+        <button id="executeMerger">Ejecutar merger</button>
+        <p id="mergerStatus" class="muted"></p>
+        <pre id="mergerSummaryOut"></pre>
+        <div id="mergerLinks"></div>
+      </section>
+
+      <section id="tab-stock" class="tab-panel card">
+        <h2>Stock por bodega (Fase 3)</h2>
+        <input id="stockRunId" placeholder="Run ID generado en Exportar" />
         <div class="row-btns">
-          <button id="startStockPhase">Iniciar Fase 2</button>
+          <button id="startStockPhase">Iniciar stock</button>
           <button id="checkStockStatus">Consultar estado</button>
         </div>
         <div class="row-btns">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Añade `OdooMigrationService.merge_phase2_with_odoo_export()` — toma el export de Odoo (`product.product`) y el Phase 2 CSV generado por nosotros, los une por `(template name, variant values)` y emite `odoo_phase2_with_odoo_ids.csv` con la columna `id` (External ID del `product.product`) para que Odoo **actualice** la variante en lugar de crear duplicados.
- Añade endpoint `POST /runs/{run_id}/phase2/merge` — el usuario sube el export de Odoo, el backend corre el merger y devuelve links a los 3 archivos de resultado.
- 7 tests nuevos: match básico, normalización de espacios alrededor de comas (Odoo no tiene espacio, nuestro CSV sí), filas no matcheadas, filas de Odoo sin usar, orden de columnas (`id` primero), case-insensitive, input vacío.

## Archivos generados por el merger

| Archivo | Uso |
|---|---|
| `odoo_phase2_with_odoo_ids.csv` | **Importar en Odoo** — tiene columna `id` → Odoo actualiza |
| `odoo_phase2_merger_unmatched.csv` | Variantes en Phase 2 que no encontraron par en Odoo |
| `odoo_phase2_merger_unused_odoo.csv` | Variantes en Odoo que no están en Phase 2 |

## Test plan

- [ ] Subir el export de Odoo al endpoint `POST /runs/{run_id}/phase2/merge`
- [ ] Verificar que `odoo_phase2_with_odoo_ids.csv` tiene columna `id` con valores `__export__.product_product_*`
- [ ] Importar en Odoo y confirmar que dice "Updated X records" (no "Created")
- [ ] Revisar `odoo_phase2_merger_unmatched.csv` — si hay filas, son variantes que aún no existen en Odoo

https://claude.ai/code/session_01GjvDiMY9bgEG666ePnmFCs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjvDiMY9bgEG666ePnmFCs)_