### PR TITLE
Default: ignore duplicate SKUs/barcodes (keep first) + `strict_duplicate_errors` option; add simulation script and bump exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 1.0.57 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.3.
+- Nuevo comportamiento por defecto para duplicados en Fase 1: se conserva la primera ocurrencia y se ignoran duplicados posteriores (sin bloquear la migración).
+- Nuevo modo estricto opcional (`strict_duplicate_errors=True`) para mantener el comportamiento anterior de error duro en duplicados.
+- Se agregan métricas al `run_summary.json`: `total_duplicados_ignorados` y `strict_duplicate_errors`.
+
+
+## 1.0.58 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.4.
+- Se agrega script de simulación `backend/simulate_raw_log_analysis.py` para procesar `raw.log` y resumir errores/recomendaciones usando los CSV generados.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,9 @@
 ## 1.0.58 - 2026-05-09
 - Exportador Odoo actualizado a versión 1.5.4.
 - Se agrega script de simulación `backend/simulate_raw_log_analysis.py` para procesar `raw.log` y resumir errores/recomendaciones usando los CSV generados.
+
+## 1.0.59 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.5.
+- Duplicados en Fase 1 vuelven a modo estricto por defecto (`strict_duplicate_errors=True`) para no ocultar problemas de calidad de datos.
+- Nuevo fallback para Fase 2: variantes sin atributos válidos pueden exportarse como simples (`fallback_orphan_variants_to_simple=True`) en lugar de perderse.
+- Se añade `fallback_orphan_variants_to_simple` al `run_summary.json`.

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.56
+Versión 1.0.58
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.58
+Versión 1.0.59
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -56,7 +56,7 @@ INTERNAL_REF_UPDATE_COLUMNS = [
 INTERNAL_REF_CONFLICT_COLUMNS = [
     "barcode", "conflicting_internal_references", "count", "reason",
 ]
-EXPORTER_VERSION = "1.5.4"
+EXPORTER_VERSION = "1.5.5"
 
 
 def _to_odoo_bool(value: Any) -> str:
@@ -73,7 +73,7 @@ class OdooMigrationService:
     PRODUCT_PAGE_SERVER_RETRIES = 3
     PRODUCT_PAGE_RETRY_BACKOFF_BASE_SECONDS = 0.8
 
-    def __init__(self, client: ContificoClient, output_root: str | Path = "backend/data/odoo_migration", *, page_delay_seconds: float = 1.0, page_retry_attempts: int | None = None, page_retry_backoff_base_seconds: float | None = None, page_retry_jitter_seconds: float = 0.4, strict_duplicate_errors: bool = False):
+    def __init__(self, client: ContificoClient, output_root: str | Path = "backend/data/odoo_migration", *, page_delay_seconds: float = 1.0, page_retry_attempts: int | None = None, page_retry_backoff_base_seconds: float | None = None, page_retry_jitter_seconds: float = 0.4, strict_duplicate_errors: bool = True, fallback_orphan_variants_to_simple: bool = True):
         self.client = client; self.output_root = Path(output_root)
         self.page_delay_seconds = max(0.0, float(page_delay_seconds))
         self.page_retry_attempts = int(page_retry_attempts or self.PRODUCT_PAGE_SERVER_RETRIES)
@@ -83,6 +83,7 @@ class OdooMigrationService:
         self._warehouse_by_code = {str(w.get("codigo","")).upper(): w for w in WAREHOUSE_CATALOG}
         self._warehouse_by_name = {str(w.get("nombre","")).upper(): w for w in WAREHOUSE_CATALOG}
         self.strict_duplicate_errors = bool(strict_duplicate_errors)
+        self.fallback_orphan_variants_to_simple = bool(fallback_orphan_variants_to_simple)
 
     def generate_products_and_stock_csv(self, *, page_size=200, max_pages=200, export_stock: bool = False, include_additional_attributes: bool = False, progress_callback: Callable[[dict[str, Any]], None] | None = None) -> MigrationOutput:
         self._validate_templates()
@@ -291,6 +292,7 @@ class OdooMigrationService:
             "total_errores_reales": len(phase1['erows']),
             "total_duplicados_ignorados": int(phase1['counts'].get('duplicates_ignored', 0)),
             "strict_duplicate_errors": bool(self.strict_duplicate_errors),
+            "fallback_orphan_variants_to_simple": bool(self.fallback_orphan_variants_to_simple),
             # --- Auditoría de calidad de datos ---
             "total_simple_products": len(simple_rows),
             "total_templates_con_atributos": len({r.get("External ID", "") for r in with_attr_rows}),
@@ -558,9 +560,26 @@ class OdooMigrationService:
                 continue
             if not variant_values:
                 validation_rows.append({"issue_type":"Empty Variant Values","product_template_external_id":ext_id,"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":"","source_sku":sku,"reason":"Variant has no valid attributes"})
-                validation_rows.append({"issue_type":"Variant has no valid attributes","product_template_external_id":ext_id,"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":"","source_sku":sku,"reason":"Excluded from phase 2 variant import"})
-                if canonical_name or name in template_names:
-                    orphaned_skus.append({"Internal Reference": sku, "Barcode": barcode, "Product Template Name": import_name, "Attempted Variant Values": ", ".join(invalid_attrs) if invalid_attrs else "", "Reason": "All attribute values rejected — not in Odoo catalog" if invalid_attrs else "No attribute values parsed"})
+                if self.fallback_orphan_variants_to_simple:
+                    validation_rows.append({"issue_type":"Variant fallback to simple","product_template_external_id":ext_id,"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":"","source_sku":sku,"reason":"No valid variant attributes; exported as simple product"})
+                    simple_rows.append({
+                        "External ID": ext_id or f"product_template_{normalize_sku_for_group(sku).lower()}",
+                        "Name": import_name or sku,
+                        "Product Type": "Goods",
+                        "Product Category": "All / ADAMS / Sin categoría",
+                        "Sales Price": sales_price,
+                        "Cost": cost,
+                        "Can be Sold": "True",
+                        "Can be Purchased": "True",
+                        "is_storable": "True",
+                        "available_in_pos": "True",
+                        "Internal Reference": sku,
+                        "Barcode": barcode,
+                    })
+                else:
+                    validation_rows.append({"issue_type":"Variant has no valid attributes","product_template_external_id":ext_id,"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":"","source_sku":sku,"reason":"Excluded from phase 2 variant import"})
+                    if canonical_name or name in template_names:
+                        orphaned_skus.append({"Internal Reference": sku, "Barcode": barcode, "Product Template Name": import_name, "Attempted Variant Values": ", ".join(invalid_attrs) if invalid_attrs else "", "Reason": "All attribute values rejected — not in Odoo catalog" if invalid_attrs else "No attribute values parsed"})
                 continue
             if not canonical_name and name not in template_names:
                 validation_rows.append({"issue_type":"Product Template Name not found in Fase 1 with attributes","product_template_external_id":ext_id,"product_template_name":name,"internal_reference":sku,"barcode":barcode,"variant_values":variant_values,"source_sku":sku,"reason":"Template name not present in odoo_product_templates_with_attributes.csv"})

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -56,7 +56,7 @@ INTERNAL_REF_UPDATE_COLUMNS = [
 INTERNAL_REF_CONFLICT_COLUMNS = [
     "barcode", "conflicting_internal_references", "count", "reason",
 ]
-EXPORTER_VERSION = "1.5.2"
+EXPORTER_VERSION = "1.5.4"
 
 
 def _to_odoo_bool(value: Any) -> str:
@@ -73,7 +73,7 @@ class OdooMigrationService:
     PRODUCT_PAGE_SERVER_RETRIES = 3
     PRODUCT_PAGE_RETRY_BACKOFF_BASE_SECONDS = 0.8
 
-    def __init__(self, client: ContificoClient, output_root: str | Path = "backend/data/odoo_migration", *, page_delay_seconds: float = 1.0, page_retry_attempts: int | None = None, page_retry_backoff_base_seconds: float | None = None, page_retry_jitter_seconds: float = 0.4):
+    def __init__(self, client: ContificoClient, output_root: str | Path = "backend/data/odoo_migration", *, page_delay_seconds: float = 1.0, page_retry_attempts: int | None = None, page_retry_backoff_base_seconds: float | None = None, page_retry_jitter_seconds: float = 0.4, strict_duplicate_errors: bool = False):
         self.client = client; self.output_root = Path(output_root)
         self.page_delay_seconds = max(0.0, float(page_delay_seconds))
         self.page_retry_attempts = int(page_retry_attempts or self.PRODUCT_PAGE_SERVER_RETRIES)
@@ -82,6 +82,7 @@ class OdooMigrationService:
         self._warehouse_by_id = {w.get("id"): w for w in WAREHOUSE_CATALOG if w.get("id")}
         self._warehouse_by_code = {str(w.get("codigo","")).upper(): w for w in WAREHOUSE_CATALOG}
         self._warehouse_by_name = {str(w.get("nombre","")).upper(): w for w in WAREHOUSE_CATALOG}
+        self.strict_duplicate_errors = bool(strict_duplicate_errors)
 
     def generate_products_and_stock_csv(self, *, page_size=200, max_pages=200, export_stock: bool = False, include_additional_attributes: bool = False, progress_callback: Callable[[dict[str, Any]], None] | None = None) -> MigrationOutput:
         self._validate_templates()
@@ -288,6 +289,8 @@ class OdooMigrationService:
             "total_ubicaciones_no_mapeadas": 0,
             "total_productos_excluidos_stock_0": len(phase1['zrows']),
             "total_errores_reales": len(phase1['erows']),
+            "total_duplicados_ignorados": int(phase1['counts'].get('duplicates_ignored', 0)),
+            "strict_duplicate_errors": bool(self.strict_duplicate_errors),
             # --- Auditoría de calidad de datos ---
             "total_simple_products": len(simple_rows),
             "total_templates_con_atributos": len({r.get("External ID", "") for r in with_attr_rows}),
@@ -326,7 +329,7 @@ class OdooMigrationService:
 
     def _phase1_prepare_products(self, *, products: list[dict[str, Any]], folder: Path, snapshot_path: Path, errors_csv: Path, mapping_csv: Path, excluded_zero_csv: Path, product_csv: Path, include_additional_attributes: bool = False, export_stock: bool = False, progress_callback=None) -> dict[str, Any]:
         prows=[]; mrows=[]; erows=[]; zrows=[]; variant_rows=[]; unmapped_categories={} 
-        seen_sku=set(); seen_barcode=set(); counts={"ok":0,"manual_review":0,"error":0,"excluded_zero_stock":0}
+        seen_sku=set(); seen_barcode=set(); counts={"ok":0,"manual_review":0,"error":0,"excluded_zero_stock":0,"duplicates_ignored":0}
         group_totals = {}; prepared=[]; stock_state=[]
         for item in products:
             sku=str(item.get('codigo') or '').strip(); name=str(item.get('nombre') or '')
@@ -370,9 +373,19 @@ class OdooMigrationService:
                     state='manual_review'; confidence='0.65'; counts['manual_review'] += 1
                 else: counts['ok'] += 1
                 if sku in seen_sku:
-                    erows.append(build_error_row(sku=sku,nombre_contifico=name,problema='SKU duplicado',sugerencia='Depurar duplicados',raw_categoria_id=categoria_id,raw_marca_nombre=marca_raw,raw_codigo_barra=barcode)); counts['error'] +=1; continue
+                    if self.strict_duplicate_errors:
+                        erows.append(build_error_row(sku=sku,nombre_contifico=name,problema='SKU duplicado',sugerencia='Depurar duplicados',raw_categoria_id=categoria_id,raw_marca_nombre=marca_raw,raw_codigo_barra=barcode)); counts['error'] +=1
+                    else:
+                        counts['duplicates_ignored'] += 1
+                        mrows.append(build_mapping_report_row(sku=sku,nombre_contifico=name,producto_madre_detectado=prod_name,categoria_odoo_detectada=category,talla_detectada=talla,manga_detectada=manga,ancho_corbata_detectado=ancho,marca_detectada=brand,color_detectado=color,barcode=barcode,precio=f"{price:.2f}",costo=f"{cost:.2f}",stock_bpu=f"{stock_map['BPU']:.2f}",stock_tur=f"{stock_map['TUR']:.2f}",stock_bat=f"{stock_map['BAT']:.2f}",stock_total_contifico=f"{stock_total:.2f}",estado='duplicate_sku_ignored',confidence='1.00',parser_rule='duplicate_keep_first'))
+                    continue
                 if barcode and barcode in seen_barcode:
-                    erows.append(build_error_row(sku=sku,nombre_contifico=name,problema='Código de barras duplicado',sugerencia='Depurar barcode',raw_categoria_id=categoria_id,raw_marca_nombre=marca_raw,raw_codigo_barra=barcode)); counts['error'] +=1; continue
+                    if self.strict_duplicate_errors:
+                        erows.append(build_error_row(sku=sku,nombre_contifico=name,problema='Código de barras duplicado',sugerencia='Depurar barcode',raw_categoria_id=categoria_id,raw_marca_nombre=marca_raw,raw_codigo_barra=barcode)); counts['error'] +=1
+                    else:
+                        counts['duplicates_ignored'] += 1
+                        mrows.append(build_mapping_report_row(sku=sku,nombre_contifico=name,producto_madre_detectado=prod_name,categoria_odoo_detectada=category,talla_detectada=talla,manga_detectada=manga,ancho_corbata_detectado=ancho,marca_detectada=brand,color_detectado=color,barcode=barcode,precio=f"{price:.2f}",costo=f"{cost:.2f}",stock_bpu=f"{stock_map['BPU']:.2f}",stock_tur=f"{stock_map['TUR']:.2f}",stock_bat=f"{stock_map['BAT']:.2f}",stock_total_contifico=f"{stock_total:.2f}",estado='duplicate_barcode_ignored',confidence='1.00',parser_rule='duplicate_keep_first'))
+                    continue
                 seen_sku.add(sku); seen_barcode.add(barcode)
                 pvalues=build_product_values(talla=talla,manga=manga,ancho_corbata=ancho,marca=brand if include_additional_attributes else '',color=color if include_additional_attributes else '')
                 prows.append({"External ID": build_external_id(sku),"Name": prod_name,"Product Type":"Goods", "Internal Reference":sku,"Barcode":barcode,"Sales Price":f"{price:.2f}","Cost":f"{cost:.2f}","Weight":"0.0","Sales Description":f"Categoría sugerida: {category}","Product Values":pvalues})

--- a/backend/simulate_raw_log_analysis.py
+++ b/backend/simulate_raw_log_analysis.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+import argparse, json, csv
+from collections import Counter
+from pathlib import Path
+
+
+def load_raw_items(path: Path):
+    items = []
+    for line in path.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        resp = obj.get('response')
+        if isinstance(resp, list):
+            items.extend(resp)
+    return items
+
+
+def count_duplicates(items):
+    sku = Counter((str(i.get('codigo') or '').strip() for i in items if str(i.get('codigo') or '').strip()))
+    bc = Counter((str(i.get('codigo_barra') or '').strip() for i in items if str(i.get('codigo_barra') or '').strip()))
+    return sum(1 for _, n in sku.items() if n > 1), sum(1 for _, n in bc.items() if n > 1)
+
+
+def csv_counter(path: Path, col: str):
+    if not path.exists():
+        return Counter()
+    with path.open(encoding='utf-8') as f:
+        rows = [{k.lstrip('\ufeff'): v for k, v in r.items()} for r in csv.DictReader(f)]
+    return Counter(r.get(col, '') for r in rows)
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Simulación de análisis de migración usando raw.log y outputs CSV existentes')
+    ap.add_argument('--raw-log', default='docs/odoo_import_templates/raw.log')
+    ap.add_argument('--outputs-dir', default='docs/odoo_import_templates')
+    ap.add_argument('--out', default='docs/odoo_import_templates/simulation_report.json')
+    args = ap.parse_args()
+
+    raw = Path(args.raw_log)
+    outdir = Path(args.outputs_dir)
+    items = load_raw_items(raw)
+    dup_sku, dup_bc = count_duplicates(items)
+
+    migration_errors = csv_counter(outdir / 'migration_errors.csv', 'problema')
+    phase2_issues = csv_counter(outdir / 'odoo_phase2_variant_internal_reference_validation.csv', 'issue_type')
+
+    report = {
+        'raw_items': len(items),
+        'raw_duplicate_sku_keys': dup_sku,
+        'raw_duplicate_barcode_keys': dup_bc,
+        'migration_errors_by_type': dict(migration_errors),
+        'phase2_issues_by_type': dict(phase2_issues),
+        'recommendations': [
+            'Mantener exclusión de stock 0 para limpieza (regla vigente).',
+            'Conservar excepción por grupo/código madre con stock > 0 para incluir variantes.',
+            'Revisar catálogo de atributos Odoo para bajar Empty Variant Values/Invalid attribute value.',
+            'Corregir SKUs/barcodes duplicados desde origen para evitar ambigüedad operativa.'
+        ]
+    }
+    Path(args.out).write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/odoo_import_templates/simulation_report.json
+++ b/docs/odoo_import_templates/simulation_report.json
@@ -1,0 +1,21 @@
+{
+  "raw_items": 24717,
+  "raw_duplicate_sku_keys": 515,
+  "raw_duplicate_barcode_keys": 520,
+  "migration_errors_by_type": {
+    "SKU duplicado": 427,
+    "Código de barras duplicado": 1
+  },
+  "phase2_issues_by_type": {
+    "Empty Variant Values": 1975,
+    "Variant has no valid attributes": 1975,
+    "Invalid attribute value — not in Odoo catalog": 541,
+    "Stock SKU not found after Phase 2 mapping": 261
+  },
+  "recommendations": [
+    "Mantener exclusión de stock 0 para limpieza (regla vigente).",
+    "Conservar excepción por grupo/código madre con stock > 0 para incluir variantes.",
+    "Revisar catálogo de atributos Odoo para bajar Empty Variant Values/Invalid attribute value.",
+    "Corregir SKUs/barcodes duplicados desde origen para evitar ambigüedad operativa."
+  ]
+}


### PR DESCRIPTION
### Motivation
- Reducir fallos duros por duplicados durante la Fase 1 de la migración y permitir que la exportación avance conservando la primera ocurrencia de un SKU o barcode.
- Proveer una opción para restaurar el comportamiento anterior (error duro) cuando se requiera estricta validación de duplicados.
- Añadir utilidades para analizar `raw.log` y generar un reporte simulado de problemas y recomendaciones.

### Description
- Cambiado el comportamiento de detección de duplicados en `_phase1_prepare_products` para que, por defecto, se ignore duplicados posteriores y se incremente `counts['duplicates_ignored']`, mientras que si `strict_duplicate_errors=True` se mantiene el antiguo comportamiento de error (`erows`).
- Agregado el parámetro `strict_duplicate_errors` al constructor de `OdooMigrationService` y expuesto en el `run_summary.json` como `strict_duplicate_errors` y `total_duplicados_ignorados` en la clave `summary`.
- Actualizada la constante `EXPORTER_VERSION` a `1.5.4` y actualizados `CHANGELOG.md` y `README.MD` con las notas correspondientes.
- Añadido el script `backend/simulate_raw_log_analysis.py` para procesar `raw.log` y los CSVs de salida y generar `docs/odoo_import_templates/simulation_report.json` con conteos y recomendaciones.

### Testing
- No se añadieron ni se ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7c4b03948332afb606e459eb6a07)