### PR TITLE
Add minimal merger CSV to avoid Odoo Variant Values validation error

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -347,6 +347,7 @@ def download_file(run_id: str, filename: str):
         "odoo_phase2_missing_stock_references.csv",
         "odoo_phase2_csv_format_errors.csv",
         "odoo_phase2_with_odoo_ids.csv",
+        "odoo_phase2_with_odoo_ids_minimal.csv",
         "odoo_phase2_merger_unmatched.csv",
         "odoo_phase2_merger_unused_odoo.csv",
         "odoo_phase1_template_renames.csv",
@@ -393,6 +394,7 @@ async def merge_phase2_with_odoo_export(run_id: str, file: UploadFile = File(...
         **result,
         "files": {
             "phase2_with_odoo_ids": f"{base}/odoo_phase2_with_odoo_ids.csv",
+            "phase2_with_odoo_ids_minimal": f"{base}/odoo_phase2_with_odoo_ids_minimal.csv",
             "unmatched": f"{base}/odoo_phase2_merger_unmatched.csv",
             "unused_odoo": f"{base}/odoo_phase2_merger_unused_odoo.csv",
         },

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -1155,10 +1155,13 @@ class OdooMigrationService:
         ]
 
         matched_cols = ["id", "product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost"]
+        minimal_cols = ["id", "Internal Reference", "Barcode", "Sales Price", "Cost"]
         unmatched_cols = ["product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost", "match_failure_reason"]
         unused_cols = ["odoo_ext_id", "tmpl_name", "variant_values", "reason"]
 
         self._write_csv(output_folder / "odoo_phase2_with_odoo_ids.csv", matched_cols, matched_rows)
+        # Minimal CSV: only id + fields to update — no Name/Variant Values to avoid Odoo relational field validation
+        self._write_csv(output_folder / "odoo_phase2_with_odoo_ids_minimal.csv", minimal_cols, matched_rows)
         self._write_csv(output_folder / "odoo_phase2_merger_unmatched.csv", unmatched_cols, unmatched_rows)
         self._write_csv(output_folder / "odoo_phase2_merger_unused_odoo.csv", unused_cols, unused_odoo_rows)
 

--- a/backend/tests/test_odoo_phase2_merger.py
+++ b/backend/tests/test_odoo_phase2_merger.py
@@ -232,6 +232,48 @@ def test_merger_output_has_id_as_first_column(tmp_path: Path):
     assert header[0] == "id", f"First column must be 'id', got: {header[0]}"
 
 
+def test_merger_minimal_csv_has_no_relational_columns(tmp_path: Path):
+    """The minimal CSV must only have id, Internal Reference, Barcode, Sales Price, Cost.
+    No Name or Variant Values — those trigger Odoo relational field validation errors."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_99",
+            "product_tmpl_id/id": "__export__.product_template_99",
+            "product_tmpl_id/name": "CORBATA NAVY",
+            "product_template_variant_value_ids": "Ancho Corbata: 7 cm",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [
+        {
+            "product_tmpl_id/id": "__import__.product_template_navy",
+            "Internal Reference": "NAV-007",
+            "Barcode": "NAV-007",
+            "Name": "CORBATA NAVY",
+            "Variant Values": "Ancho Corbata: 7 cm",
+            "Sales Price": "21.65",
+            "Cost": "8.00",
+        },
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    minimal_path = tmp_path / "odoo_phase2_with_odoo_ids_minimal.csv"
+    assert minimal_path.exists(), "Minimal CSV must be generated"
+    rows = _read_csv(minimal_path)
+    assert len(rows) == 1
+    assert rows[0]["id"] == "__export__.product_product_99"
+    assert rows[0]["Internal Reference"] == "NAV-007"
+    assert rows[0]["Barcode"] == "NAV-007"
+    assert "Name" not in rows[0], "Minimal CSV must not have Name column"
+    assert "Variant Values" not in rows[0], "Minimal CSV must not have Variant Values column"
+    assert "product_tmpl_id/id" not in rows[0], "Minimal CSV must not have product_tmpl_id/id column"
+
+
 def test_merger_case_insensitive_name_match(tmp_path: Path):
     """Template name matching is case-insensitive."""
     odoo_export = _make_odoo_export(tmp_path, [

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -344,9 +344,10 @@ function renderMergerLinks(runId, files) {
   title.textContent = 'Archivos generados por el merger';
   section.appendChild(title);
   const MERGER_FILES = [
-    { key: 'phase2_with_odoo_ids', label: '⭐ odoo_phase2_with_odoo_ids.csv — importar en Odoo (UPDATE garantizado)', isImport: true },
-    { key: 'unmatched',            label: 'Variantes sin par en Odoo (merger_unmatched)', isImport: false },
-    { key: 'unused_odoo',          label: 'Variantes Odoo sin par en Fase 2 (merger_unused_odoo)', isImport: false },
+    { key: 'phase2_with_odoo_ids_minimal', label: '⭐ IMPORTAR ESTE — odoo_phase2_with_odoo_ids_minimal.csv (id + SKU + Barcode, sin campos relacionales)', isImport: true },
+    { key: 'phase2_with_odoo_ids',         label: 'Versión completa con Name/Variant Values (solo referencia)', isImport: false },
+    { key: 'unmatched',                    label: 'Variantes sin par en Odoo (merger_unmatched)', isImport: false },
+    { key: 'unused_odoo',                  label: 'Variantes Odoo sin par en Fase 2 (merger_unused_odoo)', isImport: false },
   ];
   MERGER_FILES.forEach(({ key, label, isImport }) => {
     const path = files[key];


### PR DESCRIPTION
When importing product.product in Odoo with a Variant Values column, Odoo validates it as a relational field lookup even when 'id' is already present — causing 'No matching records found' errors for attribute values like 'Talla: 60'.

Fix: generate odoo_phase2_with_odoo_ids_minimal.csv with only id | Internal Reference | Barcode | Sales Price | Cost. Since 'id' identifies the record, Odoo does a direct UPDATE without validating relational columns. The full CSV with Name/Variant Values is kept as a reference file.

- service: write both full and minimal CSVs from merge_phase2_with_odoo_export
- router: expose minimal CSV in allowed files and merger response
- frontend: label minimal CSV as the one to import in Odoo
- test: verify minimal CSV has no relational columns (Name, Variant Values)

https://claude.ai/code/session_01GjvDiMY9bgEG666ePnmFCs