### PR TITLE
Extend merger to also set Internal Reference on simple products

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -354,7 +354,9 @@ def download_file(run_id: str, filename: str):
         "odoo_missing_variants_phase2.csv",
         "odoo_phase2_with_odoo_ids.csv",
         "odoo_phase2_with_odoo_ids_minimal.csv",
+        "odoo_phase2_simples_minimal.csv",
         "odoo_phase2_merger_unmatched.csv",
+        "odoo_phase2_simples_unmatched.csv",
         "odoo_phase2_merger_unused_odoo.csv",
         "odoo_phase1_template_renames.csv",
         "odoo_phase2_orphaned_skus.csv",
@@ -450,11 +452,14 @@ async def merge_phase2_with_odoo_export(run_id: str, file: UploadFile = File(...
     odoo_export_path = run_folder / "odoo_product_product_export.csv"
     odoo_export_path.write_bytes(await file.read())
 
+    simple_csv = run_folder / "odoo_product_templates_simple.csv"
+
     service = OdooMigrationService(client=None)  # type: ignore[arg-type]
     result = service.merge_phase2_with_odoo_export(
         odoo_export_csv=odoo_export_path,
         phase2_csv=phase2_csv,
         output_folder=run_folder,
+        simple_csv=simple_csv if simple_csv.exists() else None,
     )
 
     base = f"/odoo-migration/runs/{run_id}/files"
@@ -464,7 +469,9 @@ async def merge_phase2_with_odoo_export(run_id: str, file: UploadFile = File(...
         "files": {
             "phase2_with_odoo_ids": f"{base}/odoo_phase2_with_odoo_ids.csv",
             "phase2_with_odoo_ids_minimal": f"{base}/odoo_phase2_with_odoo_ids_minimal.csv",
+            "simples_minimal": f"{base}/odoo_phase2_simples_minimal.csv",
             "unmatched": f"{base}/odoo_phase2_merger_unmatched.csv",
+            "simples_unmatched": f"{base}/odoo_phase2_simples_unmatched.csv",
             "unused_odoo": f"{base}/odoo_phase2_merger_unused_odoo.csv",
         },
     }

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -1257,20 +1257,20 @@ class OdooMigrationService:
         odoo_export_csv: Path,
         phase2_csv: Path,
         output_folder: Path,
+        simple_csv: "Path | None" = None,
     ) -> dict[str, Any]:
-        """Enrich Phase 2 variant CSV with product.product External IDs from Odoo export.
-
-        After Phase 1 import Odoo auto-creates product.product variants. This method
-        matches each variant in our Phase 2 CSV to its Odoo record using
-        (template name, variant values) as the join key, then emits a new CSV with
-        the 'id' column populated so Odoo will UPDATE the record instead of creating
-        a duplicate.
+        """Enrich Phase 2 variant CSV (and optionally simple template CSV) with
+        product.product External IDs from Odoo export, so Odoo will UPDATE existing
+        records instead of creating duplicates.
 
         Odoo export expected columns:
-          id | id (dup) | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids
+          id | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids
 
         Phase 2 CSV expected columns:
           product_tmpl_id/id | Internal Reference | Barcode | Name | Variant Values | Sales Price | Cost
+
+        simple_csv (optional) expected columns:
+          External ID | Name | Internal Reference | Barcode | Product Type
         """
         def _norm_variant_values(variant_values: str) -> frozenset:
             return frozenset(
@@ -1350,22 +1350,51 @@ class OdooMigrationService:
                 else:
                     unmatched_rows.append({**row, "match_failure_reason": "No matching variant in Odoo export"})
 
-        # Odoo rows that didn't match any Phase 2 row
+        # ── Simple products pass ───────────────────────────────────────────────
+        # Odoo doesn't propagate product.template.default_code → product.product
+        # during CSV import, so simple products also need a Phase-2 style update.
+        # Match by __import__.{template_ext_id} (empty variant values).
+        simple_matched_rows: list[dict[str, str]] = []
+        simple_unmatched_rows: list[dict[str, str]] = []
+
+        if simple_csv and simple_csv.exists():
+            with simple_csv.open("r", newline="", encoding="utf-8-sig") as f:
+                for row in csv.DictReader(f):
+                    ext_id = str(row.get("External ID") or "").strip()
+                    ir = str(row.get("Internal Reference") or "").strip()
+                    barcode = str(row.get("Barcode") or "").strip()
+                    if not ext_id or not ir:
+                        continue
+                    # Odoo stores the imported External ID as __import__.{ext_id}
+                    odoo_tmpl_id = f"__import__.{ext_id}"
+                    primary_key = (_norm_tmpl_id(odoo_tmpl_id), frozenset())
+                    pp_ext_id = tmpl_id_lookup.get(primary_key)
+                    if pp_ext_id:
+                        odoo_keys_used.add(pp_ext_id)
+                        simple_matched_rows.append({"id": pp_ext_id, "Internal Reference": ir, "Barcode": barcode})
+                    else:
+                        simple_unmatched_rows.append({"External ID": ext_id, "Internal Reference": ir, "match_failure_reason": "No matching product.product in Odoo export"})
+
+        # Odoo rows that didn't match any Phase 2 or simple row
         unused_odoo_rows: list[dict[str, str]] = [
-            {"odoo_ext_id": r["pp_ext_id"], "tmpl_id": r["tmpl_id"], "tmpl_name": r["tmpl_name"], "variant_values": r["variant_values"], "reason": "Not present in Phase 2 CSV"}
+            {"odoo_ext_id": r["pp_ext_id"], "tmpl_id": r["tmpl_id"], "tmpl_name": r["tmpl_name"], "variant_values": r["variant_values"], "reason": "Not present in Phase 2 or simple CSV"}
             for r in all_odoo_rows
             if r["pp_ext_id"] not in odoo_keys_used
         ]
 
         matched_cols = ["id", "match_method", "product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost"]
         minimal_cols = ["id", "Internal Reference", "Barcode", "Sales Price", "Cost"]
+        simples_minimal_cols = ["id", "Internal Reference", "Barcode"]
         unmatched_cols = ["product_tmpl_id/id", "Internal Reference", "Barcode", "Name", "Variant Values", "Sales Price", "Cost", "match_failure_reason"]
+        simples_unmatched_cols = ["External ID", "Internal Reference", "match_failure_reason"]
         unused_cols = ["odoo_ext_id", "tmpl_id", "tmpl_name", "variant_values", "reason"]
 
         self._write_csv(output_folder / "odoo_phase2_with_odoo_ids.csv", matched_cols, matched_rows)
         # Minimal CSV: only id + fields to update — no Name/Variant Values to avoid Odoo relational field validation
         self._write_csv(output_folder / "odoo_phase2_with_odoo_ids_minimal.csv", minimal_cols, matched_rows)
+        self._write_csv(output_folder / "odoo_phase2_simples_minimal.csv", simples_minimal_cols, simple_matched_rows)
         self._write_csv(output_folder / "odoo_phase2_merger_unmatched.csv", unmatched_cols, unmatched_rows)
+        self._write_csv(output_folder / "odoo_phase2_simples_unmatched.csv", simples_unmatched_cols, simple_unmatched_rows)
         self._write_csv(output_folder / "odoo_phase2_merger_unused_odoo.csv", unused_cols, unused_odoo_rows)
 
         return {
@@ -1376,6 +1405,8 @@ class OdooMigrationService:
             "matched_by_name": matched_by_name,
             "total_odoo_rows": len(all_odoo_rows),
             "unused_odoo_rows": len(unused_odoo_rows),
+            "simple_matched": len(simple_matched_rows),
+            "simple_unmatched": len(simple_unmatched_rows),
         }
 
     @staticmethod

--- a/backend/tests/test_odoo_phase2_merger.py
+++ b/backend/tests/test_odoo_phase2_merger.py
@@ -306,6 +306,94 @@ def test_merger_case_insensitive_name_match(tmp_path: Path):
     assert result["matched"] == 1
 
 
+SIMPLE_COLS = ["External ID", "Name", "Internal Reference", "Barcode", "Product Type"]
+
+
+def _make_simple_csv(tmp_path: Path, rows: list[dict]) -> Path:
+    path = tmp_path / "odoo_product_templates_simple.csv"
+    _write_csv(path, SIMPLE_COLS, rows)
+    return path
+
+
+def test_merger_simple_products_matched(tmp_path: Path):
+    """Simple products (no variant values) are matched via product_tmpl_id/id."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {
+            "id": "__export__.product_product_95867",
+            "product_tmpl_id/id": "__import__.product_template_ykltb_sq10_2w_wht",
+            "product_tmpl_id/name": "3 STEP GLASS DOWN LIGHT",
+            "product_template_variant_value_ids": "",
+        },
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [])
+    simple_csv = _make_simple_csv(tmp_path, [
+        {"External ID": "product_template_ykltb_sq10_2w_wht", "Name": "3 STEP GLASS DOWN LIGHT",
+         "Internal Reference": "ykltb_sq10_2w_wht", "Barcode": "", "Product Type": "storable"},
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+        simple_csv=simple_csv,
+    )
+
+    assert result["simple_matched"] == 1
+    assert result["simple_unmatched"] == 0
+    assert result["matched"] == 0  # no variants
+
+    rows = _read_csv(tmp_path / "odoo_phase2_simples_minimal.csv")
+    assert len(rows) == 1
+    assert rows[0]["id"] == "__export__.product_product_95867"
+    assert rows[0]["Internal Reference"] == "ykltb_sq10_2w_wht"
+    assert "Name" not in rows[0]
+    assert "Variant Values" not in rows[0]
+
+
+def test_merger_simple_unmatched_reported(tmp_path: Path):
+    """Simple products not found in Odoo export go to simples_unmatched."""
+    odoo_export = _make_odoo_export(tmp_path, [])
+    phase2_csv = _make_phase2_csv(tmp_path, [])
+    simple_csv = _make_simple_csv(tmp_path, [
+        {"External ID": "product_template_xyz", "Name": "PROD XYZ",
+         "Internal Reference": "XYZ-001", "Barcode": "", "Product Type": "storable"},
+    ])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+        simple_csv=simple_csv,
+    )
+
+    assert result["simple_matched"] == 0
+    assert result["simple_unmatched"] == 1
+
+    rows = _read_csv(tmp_path / "odoo_phase2_simples_unmatched.csv")
+    assert rows[0]["Internal Reference"] == "XYZ-001"
+
+
+def test_merger_without_simple_csv_returns_zero_simple_counts(tmp_path: Path):
+    """When no simple_csv is passed, simple counts are zero and no error is raised."""
+    odoo_export = _make_odoo_export(tmp_path, [
+        {"id": "__export__.pp_1", "product_tmpl_id/id": "__export__.tmpl_1",
+         "product_tmpl_id/name": "PROD", "product_template_variant_value_ids": "Talla: M"},
+    ])
+    phase2_csv = _make_phase2_csv(tmp_path, [])
+
+    service = OdooMigrationService(client=None)  # type: ignore[arg-type]
+    result = service.merge_phase2_with_odoo_export(
+        odoo_export_csv=odoo_export,
+        phase2_csv=phase2_csv,
+        output_folder=tmp_path,
+    )
+
+    assert result["simple_matched"] == 0
+    assert result["simple_unmatched"] == 0
+
+
 def test_merger_primary_key_by_tmpl_id(tmp_path: Path):
     """When Phase 2 CSV and Odoo export share __import__.* template IDs, match by that key."""
     odoo_export = _make_odoo_export(tmp_path, [

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -471,10 +471,12 @@ function renderMergerLinks(runId, files) {
   title.textContent = 'Archivos generados por el merger';
   section.appendChild(title);
   const MERGER_FILES = [
-    { key: 'phase2_with_odoo_ids_minimal', label: '⭐ IMPORTAR ESTE — odoo_phase2_with_odoo_ids_minimal.csv (id + SKU + Barcode, sin campos relacionales)', isImport: true },
-    { key: 'phase2_with_odoo_ids',         label: 'Versión completa con Name/Variant Values (solo referencia)', isImport: false },
+    { key: 'phase2_with_odoo_ids_minimal', label: '⭐ IMPORTAR (variantes) — odoo_phase2_with_odoo_ids_minimal.csv (id + SKU + Barcode + Precio)', isImport: true },
+    { key: 'simples_minimal',              label: '⭐ IMPORTAR (simples) — odoo_phase2_simples_minimal.csv (id + SKU + Barcode)', isImport: true },
+    { key: 'phase2_with_odoo_ids',         label: 'Variantes versión completa con Name/Variant Values (solo referencia)', isImport: false },
     { key: 'unmatched',                    label: 'Variantes sin par en Odoo (merger_unmatched)', isImport: false },
-    { key: 'unused_odoo',                  label: 'Variantes Odoo sin par en Fase 2 (merger_unused_odoo)', isImport: false },
+    { key: 'simples_unmatched',            label: 'Simples sin par en Odoo (simples_unmatched)', isImport: false },
+    { key: 'unused_odoo',                  label: 'Registros Odoo sin par en Fase 2 (merger_unused_odoo)', isImport: false },
   ];
   MERGER_FILES.forEach(({ key, label, isImport }) => {
     const path = files[key];
@@ -503,7 +505,8 @@ $('executeMerger').addEventListener('click', async () => {
     renderMergerLinks(runId, data.files);
     const byId = data.matched_by_tmpl_id ?? 0;
     const byName = data.matched_by_name ?? 0;
-    setMergerStatus(`Merger completado. Matcheados: ${data.matched} (${byId} por ID, ${byName} por nombre) · Sin par: ${data.unmatched} · Odoo sin usar: ${data.unused_odoo_rows}`);
+    const simples = data.simple_matched ?? 0;
+    setMergerStatus(`Merger completado. Variantes: ${data.matched} (${byId} por ID, ${byName} por nombre) · Simples: ${simples} · Sin par: ${data.unmatched} · Odoo sin usar: ${data.unused_odoo_rows}`);
     // Pre-fill run_id en Stock si está vacío
     if (!$('stockRunId').value.trim()) $('stockRunId').value = runId;
   } catch(e) {


### PR DESCRIPTION
Odoo does not propagate product.template.default_code → product.product during CSV import, so simple products imported in Phase 1 end up with empty default_code. The merger now reads odoo_product_templates_simple.csv and matches each row against Odoo export rows with empty variant values using product_tmpl_id/id as the join key (__import__.{ext_id}).

Outputs two new import files:
  odoo_phase2_simples_minimal.csv     — id | Internal Reference | Barcode
  odoo_phase2_simples_unmatched.csv   — simples not found in Odoo export

Also adds simple_matched / simple_unmatched to API response and merger status bar. Adds 3 new tests.

https://claude.ai/code/session_01GjvDiMY9bgEG666ePnmFCs