### PR TITLE
Add inventory comparator: Contifico extraction vs Odoo product.produc…

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -346,6 +346,9 @@ def download_file(run_id: str, filename: str):
         "odoo_phase2_duplicate_variant_keys.csv",
         "odoo_phase2_missing_stock_references.csv",
         "odoo_phase2_csv_format_errors.csv",
+        "odoo_compare_only_in_contifico.csv",
+        "odoo_compare_only_in_odoo.csv",
+        "odoo_compare_in_both.csv",
         "odoo_phase2_with_odoo_ids.csv",
         "odoo_phase2_with_odoo_ids_minimal.csv",
         "odoo_phase2_merger_unmatched.csv",
@@ -360,6 +363,40 @@ def download_file(run_id: str, filename: str):
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
     media_type = "text/plain; charset=utf-8" if filename.endswith(('.log', '.md')) else "text/csv; charset=utf-8"
     return FileResponse(path=file_path, filename=filename, media_type=media_type)
+
+
+@router.post('/runs/{run_id}/compare-inventory')
+async def compare_inventory(run_id: str, file: UploadFile = File(...)):
+    """Upload the Odoo product.product inventory export to compare SKUs against the
+    Contifico extraction for this run.
+
+    Expected Odoo export columns (product.product export):
+      id | is_favorite | default_code | barcode | name | product_template_variant_value_ids | lst_price | standard_price | qty_available
+    """
+    run_folder = _output_root() / run_id
+    if not run_folder.exists():
+        raise HTTPException(status_code=404, detail="Run no encontrado")
+
+    odoo_export_path = run_folder / "odoo_inventory_export.csv"
+    odoo_export_path.write_bytes(await file.read())
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.compare_inventory_with_odoo_export(
+        run_folder=run_folder,
+        odoo_export_csv=odoo_export_path,
+        output_folder=run_folder,
+    )
+
+    base = f"/odoo-migration/runs/{run_id}/files"
+    return {
+        "run_id": run_id,
+        **result,
+        "files": {
+            "only_in_contifico": f"{base}/odoo_compare_only_in_contifico.csv",
+            "only_in_odoo": f"{base}/odoo_compare_only_in_odoo.csv",
+            "in_both": f"{base}/odoo_compare_in_both.csv",
+        },
+    }
 
 
 @router.post('/runs/{run_id}/phase2/merge')

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -1085,6 +1085,102 @@ class OdooMigrationService:
         if not path.exists(): return []
         return json.loads(path.read_text(encoding='utf-8'))
 
+    def compare_inventory_with_odoo_export(
+        self,
+        *,
+        run_folder: Path,
+        odoo_export_csv: Path,
+        output_folder: Path,
+    ) -> dict[str, Any]:
+        """Compare SKUs from a Contifico extraction run against an Odoo inventory export.
+
+        Reads Internal References from the run's simple + variant CSVs, then compares
+        against the Odoo export (expected column: default_code).
+
+        Returns counts and writes three CSVs:
+          - odoo_compare_only_in_contifico.csv
+          - odoo_compare_only_in_odoo.csv
+          - odoo_compare_in_both.csv
+        """
+        # --- Load Contifico SKUs from run outputs ---
+        contifico_rows: list[dict[str, str]] = []
+
+        simple_csv = run_folder / "odoo_product_templates_simple.csv"
+        for row in self._read_csv_rows(simple_csv):
+            sku = str(row.get("Internal Reference") or "").strip()
+            if sku:
+                contifico_rows.append({"sku": sku, "source": "simple", "name": str(row.get("Name") or "").strip()})
+
+        variant_csv = run_folder / "odoo_product_variant_internal_references.csv"
+        for row in self._read_csv_rows(variant_csv):
+            sku = str(row.get("Internal Reference") or "").strip()
+            if sku:
+                contifico_rows.append({"sku": sku, "source": "variant", "name": str(row.get("Name") or "").strip()})
+
+        contifico_by_sku: dict[str, dict] = {}
+        for r in contifico_rows:
+            contifico_by_sku.setdefault(r["sku"].casefold(), r)
+
+        # --- Load Odoo SKUs from upload ---
+        odoo_rows: list[dict[str, str]] = []
+        with odoo_export_csv.open("r", newline="", encoding="utf-8-sig") as f:
+            for row in csv.DictReader(f):
+                sku = str(row.get("default_code") or "").strip()
+                if not sku:
+                    continue
+                odoo_rows.append({
+                    "sku": sku,
+                    "name": str(row.get("name") or "").strip(),
+                    "barcode": str(row.get("barcode") or "").strip(),
+                    "qty_available": str(row.get("qty_available") or "0").strip(),
+                    "lst_price": str(row.get("lst_price") or "").strip(),
+                })
+
+        odoo_by_sku: dict[str, dict] = {}
+        for r in odoo_rows:
+            odoo_by_sku.setdefault(r["sku"].casefold(), r)
+
+        contifico_keys = set(contifico_by_sku.keys())
+        odoo_keys = set(odoo_by_sku.keys())
+
+        only_contifico_keys = contifico_keys - odoo_keys
+        only_odoo_keys = odoo_keys - contifico_keys
+        both_keys = contifico_keys & odoo_keys
+
+        only_contifico_rows = sorted(
+            [{"Internal Reference": contifico_by_sku[k]["sku"], "Name": contifico_by_sku[k]["name"], "Source": contifico_by_sku[k]["source"]}
+             for k in only_contifico_keys],
+            key=lambda r: r["Internal Reference"],
+        )
+        only_odoo_rows = sorted(
+            [{"default_code": odoo_by_sku[k]["sku"], "name": odoo_by_sku[k]["name"], "barcode": odoo_by_sku[k]["barcode"], "qty_available": odoo_by_sku[k]["qty_available"]}
+             for k in only_odoo_keys],
+            key=lambda r: r["default_code"],
+        )
+        in_both_rows = sorted(
+            [{"Internal Reference": contifico_by_sku[k]["sku"], "name_odoo": odoo_by_sku[k]["name"], "qty_available": odoo_by_sku[k]["qty_available"], "barcode": odoo_by_sku[k]["barcode"]}
+             for k in both_keys],
+            key=lambda r: r["Internal Reference"],
+        )
+
+        self._write_csv(output_folder / "odoo_compare_only_in_contifico.csv",
+                        ["Internal Reference", "Name", "Source"], only_contifico_rows)
+        self._write_csv(output_folder / "odoo_compare_only_in_odoo.csv",
+                        ["default_code", "name", "barcode", "qty_available"], only_odoo_rows)
+        self._write_csv(output_folder / "odoo_compare_in_both.csv",
+                        ["Internal Reference", "name_odoo", "qty_available", "barcode"], in_both_rows)
+
+        return {
+            "contifico_total": len(contifico_by_sku),
+            "odoo_total": len(odoo_by_sku),
+            "in_both": len(both_keys),
+            "only_in_contifico": len(only_contifico_keys),
+            "only_in_odoo": len(only_odoo_keys),
+            "preview_only_contifico": [r["Internal Reference"] for r in only_contifico_rows[:30]],
+            "preview_only_odoo": [r["default_code"] for r in only_odoo_rows[:30]],
+            "preview_in_both": [r["Internal Reference"] for r in in_both_rows[:30]],
+        }
+
     def merge_phase2_with_odoo_export(
         self,
         *,

--- a/backend/tests/test_odoo_compare_inventory.py
+++ b/backend/tests/test_odoo_compare_inventory.py
@@ -1,0 +1,163 @@
+import csv
+from pathlib import Path
+from app.odoo_migration.service import OdooMigrationService
+
+
+def _write_csv(path: Path, fieldnames: list, rows: list) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _read_csv(path: Path) -> list:
+    with path.open("r", newline="", encoding="utf-8-sig") as f:
+        return list(csv.DictReader(f))
+
+
+ODOO_EXPORT_COLS = ["id", "is_favorite", "default_code", "barcode", "name",
+                    "product_template_variant_value_ids", "lst_price", "standard_price", "qty_available"]
+SIMPLE_COLS = ["External ID", "Name", "Internal Reference", "Barcode", "Product Type"]
+VARIANT_COLS = ["product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost"]
+
+
+def _setup_run(tmp_path: Path, simple_skus: list[str], variant_skus: list[str]) -> Path:
+    run_folder = tmp_path / "run"
+    run_folder.mkdir()
+    _write_csv(run_folder / "odoo_product_templates_simple.csv", SIMPLE_COLS, [
+        {"External ID": f"tmpl_{s}", "Name": f"Prod {s}", "Internal Reference": s, "Barcode": "", "Product Type": "storable"}
+        for s in simple_skus
+    ])
+    _write_csv(run_folder / "odoo_product_variant_internal_references.csv", VARIANT_COLS, [
+        {"product_tmpl_id/id": f"__import__.tmpl_{v}", "Internal Reference": v, "Barcode": "", "Name": f"Variante {v}", "Variant Values": "Talla: M", "Sales Price": "10.00", "Cost": "5.00"}
+        for v in variant_skus
+    ])
+    return run_folder
+
+
+def _make_odoo_export(tmp_path: Path, skus: list[str]) -> Path:
+    path = tmp_path / "odoo_export.csv"
+    _write_csv(path, ODOO_EXPORT_COLS, [
+        {"id": f"__export__.pp_{s}", "is_favorite": "False", "default_code": s, "barcode": "",
+         "name": f"Producto {s}", "product_template_variant_value_ids": "", "lst_price": "10.00",
+         "standard_price": "5.00", "qty_available": "3.0"}
+        for s in skus
+    ])
+    return path
+
+
+def test_compare_basic_sets(tmp_path: Path):
+    run_folder = _setup_run(tmp_path, simple_skus=["SIMPLE-1", "SIMPLE-2"], variant_skus=["VAR-A", "VAR-B"])
+    odoo_export = _make_odoo_export(tmp_path, ["SIMPLE-1", "VAR-A", "ODOO-ONLY-1"])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.compare_inventory_with_odoo_export(
+        run_folder=run_folder,
+        odoo_export_csv=odoo_export,
+        output_folder=tmp_path,
+    )
+
+    assert result["contifico_total"] == 4  # SIMPLE-1, SIMPLE-2, VAR-A, VAR-B
+    assert result["odoo_total"] == 3       # SIMPLE-1, VAR-A, ODOO-ONLY-1
+    assert result["in_both"] == 2          # SIMPLE-1, VAR-A
+    assert result["only_in_contifico"] == 2  # SIMPLE-2, VAR-B
+    assert result["only_in_odoo"] == 1      # ODOO-ONLY-1
+
+
+def test_compare_only_in_contifico_csv(tmp_path: Path):
+    run_folder = _setup_run(tmp_path, simple_skus=["S1", "S2"], variant_skus=[])
+    odoo_export = _make_odoo_export(tmp_path, ["S1"])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    service.compare_inventory_with_odoo_export(
+        run_folder=run_folder, odoo_export_csv=odoo_export, output_folder=tmp_path,
+    )
+
+    rows = _read_csv(tmp_path / "odoo_compare_only_in_contifico.csv")
+    skus = {r["Internal Reference"] for r in rows}
+    assert "S2" in skus
+    assert "S1" not in skus
+
+
+def test_compare_only_in_odoo_csv(tmp_path: Path):
+    run_folder = _setup_run(tmp_path, simple_skus=["S1"], variant_skus=[])
+    odoo_export = _make_odoo_export(tmp_path, ["S1", "ODOO-X", "ODOO-Y"])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    service.compare_inventory_with_odoo_export(
+        run_folder=run_folder, odoo_export_csv=odoo_export, output_folder=tmp_path,
+    )
+
+    rows = _read_csv(tmp_path / "odoo_compare_only_in_odoo.csv")
+    skus = {r["default_code"] for r in rows}
+    assert "ODOO-X" in skus
+    assert "ODOO-Y" in skus
+    assert "S1" not in skus
+
+
+def test_compare_in_both_csv(tmp_path: Path):
+    run_folder = _setup_run(tmp_path, simple_skus=["S1", "S2"], variant_skus=["V1"])
+    odoo_export = _make_odoo_export(tmp_path, ["S1", "V1", "EXTRA"])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    service.compare_inventory_with_odoo_export(
+        run_folder=run_folder, odoo_export_csv=odoo_export, output_folder=tmp_path,
+    )
+
+    rows = _read_csv(tmp_path / "odoo_compare_in_both.csv")
+    skus = {r["Internal Reference"] for r in rows}
+    assert "S1" in skus
+    assert "V1" in skus
+    assert "S2" not in skus
+    assert "EXTRA" not in skus
+
+
+def test_compare_skips_empty_default_code(tmp_path: Path):
+    """Odoo rows with empty default_code must be ignored."""
+    run_folder = _setup_run(tmp_path, simple_skus=["S1"], variant_skus=[])
+    path = tmp_path / "odoo_export.csv"
+    _write_csv(path, ODOO_EXPORT_COLS, [
+        {"id": "__export__.pp_1", "is_favorite": "False", "default_code": "S1",
+         "barcode": "", "name": "Prod S1", "product_template_variant_value_ids": "",
+         "lst_price": "10.00", "standard_price": "5.00", "qty_available": "1.0"},
+        {"id": "__export__.pp_2", "is_favorite": "False", "default_code": "",
+         "barcode": "", "name": "Sin referencia", "product_template_variant_value_ids": "",
+         "lst_price": "10.00", "standard_price": "5.00", "qty_available": "0.0"},
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.compare_inventory_with_odoo_export(
+        run_folder=run_folder, odoo_export_csv=path, output_folder=tmp_path,
+    )
+
+    assert result["odoo_total"] == 1  # Only S1, not the empty-code row
+
+
+def test_compare_case_insensitive(tmp_path: Path):
+    """SKU matching must be case-insensitive."""
+    run_folder = _setup_run(tmp_path, simple_skus=["sku-ABC"], variant_skus=[])
+    odoo_export = _make_odoo_export(tmp_path, ["SKU-ABC"])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.compare_inventory_with_odoo_export(
+        run_folder=run_folder, odoo_export_csv=odoo_export, output_folder=tmp_path,
+    )
+
+    assert result["in_both"] == 1
+    assert result["only_in_contifico"] == 0
+    assert result["only_in_odoo"] == 0
+
+
+def test_compare_preview_capped_at_30(tmp_path: Path):
+    """Preview lists must be capped at 30 items each."""
+    skus = [f"SKU-{i:03d}" for i in range(50)]
+    run_folder = _setup_run(tmp_path, simple_skus=skus, variant_skus=[])
+    odoo_export = _make_odoo_export(tmp_path, [])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.compare_inventory_with_odoo_export(
+        run_folder=run_folder, odoo_export_csv=odoo_export, output_folder=tmp_path,
+    )
+
+    assert len(result["preview_only_contifico"]) == 30
+    assert result["only_in_contifico"] == 50

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -251,6 +251,7 @@ $('generateMigrationCsv').addEventListener('click', async () => {
         if (job.run_id) {
           if (!$('mergerRunId').value.trim()) $('mergerRunId').value = job.run_id;
           if (!$('stockRunId').value.trim()) $('stockRunId').value = job.run_id;
+          if (!$('compareRunId').value.trim()) $('compareRunId').value = job.run_id;
         }
         const summaryExpected = Number((job.summary || {}).expected_min_items_from_api || 0);
         const summaryFound = Number(job.found_items || (job.summary || {}).total_products || 0);
@@ -308,6 +309,7 @@ $('processRawJson').addEventListener('click', async () => {
     if (data.run_id) {
       if (!$('mergerRunId').value.trim()) $('mergerRunId').value = data.run_id;
       if (!$('stockRunId').value.trim()) $('stockRunId').value = data.run_id;
+      if (!$('compareRunId').value.trim()) $('compareRunId').value = data.run_id;
     }
     setMigrationStatus(`Archivo procesado. Productos detectados: ${data.detected_products}.`);
   } catch (e) { showErr(e); }
@@ -328,6 +330,97 @@ function activateTab(name) {
   document.querySelectorAll('.tab-panel').forEach((p)=>p.classList.toggle('active', p.id===`tab-${name}`));
 }
 document.querySelectorAll('.tab-btn').forEach((btn)=>btn.addEventListener('click',()=>activateTab(btn.dataset.tab)));
+
+// ── Comparador de inventario ────────────────────────────────────────────────
+
+function setCompareStatus(msg) { const el=$('compareStatus'); if(el) el.textContent=msg||''; }
+
+function renderCompareStats(data) {
+  const el = $('compareStats');
+  if (!el) return;
+  el.innerHTML = `
+    <div class="stat-card stat-card--total"><div class="stat-num">${data.contifico_total}</div><div class="stat-lbl">Contífico</div></div>
+    <div class="stat-card stat-card--total"><div class="stat-num">${data.odoo_total}</div><div class="stat-lbl">Odoo</div></div>
+    <div class="stat-card stat-card--both"><div class="stat-num">${data.in_both}</div><div class="stat-lbl">Coinciden</div></div>
+    <div class="stat-card stat-card--contifico"><div class="stat-num">${data.only_in_contifico}</div><div class="stat-lbl">Solo Contífico</div></div>
+    <div class="stat-card stat-card--odoo"><div class="stat-num">${data.only_in_odoo}</div><div class="stat-lbl">Solo Odoo</div></div>
+  `;
+  el.classList.remove('hidden');
+}
+
+function renderComparePreviews(data) {
+  const el = $('comparePreviews');
+  if (!el) return;
+  el.innerHTML = '';
+  const sections = [
+    { key: 'preview_only_contifico', label: `Solo en Contífico — ${data.only_in_contifico} SKUs (en extracción pero no en Odoo)`, cls: 'stat-card--contifico' },
+    { key: 'preview_only_odoo',      label: `Solo en Odoo — ${data.only_in_odoo} SKUs (en Odoo pero no en extracción)`,   cls: 'stat-card--odoo' },
+    { key: 'preview_in_both',        label: `Coinciden — ${data.in_both} SKUs`,                                             cls: 'stat-card--both' },
+  ];
+  sections.forEach(({ key, label, cls }) => {
+    const items = data[key] || [];
+    if (!items.length) return;
+    const details = document.createElement('details');
+    details.className = 'compare-preview';
+    const summary = document.createElement('summary');
+    summary.textContent = label + (items.length === 30 ? ' (mostrando primeros 30)' : '');
+    details.appendChild(summary);
+    const ul = document.createElement('ul');
+    items.forEach(sku => { const li = document.createElement('li'); li.textContent = sku; ul.appendChild(li); });
+    details.appendChild(ul);
+    el.appendChild(details);
+  });
+}
+
+function renderCompareLinks(files) {
+  const el = $('compareLinks');
+  if (!el || !files) return;
+  el.innerHTML = '';
+  const title = document.createElement('div');
+  title.className = 'phase-title';
+  title.textContent = 'Descargar resultados';
+  el.appendChild(title);
+  const COMPARE_FILES = [
+    { key: 'only_in_contifico', label: 'Solo en Contífico (faltan importar en Odoo)', isImport: false },
+    { key: 'only_in_odoo',      label: 'Solo en Odoo (no vienen de esta extracción)',  isImport: false },
+    { key: 'in_both',           label: 'Coinciden en ambos sistemas',                  isImport: false },
+  ];
+  COMPARE_FILES.forEach(({ key, label, isImport }) => {
+    const path = files[key];
+    if (!path) return;
+    el.appendChild(makeLink(`${base()}${path}`, label, isImport));
+  });
+}
+
+$('executeCompare').addEventListener('click', async () => {
+  try {
+    const runId = $('compareRunId').value.trim();
+    if (!runId) throw new Error('Debes ingresar el Run ID de la extracción.');
+    const input = $('compareOdooFile');
+    if (!input?.files?.[0]) throw new Error('Debes seleccionar el CSV exportado de Odoo.');
+    $('executeCompare').disabled = true;
+    $('compareStats').classList.add('hidden');
+    $('comparePreviews').innerHTML = '';
+    $('compareLinks').innerHTML = '';
+    setCompareStatus('Comparando inventarios...');
+    const url = new URL(`${base()}/odoo-migration/runs/${encodeURIComponent(runId)}/compare-inventory`);
+    const form = new FormData();
+    form.append('file', input.files[0]);
+    const resp = await fetch(url, { method: 'POST', body: form });
+    const text = await resp.text();
+    let data; try { data = JSON.parse(text); } catch { data = text; }
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}: ${typeof data === 'string' ? data : JSON.stringify(data)}`);
+    renderCompareStats(data);
+    renderComparePreviews(data);
+    renderCompareLinks(data.files);
+    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Solo Contífico: ${data.only_in_contifico} · Solo Odoo: ${data.only_in_odoo}`);
+  } catch(e) {
+    setCompareStatus(`Error: ${e.message}`);
+    showErr(e);
+  } finally {
+    $('executeCompare').disabled = false;
+  }
+});
 
 // ── Merger Variantes ────────────────────────────────────────────────────────
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,7 @@
         <button class="tab-btn active" data-tab="export">Exportar</button>
         <button class="tab-btn" data-tab="merger">Merger Variantes</button>
         <button class="tab-btn" data-tab="stock">Stock</button>
+        <button class="tab-btn" data-tab="compare">Comparador</button>
         <button class="tab-btn" data-tab="preview">Preview Contífico</button>
       </section>
 
@@ -67,6 +68,20 @@
         </div>
         <p id="stockStatusText" class="muted"></p>
         <pre id="stockStatusOut"></pre>
+      </section>
+
+      <section id="tab-compare" class="tab-panel card">
+        <h2>Comparador de Inventario</h2>
+        <p class="muted">Sube el export de <code>product.product</code> de Odoo (<code>default_code | name | barcode | qty_available</code>) para comparar contra los SKUs de la extracción de Contífico.</p>
+        <label>Run ID de la extracción Contífico</label>
+        <input id="compareRunId" placeholder="Run ID generado en Exportar" />
+        <label>Export de Odoo (product.product CSV)</label>
+        <input id="compareOdooFile" type="file" accept=".csv,text/csv" />
+        <button id="executeCompare">Comparar inventarios</button>
+        <p id="compareStatus" class="muted"></p>
+        <div id="compareStats" class="compare-stats hidden"></div>
+        <div id="compareLinks" class="phase-section"></div>
+        <div id="comparePreviews"></div>
       </section>
 
       <section id="tab-preview" class="tab-panel">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -31,6 +31,21 @@ button:disabled{opacity:.55;cursor:not-allowed}
 .download-link--report{color:#1e40af;background:#eff6ff;border:1px solid #bfdbfe;padding:4px 10px;border-radius:6px;font-size:12px}
 .download-link--report:hover{background:#dbeafe}
 
+/* Comparador */
+.compare-stats{display:flex;gap:10px;flex-wrap:wrap;margin:12px 0}
+.stat-card{flex:1;min-width:120px;padding:12px 16px;border-radius:8px;text-align:center}
+.stat-card .stat-num{font-size:28px;font-weight:700;line-height:1}
+.stat-card .stat-lbl{font-size:11px;text-transform:uppercase;letter-spacing:.04em;margin-top:4px;opacity:.75}
+.stat-card--total{background:#f1f5f9;border:1px solid #cbd5e1;color:#334155}
+.stat-card--both{background:#f0fdf4;border:1px solid #bbf7d0;color:#166534}
+.stat-card--contifico{background:#fff7ed;border:1px solid #fed7aa;color:#9a3412}
+.stat-card--odoo{background:#eff6ff;border:1px solid #bfdbfe;color:#1e40af}
+.compare-preview{margin:10px 0}
+.compare-preview summary{cursor:pointer;font-weight:600;font-size:13px;padding:6px 0}
+.compare-preview ul{margin:4px 0;padding-left:18px;font-size:12px;font-family:monospace;column-count:3;column-gap:16px}
+@media(max-width:900px){.compare-preview ul{column-count:2}}
+@media(max-width:600px){.compare-preview ul{column-count:1}}
+
 /* Warnings panel */
 .warnings-panel{margin:10px 0;display:flex;flex-direction:column;gap:4px}
 .warning-item{padding:7px 10px;border-radius:6px;font-size:13px;font-weight:500}


### PR DESCRIPTION
…t export

Compares SKUs from a run's extracted CSVs (simple + variant) against an Odoo product.product export (default_code column), producing three output CSVs and a preview in the frontend.

Backend:
- OdooMigrationService.compare_inventory_with_odoo_export(): reads odoo_product_templates_simple.csv + odoo_product_variant_internal_references.csv from the run folder, compares against uploaded Odoo export by default_code (case-insensitive). Returns counts + 30-item previews per group.
- POST /runs/{run_id}/compare-inventory endpoint
- Output files: odoo_compare_only_in_contifico.csv, odoo_compare_only_in_odoo.csv, odoo_compare_in_both.csv
- 7 tests: basic sets, per-CSV content, empty default_code skipped, case-insensitive match, preview cap at 30

Frontend:
- New "Comparador" tab between Stock and Preview
- 5 stat cards: Contífico total | Odoo total | Coinciden | Solo Contífico | Solo Odoo
- Expandable preview lists (up to 30 SKUs per group, 3-column layout)
- Download links for the 3 result CSVs
- Run ID auto-filled from last export run

https://claude.ai/code/session_01GjvDiMY9bgEG666ePnmFCs