### PR TITLE
Add generate-missing-import feature: filtered Phase 1/2 CSVs for delt…

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -349,6 +349,9 @@ def download_file(run_id: str, filename: str):
         "odoo_compare_only_in_contifico.csv",
         "odoo_compare_only_in_odoo.csv",
         "odoo_compare_in_both.csv",
+        "odoo_missing_simple_for_import.csv",
+        "odoo_missing_templates_with_attributes.csv",
+        "odoo_missing_variants_phase2.csv",
         "odoo_phase2_with_odoo_ids.csv",
         "odoo_phase2_with_odoo_ids_minimal.csv",
         "odoo_phase2_merger_unmatched.csv",
@@ -363,6 +366,35 @@ def download_file(run_id: str, filename: str):
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
     media_type = "text/plain; charset=utf-8" if filename.endswith(('.log', '.md')) else "text/csv; charset=utf-8"
     return FileResponse(path=file_path, filename=filename, media_type=media_type)
+
+
+@router.get('/runs/{run_id}/compare-inventory/generate-missing')
+def generate_missing_import(run_id: str):
+    """Using the results of a prior compare-inventory run, generate filtered Phase 1/2
+    import CSVs containing only the products that are missing from Odoo."""
+    run_folder = _output_root() / run_id
+    if not run_folder.exists():
+        raise HTTPException(status_code=404, detail="Run no encontrado")
+    compare_csv = run_folder / "odoo_compare_only_in_contifico.csv"
+    if not compare_csv.exists():
+        raise HTTPException(status_code=404, detail="Comparación no encontrada — ejecuta primero el comparador.")
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    try:
+        result = service.generate_missing_import_csvs(run_folder=run_folder, output_folder=run_folder)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    base = f"/odoo-migration/runs/{run_id}/files"
+    return {
+        "run_id": run_id,
+        **result,
+        "files": {
+            "missing_simple": f"{base}/odoo_missing_simple_for_import.csv",
+            "missing_templates": f"{base}/odoo_missing_templates_with_attributes.csv",
+            "missing_variants_phase2": f"{base}/odoo_missing_variants_phase2.csv",
+        },
+    }
 
 
 @router.post('/runs/{run_id}/compare-inventory')

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -1085,6 +1085,76 @@ class OdooMigrationService:
         if not path.exists(): return []
         return json.loads(path.read_text(encoding='utf-8'))
 
+    def generate_missing_import_csvs(
+        self,
+        *,
+        run_folder: Path,
+        output_folder: Path,
+    ) -> dict[str, Any]:
+        """Generate filtered Phase 1/Phase 2 import CSVs containing only products
+        that are missing from Odoo (as determined by a prior compare_inventory run).
+
+        Reads odoo_compare_only_in_contifico.csv from the run folder, then filters:
+          - odoo_product_templates_simple.csv → odoo_missing_simple_for_import.csv
+          - odoo_product_templates_with_attributes.csv → odoo_missing_templates_with_attributes.csv
+          - odoo_product_variant_internal_references.csv → odoo_missing_variants_phase2.csv
+        """
+        compare_csv = run_folder / "odoo_compare_only_in_contifico.csv"
+        if not compare_csv.exists():
+            raise FileNotFoundError("odoo_compare_only_in_contifico.csv no encontrado — ejecuta primero el comparador.")
+
+        missing_rows = self._read_csv_rows(compare_csv)
+        missing_simple_skus: set[str] = set()
+        missing_variant_skus: set[str] = set()
+        for r in missing_rows:
+            sku = str(r.get("Internal Reference") or "").strip()
+            source = str(r.get("Source") or "").strip().lower()
+            if not sku:
+                continue
+            if source == "simple":
+                missing_simple_skus.add(sku)
+            else:
+                missing_variant_skus.add(sku)
+
+        # ── Simple products ──────────────────────────────────────────────────
+        simple_all = self._read_csv_rows(run_folder / "odoo_product_templates_simple.csv")
+        simple_cols = list(simple_all[0].keys()) if simple_all else []
+        simple_filtered = [r for r in simple_all if str(r.get("Internal Reference") or "").strip() in missing_simple_skus]
+
+        # ── Variant templates (with attributes) ──────────────────────────────
+        # Find which template External IDs are needed for missing variants
+        variant_refs = self._read_csv_rows(run_folder / "odoo_product_variant_internal_references.csv")
+        needed_template_ext_ids: set[str] = set()
+        for r in variant_refs:
+            sku = str(r.get("Internal Reference") or "").strip()
+            if sku in missing_variant_skus:
+                ext_id = str(r.get("product_tmpl_id/id") or "").strip()
+                # Strip __import__. prefix for comparison with the templates CSV External ID column
+                raw_ext_id = ext_id.removeprefix("__import__.")
+                if raw_ext_id:
+                    needed_template_ext_ids.add(raw_ext_id)
+
+        templates_all = self._read_csv_rows(run_folder / "odoo_product_templates_with_attributes.csv")
+        tmpl_cols = list(templates_all[0].keys()) if templates_all else []
+        templates_filtered = [r for r in templates_all if str(r.get("External ID") or "").strip() in needed_template_ext_ids]
+
+        # ── Variant Phase 2 CSV ───────────────────────────────────────────────
+        variant_cols = list(variant_refs[0].keys()) if variant_refs else []
+        variants_filtered = [r for r in variant_refs if str(r.get("Internal Reference") or "").strip() in missing_variant_skus]
+
+        self._write_csv(output_folder / "odoo_missing_simple_for_import.csv", simple_cols, simple_filtered)
+        self._write_csv(output_folder / "odoo_missing_templates_with_attributes.csv", tmpl_cols, templates_filtered)
+        self._write_csv(output_folder / "odoo_missing_variants_phase2.csv", variant_cols, variants_filtered)
+
+        return {
+            "missing_simple_total": len(missing_simple_skus),
+            "missing_variants_total": len(missing_variant_skus),
+            "simple_rows_exported": len(simple_filtered),
+            "template_rows_exported": len(templates_filtered),
+            "variant_rows_exported": len(variants_filtered),
+            "needed_templates": len(needed_template_ext_ids),
+        }
+
     def compare_inventory_with_odoo_export(
         self,
         *,

--- a/backend/tests/test_odoo_compare_inventory.py
+++ b/backend/tests/test_odoo_compare_inventory.py
@@ -148,6 +148,77 @@ def test_compare_case_insensitive(tmp_path: Path):
     assert result["only_in_odoo"] == 0
 
 
+def test_generate_missing_filters_simples(tmp_path: Path):
+    """generate_missing_import_csvs filters simple products from compare results."""
+    run_folder = tmp_path / "run"
+    run_folder.mkdir()
+
+    _write_csv(run_folder / "odoo_compare_only_in_contifico.csv",
+               ["Internal Reference", "Name", "Source"],
+               [{"Internal Reference": "S2", "Name": "Prod S2", "Source": "simple"}])
+    _write_csv(run_folder / "odoo_product_templates_simple.csv", SIMPLE_COLS, [
+        {"External ID": "tmpl_s1", "Name": "Prod S1", "Internal Reference": "S1", "Barcode": "", "Product Type": "storable"},
+        {"External ID": "tmpl_s2", "Name": "Prod S2", "Internal Reference": "S2", "Barcode": "", "Product Type": "storable"},
+    ])
+    _write_csv(run_folder / "odoo_product_templates_with_attributes.csv",
+               ["External ID", "Name", "Product Attributes / Attribute", "Product Attributes / Values", "Product Attributes / Create Variants"],
+               [])
+    _write_csv(run_folder / "odoo_product_variant_internal_references.csv", VARIANT_COLS, [])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.generate_missing_import_csvs(run_folder=run_folder, output_folder=tmp_path)
+
+    assert result["simple_rows_exported"] == 1
+    rows = _read_csv(tmp_path / "odoo_missing_simple_for_import.csv")
+    assert len(rows) == 1
+    assert rows[0]["Internal Reference"] == "S2"
+
+
+def test_generate_missing_filters_variant_templates(tmp_path: Path):
+    """generate_missing_import_csvs includes template rows for missing variants only."""
+    run_folder = tmp_path / "run"
+    run_folder.mkdir()
+
+    _write_csv(run_folder / "odoo_compare_only_in_contifico.csv",
+               ["Internal Reference", "Name", "Source"],
+               [{"Internal Reference": "VAR-B-M", "Name": "Template B", "Source": "variant"}])
+    _write_csv(run_folder / "odoo_product_templates_simple.csv", SIMPLE_COLS, [])
+
+    tmpl_cols = ["External ID", "Name", "Product Attributes / Attribute", "Product Attributes / Values", "Product Attributes / Create Variants"]
+    _write_csv(run_folder / "odoo_product_templates_with_attributes.csv", tmpl_cols, [
+        {"External ID": "product_template_a", "Name": "Template A", "Product Attributes / Attribute": "Talla", "Product Attributes / Values": "S,M", "Product Attributes / Create Variants": "Always"},
+        {"External ID": "product_template_b", "Name": "Template B", "Product Attributes / Attribute": "Talla", "Product Attributes / Values": "S,M", "Product Attributes / Create Variants": "Always"},
+    ])
+    _write_csv(run_folder / "odoo_product_variant_internal_references.csv", VARIANT_COLS, [
+        {"product_tmpl_id/id": "__import__.product_template_a", "Internal Reference": "VAR-A-S", "Barcode": "", "Name": "Template A", "Variant Values": "Talla: S", "Sales Price": "10", "Cost": "5"},
+        {"product_tmpl_id/id": "__import__.product_template_b", "Internal Reference": "VAR-B-M", "Barcode": "", "Name": "Template B", "Variant Values": "Talla: M", "Sales Price": "10", "Cost": "5"},
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.generate_missing_import_csvs(run_folder=run_folder, output_folder=tmp_path)
+
+    assert result["needed_templates"] == 1
+    tmpl_rows = _read_csv(tmp_path / "odoo_missing_templates_with_attributes.csv")
+    ext_ids = {r["External ID"] for r in tmpl_rows}
+    assert "product_template_b" in ext_ids
+    assert "product_template_a" not in ext_ids
+
+    variant_rows = _read_csv(tmp_path / "odoo_missing_variants_phase2.csv")
+    skus = {r["Internal Reference"] for r in variant_rows}
+    assert "VAR-B-M" in skus
+    assert "VAR-A-S" not in skus
+
+
+def test_generate_missing_raises_if_no_compare_csv(tmp_path: Path):
+    """Raises FileNotFoundError if compare CSV doesn't exist yet."""
+    import pytest
+    run_folder = tmp_path / "run"
+    run_folder.mkdir()
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    with pytest.raises(FileNotFoundError):
+        service.generate_missing_import_csvs(run_folder=run_folder, output_folder=tmp_path)
+
+
 def test_compare_preview_capped_at_30(tmp_path: Path):
     """Preview lists must be capped at 30 items each."""
     skus = [f"SKU-{i:03d}" for i in range(50)]

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -414,11 +414,45 @@ $('executeCompare').addEventListener('click', async () => {
     renderComparePreviews(data);
     renderCompareLinks(data.files);
     setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Solo Contífico: ${data.only_in_contifico} · Solo Odoo: ${data.only_in_odoo}`);
+    if (data.only_in_contifico > 0) $('generateMissingSection').classList.remove('hidden');
   } catch(e) {
     setCompareStatus(`Error: ${e.message}`);
     showErr(e);
   } finally {
     $('executeCompare').disabled = false;
+  }
+});
+
+$('generateMissingImport').addEventListener('click', async () => {
+  try {
+    const runId = $('compareRunId').value.trim();
+    if (!runId) throw new Error('Debes ingresar el Run ID.');
+    $('generateMissingImport').disabled = true;
+    $('generateMissingStatus').textContent = 'Generando CSVs...';
+    $('generateMissingLinks').innerHTML = '';
+    const data = await apiGet(`/odoo-migration/runs/${encodeURIComponent(runId)}/compare-inventory/generate-missing`);
+    const el = $('generateMissingLinks');
+    el.innerHTML = '';
+    const title = document.createElement('div');
+    title.className = 'phase-title';
+    title.textContent = 'Archivos generados (importar en este orden)';
+    el.appendChild(title);
+    const MISSING_FILES = [
+      { key: 'missing_simple',           label: `① Simples faltantes — ${data.simple_rows_exported} productos (odoo_missing_simple_for_import.csv)`,           isImport: true },
+      { key: 'missing_templates',        label: `② Templates con atributos — ${data.template_rows_exported} filas / ${data.needed_templates} templates (odoo_missing_templates_with_attributes.csv)`, isImport: true },
+      { key: 'missing_variants_phase2',  label: `③ Variantes Phase 2 — ${data.variant_rows_exported} SKUs (odoo_missing_variants_phase2.csv)`,                isImport: true },
+    ];
+    MISSING_FILES.forEach(({ key, label, isImport }) => {
+      const path = (data.files || {})[key];
+      if (!path) return;
+      el.appendChild(makeLink(`${base()}${path}`, label, isImport));
+    });
+    $('generateMissingStatus').textContent = `CSVs generados. Simples: ${data.missing_simple_total} · Variantes: ${data.missing_variants_total} · Templates necesarios: ${data.needed_templates}`;
+  } catch(e) {
+    $('generateMissingStatus').textContent = `Error: ${e.message}`;
+    showErr(e);
+  } finally {
+    $('generateMissingImport').disabled = false;
   }
 });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -82,6 +82,14 @@
         <div id="compareStats" class="compare-stats hidden"></div>
         <div id="compareLinks" class="phase-section"></div>
         <div id="comparePreviews"></div>
+        <div id="generateMissingSection" class="hidden">
+          <hr style="margin:16px 0;border:none;border-top:1px solid #e5e7eb" />
+          <h3 style="margin:0 0 4px">Generar importación de faltantes</h3>
+          <p class="muted">Genera CSVs filtrados listos para importar en Odoo con solo los productos que faltan.</p>
+          <button id="generateMissingImport">Generar CSVs de importación</button>
+          <p id="generateMissingStatus" class="muted"></p>
+          <div id="generateMissingLinks"></div>
+        </div>
       </section>
 
       <section id="tab-preview" class="tab-panel">


### PR DESCRIPTION
…a import

After comparing Contifico extraction vs Odoo inventory, the user can now generate filtered import CSVs containing ONLY the products missing from Odoo. This avoids reimporting the full catalog and lets the user do incremental imports.

Backend:
- generate_missing_import_csvs(): reads odoo_compare_only_in_contifico.csv, filters odoo_product_templates_simple.csv → odoo_missing_simple_for_import.csv, resolves needed template External IDs from the variant CSV and filters odoo_product_templates_with_attributes.csv → odoo_missing_templates_with_attributes.csv, filters odoo_product_variant_internal_references.csv → odoo_missing_variants_phase2.csv
- GET /runs/{run_id}/compare-inventory/generate-missing endpoint
- 3 new tests: filters simples, filters templates/variants, raises without compare CSV

Frontend:
- "Generar CSVs de importación" button appears in Comparador after comparison when there are missing products; shows 3 labelled download links with row counts

https://claude.ai/code/session_01GjvDiMY9bgEG666ePnmFCs