### PR TITLE
Harden Phase‑2 variant uniqueness and add clean import CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,9 @@
 - Duplicados en Fase 1 vuelven a modo estricto por defecto (`strict_duplicate_errors=True`) para no ocultar problemas de calidad de datos.
 - Nuevo fallback para Fase 2: variantes sin atributos válidos pueden exportarse como simples (`fallback_orphan_variants_to_simple=True`) en lugar de perderse.
 - Se añade `fallback_orphan_variants_to_simple` al `run_summary.json`.
+
+## 1.0.60 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.6.
+- Se agrega guardarraíl en Fase 2 para detectar y deduplicar por (`product_tmpl_id/id`, `Variant Values`) antes de exportar `odoo_product_variant_internal_references.csv`.
+- Se reportan nuevas validaciones de riesgo para prevenir el error de unicidad de Odoo `product_product_combination_unique`.
+- Se genera en `docs/odoo_import_templates/Last` un CSV saneado de variantes (`odoo_product_variant_internal_references_clean.csv`) listo para importación segura.

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.59
+Versión 1.0.60
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -56,7 +56,7 @@ INTERNAL_REF_UPDATE_COLUMNS = [
 INTERNAL_REF_CONFLICT_COLUMNS = [
     "barcode", "conflicting_internal_references", "count", "reason",
 ]
-EXPORTER_VERSION = "1.5.5"
+EXPORTER_VERSION = "1.5.6"
 
 
 def _to_odoo_bool(value: Any) -> str:
@@ -609,11 +609,14 @@ class OdooMigrationService:
         sku_counts = {}
         barcode_counts = {}
         key_counts = {}
+        template_combo_counts = {}
         for r in variant_rows:
             sku_counts[r["Internal Reference"]] = sku_counts.get(r["Internal Reference"], 0) + 1
             barcode_counts[r["Barcode"]] = barcode_counts.get(r["Barcode"], 0) + 1
             k=(r["Name"], r["Variant Values"])
             key_counts[k] = key_counts.get(k, 0) + 1
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            template_combo_counts[template_combo] = template_combo_counts.get(template_combo, 0) + 1
 
         duplicate_key_rows = []
         for r in variant_rows:
@@ -625,6 +628,24 @@ class OdooMigrationService:
             if key_counts.get(key,0)>1:
                 validation_rows.append({"issue_type":"Duplicate Name + Variant Values","product_template_external_id":"","product_template_name":r["Name"],"internal_reference":sku,"barcode":bc,"variant_values":r["Variant Values"],"source_sku":sku,"reason":"Variant key duplicated"})
                 duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":sku,"barcode":bc,"source_sku":sku,"reason":"Duplicate Name + Variant Values"})
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            if template_combo_counts.get(template_combo, 0) > 1:
+                validation_rows.append({"issue_type":"Duplicate product_tmpl_id + Variant Values","product_template_external_id":str(r.get("product_tmpl_id/id") or "").replace("__import__.", ""),"product_template_name":r["Name"],"internal_reference":sku,"barcode":bc,"variant_values":r["Variant Values"],"source_sku":sku,"reason":"Would violate Odoo unique constraint product_product_combination_unique"})
+                duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":sku,"barcode":bc,"source_sku":sku,"reason":"Duplicate product_tmpl_id + Variant Values"})
+
+        # Hard safety net for Odoo constraint:
+        # product_product_combination_unique requires one row per (template, variant values).
+        deduped_variant_rows = []
+        seen_template_combo: set[tuple[str, str]] = set()
+        for r in variant_rows:
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            if template_combo in seen_template_combo:
+                validation_rows.append({"issue_type":"Dropped duplicate product_tmpl_id + Variant Values","product_template_external_id":str(r.get("product_tmpl_id/id") or "").replace("__import__.", ""),"product_template_name":r["Name"],"internal_reference":r["Internal Reference"],"barcode":r["Barcode"],"variant_values":r["Variant Values"],"source_sku":r["Internal Reference"],"reason":"Safety dedupe applied before CSV export"})
+                duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":r["Internal Reference"],"barcode":r["Barcode"],"source_sku":r["Internal Reference"],"reason":"Dropped duplicate product_tmpl_id + Variant Values"})
+                continue
+            seen_template_combo.add(template_combo)
+            deduped_variant_rows.append(r)
+        variant_rows = deduped_variant_rows
 
         simple_skus = {str(r.get("Internal Reference") or "").strip() for r in simple_rows if str(r.get("Internal Reference") or "").strip()}
         variant_skus = {r["Internal Reference"] for r in variant_rows}

--- a/docs/odoo_import_templates/Last/odoo_product_variant_internal_references_clean.csv
+++ b/docs/odoo_import_templates/Last/odoo_product_variant_internal_references_clean.csv
@@ -1,0 +1,6242 @@
+product_tmpl_id/id,Internal Reference,Barcode,Name,Variant Values,Sales Price,Cost
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/60,23E424615202460PT,Leva 23E4246-15-PAT,Talla: 60,173.83,0.00
+__import__.product_template_23e4246_13_pat,23E4246-13-PAT/58,23E424613202558PT,Leva 23E4246-13-PAT,Talla: 58,173.83,0.00
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/46,23E424615202446PT,Leva 23E4246-15-PAT,Talla: 46,173.83,0.00
+__import__.product_template_geo1982_1,GEO1982-1/48,G19820120251248,Leva GEO1982-1,Talla: 48,165.13,0.00
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/48,23E424615202448PT,Leva 23E4246-15-PAT,Talla: 48,173.83,0.00
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/50,23E424615202450PT,Leva 23E4246-15-PAT,Talla: 50,173.83,0.00
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/52,23E424615202452PT,Leva 23E4246-15-PAT,Talla: 52,173.83,0.00
+__import__.product_template_24b11398_157,24B11398-157/46,24B113981572546,Leva 24B11398-157,Talla: 46,165.13,0.00
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/54,23E424615202454PT,Leva 23E4246-15-PAT,Talla: 54,173.83,0.00
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/56,23E424615202456PT,Leva 23E4246-15-PAT,Talla: 56,173.83,0.00
+__import__.product_template_23e4246_15_pat,23E4246-15-PAT/58,23E424615202458PT,Leva 23E4246-15-PAT,Talla: 58,173.83,0.00
+__import__.product_template_hd19152_4,HD19152-4/50,HD1915204202550,Leva HD19152-4,Talla: 50,165.13,0.00
+__import__.product_template_24b11398_157,24B11398-157/48,24B113981572548,Leva 24B11398-157,Talla: 48,165.13,0.00
+__import__.product_template_24b11398_157,24B11398-157/50,24B113981572550,Leva 24B11398-157,Talla: 50,165.13,0.00
+__import__.product_template_geo1982_1,GEO1982-1/50,G19820120251250,Leva GEO1982-1,Talla: 50,165.13,0.00
+__import__.product_template_geo1982_1,GEO1982-1/52,G19820120251252,Leva GEO1982-1,Talla: 52,165.13,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/54,23E424616202554PT,Leva 23E4246-16-PAT,Talla: 54,173.83,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/52,23E424616202552PT,Leva 23E4246-16-PAT,Talla: 52,173.83,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/50,23E424616202550PT,Leva 23E4246-16-PAT,Talla: 50,173.83,0.00
+__import__.product_template_geo1982_4,GEO1982-4/50,G19820420251250,Leva GEO1982-4,Talla: 50,165.13,0.00
+__import__.product_template_23e4246_16,23E4246-16/52,23E424616202552,Leva 23E4246-16,Talla: 52,165.13,0.00
+__import__.product_template_23e4246_16,23E4246-16/54,23E424616202554,Leva 23E4246-16,Talla: 54,165.13,0.00
+__import__.product_template_24b11398_157,24B11398-157/60,24B113981572560,Leva 24B11398-157,Talla: 60,165.13,0.00
+__import__.product_template_24b11398_157,24B11398-157/58,24B113981572558,Leva 24B11398-157,Talla: 58,165.13,0.00
+__import__.product_template_24b11398_157,24B11398-157/56,24B113981572556,Leva 24B11398-157,Talla: 56,165.13,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/48,23E424616202548PT,Leva 23E4246-16-PAT,Talla: 48,173.83,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/46,23E424616202546PT,Leva 23E4246-16-PAT,Talla: 46,173.83,0.00
+__import__.product_template_geo1982_1,GEO1982-1/56,G19820120251256,Leva GEO1982-1,Talla: 56,165.13,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/60,23E424616202560PT,Leva 23E4246-16-PAT,Talla: 60,173.83,0.00
+__import__.product_template_geo1982_4,GEO1982-4/48,G19820420251248,Leva GEO1982-4,Talla: 48,165.13,0.00
+__import__.product_template_hd19152_4,HD19152-4/52,HD1915204202552,Leva HD19152-4,Talla: 52,165.13,0.00
+__import__.product_template_hd19152_4,HD19152-4/54,HD1915204202554,Leva HD19152-4,Talla: 54,165.13,0.00
+__import__.product_template_hd19152_4,HD19152-4/48,HD1915204202548,Leva HD19152-4,Talla: 48,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/60,HD1915223202560,Leva HD19152-23,Talla: 60,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/58,HD1915223202558,Leva HD19152-23,Talla: 58,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/56,HD1915223202556,Leva HD19152-23,Talla: 56,165.13,0.00
+__import__.product_template_23e4246_13_pat,23E4246-13-PAT/56,23E424613202556PT,Leva 23E4246-13-PAT,Talla: 56,173.83,0.00
+__import__.product_template_23e4246_16,23E4246-16/50,23E424616202550,Leva 23E4246-16,Talla: 50,165.13,0.00
+__import__.product_template_23e4246_13_pat,23E4246-13-PAT/60,23E424613202560PT,Leva 23E4246-13-PAT,Talla: 60,173.83,0.00
+__import__.product_template_hd19152_4,HD19152-4/60,HD1915204202560,Leva HD19152-4,Talla: 60,165.13,0.00
+__import__.product_template_hd19152_4,HD19152-4/58,HD1915204202558,Leva HD19152-4,Talla: 58,165.13,0.00
+__import__.product_template_23e4246_16,23E4246-16/48,23E424616202548,Leva 23E4246-16,Talla: 48,165.13,0.00
+__import__.product_template_23e4246_16,23E4246-16/46,23E424616202546,Leva 23E4246-16,Talla: 46,165.13,0.00
+__import__.product_template_hd19152_4,HD19152-4/46,HD1915204202546,Leva HD19152-4,Talla: 46,165.13,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/58,23E424616202558PT,Leva 23E4246-16-PAT,Talla: 58,173.83,0.00
+__import__.product_template_hd19152_4,HD19152-4/56,HD1915204202556,Leva HD19152-4,Talla: 56,165.13,0.00
+__import__.product_template_geo1982_1,GEO1982-1/46,G19820120251246,Leva GEO1982-1,Talla: 46,165.13,0.00
+__import__.product_template_23e4246_16_pat,23E4246-16-PAT/56,23E424616202556PT,Leva 23E4246-16-PAT,Talla: 56,173.83,0.00
+__import__.product_template_geo1982_4,GEO1982-4/56,G19820420251256,Leva GEO1982-4,Talla: 56,165.13,0.00
+__import__.product_template_geo1982_1,GEO1982-1/54,G19820120251254,Leva GEO1982-1,Talla: 54,165.13,0.00
+__import__.product_template_geo1982_4,GEO1982-4/46,G19820420251246,Leva GEO1982-4,Talla: 46,165.13,0.00
+__import__.product_template_23e4246_16,23E4246-16/58,23E424616202558,Leva 23E4246-16,Talla: 58,165.13,0.00
+__import__.product_template_23e4246_16,23E4246-16/60,23E424616202560,Leva 23E4246-16,Talla: 60,165.13,0.00
+__import__.product_template_geo1982_1,GEO1982-1/60,G19820120251260,Leva GEO1982-1,Talla: 60,165.13,0.00
+__import__.product_template_23e4246_16,23E4246-16/56,23E424616202556,Leva 23E4246-16,Talla: 56,165.13,0.00
+__import__.product_template_geo1982_4,GEO1982-4/52,G19820420251252,Leva GEO1982-4,Talla: 52,165.13,0.00
+__import__.product_template_geo1982_1,GEO1982-1/58,G19820120251258,Leva GEO1982-1,Talla: 58,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/52,HD1915223202552,Leva HD19152-23,Talla: 52,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/54,HD1915223202554,Leva HD19152-23,Talla: 54,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/50,HD1915223202550,Leva HD19152-23,Talla: 50,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/48,HD1915223202548,Leva HD19152-23,Talla: 48,165.13,0.00
+__import__.product_template_hd19152_23,HD19152-23/46,HD1915223202546,Leva HD19152-23,Talla: 46,165.13,0.00
+__import__.product_template_geo1982_4,GEO1982-4/60,G19820420251260,Leva GEO1982-4,Talla: 60,165.13,0.00
+__import__.product_template_geo1982_4,GEO1982-4/54,G19820420251254,Leva GEO1982-4,Talla: 54,165.13,0.00
+__import__.product_template_geo1982_4,GEO1982-4/58,G19820420251258,Leva GEO1982-4,Talla: 58,165.13,0.00
+__import__.product_template_24b11398_157,24B11398-157/54,24B113981572554,Leva 24B11398-157,Talla: 54,165.13,0.00
+__import__.product_template_24b11398_157,24B11398-157/52,24B113981572552,Leva 24B11398-157,Talla: 52,165.13,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/60,23E424604202560PT,Leva 23E4246-4-PAT,Talla: 60,173.83,0.00
+__import__.product_template_23e4246_4,23E4246-4/46,23E424604202546,Leva 23E4246-4,Talla: 46,165.13,0.00
+__import__.product_template_23e4246_4,23E4246-4/48,23E424604202548,Leva 23E4246-4,Talla: 48,165.13,0.00
+__import__.product_template_23e4246_4,23E4246-4/50,23E424604202550,Leva 23E4246-4,Talla: 50,165.13,0.00
+__import__.product_template_23e4246_12,23E4246-12/50,23E424612202550,Leva 23E4246-12,Talla: 50,165.13,0.00
+__import__.product_template_23e4246_12,23E4246-12/48,23E424612202548,Leva 23E4246-12,Talla: 48,165.13,0.00
+__import__.product_template_23e4246_12,23E4246-12/46,23E424612202546,Leva 23E4246-12,Talla: 46,165.13,0.00
+__import__.product_template_23e4246_4,23E4246-4/60,23E424604202560,Leva 23E4246-4,Talla: 60,165.13,0.00
+__import__.product_template_23e4246_4,23E4246-4/58,23E424604202558,Leva 23E4246-4,Talla: 58,165.13,0.00
+__import__.product_template_23e4246_4,23E4246-4/56,23E424604202556,Leva 23E4246-4,Talla: 56,165.13,0.00
+__import__.product_template_23e4246_4,23E4246-4/54,23E424604202554,Leva 23E4246-4,Talla: 54,165.13,0.00
+__import__.product_template_23e4246_4,23E4246-4/52,23E424604202552,Leva 23E4246-4,Talla: 52,165.13,0.00
+__import__.product_template_23e4246_12_pat,23E4246-12-PAT/56,23E424612202556PT,Leva 23E4246-12-PAT,Talla: 56,173.83,0.00
+__import__.product_template_23e4246_12_pat,23E4246-12-PAT/58,23E424612202558PT,Leva 23E4246-12-PAT,Talla: 58,173.83,0.00
+__import__.product_template_23e4246_12_pat,23E4246-12-PAT/54,23E424612202554PT,Leva 23E4246-12-PAT,Talla: 54,173.83,0.00
+__import__.product_template_23e4246_12_pat,23E4246-12-PAT/52,23E424612202552PT,Leva 23E4246-12-PAT,Talla: 52,173.83,0.00
+__import__.product_template_23e4246_12_pat,23E4246-12-PAT/50,23E424612202550PT,Leva 23E4246-12-PAT,Talla: 50,173.83,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/52,23E424604202552PT,Leva 23E4246-4-PAT,Talla: 52,173.83,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/50,23E424604202550PT,Leva 23E4246-4-PAT,Talla: 50,173.83,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/48,23E424604202548PT,Leva 23E4246-4-PAT,Talla: 48,173.83,0.00
+__import__.product_template_23e4246_12,23E4246-12/60,23E424612202560,Leva 23E4246-12,Talla: 60,165.13,0.00
+__import__.product_template_23e4246_13_pat,23E4246-13-PAT/52,23E424613202552PT,Leva 23E4246-13-PAT,Talla: 52,173.83,0.00
+__import__.product_template_23e4246_13_pat,23E4246-13-PAT/54,23E424613202554PT,Leva 23E4246-13-PAT,Talla: 54,173.83,0.00
+__import__.product_template_23e4246_12,23E4246-12/56,23E424612202556,Leva 23E4246-12,Talla: 56,165.13,0.00
+__import__.product_template_23e4246_12,23E4246-12/58,23E424612202558,Leva 23E4246-12,Talla: 58,165.13,0.00
+__import__.product_template_23e4246_12,23E4246-12/54,23E424612202554,Leva 23E4246-12,Talla: 54,165.13,0.00
+__import__.product_template_23e4246_12,23E4246-12/52,23E424612202552,Leva 23E4246-12,Talla: 52,165.13,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/46,23E424604202546PT,Leva 23E4246-4-PAT,Talla: 46,173.83,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/54,23E424604202554PT,Leva 23E4246-4-PAT,Talla: 54,173.83,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/56,23E424604202556PT,Leva 23E4246-4-PAT,Talla: 56,173.83,0.00
+__import__.product_template_23e4246_4_pat,23E4246-4-PAT/58,23E424604202558PT,Leva 23E4246-4-PAT,Talla: 58,173.83,0.00
+__import__.product_template_23e4246_12_pat,23E4246-12-PAT/46,23E424612202546PT,Leva 23E4246-12-PAT,Talla: 46,173.83,0.00
+__import__.product_template_23e4246_12_pat,23E4246-12-PAT/48,23E424612202548PT,Leva 23E4246-12-PAT,Talla: 48,173.83,0.00
+__import__.product_template_23e4246_13_pat,23E4246-13-PAT/48,23E424613202548PT,Leva 23E4246-13-PAT,Talla: 48,173.83,0.00
+__import__.product_template_23e4246_13_pat,23E4246-13-PAT/50,23E424613202550PT,Leva 23E4246-13-PAT,Talla: 50,173.83,0.00
+__import__.product_template_ve_ela_stp,VE-ELA-STP-M,VE-ELA-STP-M,VESTIDO ELA ESTAMPADO,Talla: M,198.17,0.00
+__import__.product_template_ve_ela_stp,VE-ELA-STP-L,VE-ELA-STP-L,VESTIDO ELA ESTAMPADO,Talla: L,198.17,0.00
+__import__.product_template_ve_ela_li,VE-ELA-LI-L,VE-ELA-LI-L,VESTIDO ELA LILA,Talla: L,156.43,0.00
+__import__.product_template_ve_clarisa_bge,VE-CLARISA-BGE-XL,VE-CLARISA-BGE-XL,VESTIDO CLARISA BEIGE,Talla: XL,182.52,0.00
+__import__.product_template_ve_clarisa_bge,VE-CLARISA-BGE-M,VE-CLARISA-BGE-M,VESTIDO CLARISA BEIGE,Talla: M,182.52,0.00
+__import__.product_template_ve_clarisa_bge,VE-CLARISA-BGE-L,VE-CLARISA-BGE-L,VESTIDO CLARISA BEIGE,Talla: L,182.52,0.00
+__import__.product_template_ve_micaela_pi,VE-MICAELA-PI-XL,VE-MICAELA-PI-XL,VESTIDO MICAELA PISTACHO,Talla: XL,182.52,0.00
+__import__.product_template_ve_micaela_pi,VE-MICAELA-PI-L,VE-MICAELA-PI-L,VESTIDO MICAELA PISTACHO,Talla: L,182.52,0.00
+__import__.product_template_ve_micaela_az,VE-MICAELA-AZ-XL,VE-MICAELA-AZ-XL,VESTIDO MICAELA AZUL,Talla: XL,182.52,0.00
+__import__.product_template_ve_micaela_az,VE-MICAELA-AZ-L,VE-MICAELA-AZ-L,VESTIDO MICAELA AZUL,Talla: L,182.52,0.00
+__import__.product_template_ve_micaela_az,VE-MICAELA-AZ-M,VE-MICAELA-AZ-M,VESTIDO MICAELA AZUL,Talla: M,182.52,0.00
+__import__.product_template_ve_whit_bge,VE-WHIT-BGE-XL,VE-WHIT-BGE-XL,VESTIDO WHITNEY BEIGE CIRCULOS,Talla: XL,172.09,0.00
+__import__.product_template_ve_whit_bge,VE-WHIT-BGE-L,VE-WHIT-BGE-L,VESTIDO WHITNEY BEIGE CIRCULOS,Talla: L,172.09,0.00
+__import__.product_template_ve_carson_mus,VE-CARSON-MUS-M,VE-CARSON-MUS-M,VESTIDO CARSON MUSTARD,Talla: M,156.43,0.00
+__import__.product_template_ve_carson_mus,VE-CARSON-MUS-L,VE-CARSON-MUS-L,VESTIDO CARSON MUSTARD,Talla: L,156.43,0.00
+__import__.product_template_ve_carson_vn,VE-CARSON-VN-XL,VE-CARSON-VN-XL,VESTIDO CARSON VINO,Talla: XL,156.43,0.00
+__import__.product_template_ve_carson_vn,VE-CARSON-VN-L,VE-CARSON-VN-L,VESTIDO CARSON VINO,Talla: L,156.43,0.00
+__import__.product_template_set_chris_wh,SET-CHRIS-WH-XL,SET-CHRIS-WH-XL,SET CHRISTINE WHITE,Talla: XL,166.87,0.00
+__import__.product_template_set_chris_wh,SET-CHRIS-WH-M,SET-CHRIS-WH-M,SET CHRISTINE WHITE,Talla: M,166.87,0.00
+__import__.product_template_set_chris_wh,SET-CHRIS-WH-L,SET-CHRIS-WH-L,SET CHRISTINE WHITE,Talla: L,166.87,0.00
+__import__.product_template_set_meg_ylw,SET-MEG-YLW-L,SET-MEG-YLW-L,SET MEGHAN YELLOW,Talla: L,208.61,0.00
+__import__.product_template_pt_25c29118_10,PT-25C29118-10/32,PT-25C29118-10/32,Pantalon PT-25C29118-10,Talla: 32,47.74,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/10,ZP-0907-BRW/10,Zapato ZP-0907-BRW,Talla: 10,152.09,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/9.5,ZP-0907-BRW/9.5,Zapato ZP-0907-BRW,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/9,ZP-0907-BRW/9,Zapato ZP-0907-BRW,Talla: 9,152.09,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/8.5,ZP-0907-BRW/8.5,Zapato ZP-0907-BRW,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/7.5,ZP-0907-BRW/7.5,Zapato ZP-0907-BRW,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/7,ZP-0907-BRW/7,Zapato ZP-0907-BRW,Talla: 7,152.09,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/6.5,ZP-0907-BRW/6.5,Zapato ZP-0907-BRW,Talla: 6.5,152.09,0.00
+__import__.product_template_ve_lucero_nvy,VE-LUCERO-NVY/XL,VE-LUCERO-NVY/XL,VESTIDO LUCERO NAVY,Talla: XL,138.17,0.00
+__import__.product_template_ve_lucero_nvy,VE-LUCERO-NVY/L,VE-LUCERO-NVY/L,VESTIDO LUCERO NAVY,Talla: L,138.17,0.00
+__import__.product_template_ve_katya_pk,VE-KATYA-PK/L,VE-KATYA-PK/L,VESTIDO KATYA PINK,Talla: L,133.83,0.00
+__import__.product_template_ve_katya_az,VE-KATYA-AZ/XL,VE-KATYA-AZ/XL,VESTIDO KATYA AZUL,Talla: XL,133.83,0.00
+__import__.product_template_ve_nino_bge,VE-NINO-BGE/S,VE-NINO-BGE/S,VESTIDO NINOSKA BEIGE,Talla: S,108.61,0.00
+__import__.product_template_ve_nino_bge,VE-NINO-BGE/M,VE-NINO-BGE/M,VESTIDO NINOSKA BEIGE,Talla: M,108.61,0.00
+__import__.product_template_ve_nino_bge,VE-NINO-BGE/L,VE-NINO-BGE/L,VESTIDO NINOSKA BEIGE,Talla: L,108.61,0.00
+__import__.product_template_ve_ariana_wh,VE-ARIANA-WH/M,VE-ARIANA-WH/M,VESTIDO ARIANA WHITE,Talla: M,138.17,0.00
+__import__.product_template_ve_ariana_wh,VE-ARIANA-WH/L,VE-ARIANA-WH/L,VESTIDO ARIANA WHITE,Talla: L,138.17,0.00
+__import__.product_template_bl_rive_wh,BL-RIVE-WH-/XL,BL-RIVE-WH-/XL,BLUSA RIVERA WHITE,Talla: XL,55.57,0.00
+__import__.product_template_bl_rive_wh,BL-RIVE-WH-/M,BL-RIVE-WH-/M,BLUSA RIVERA WHITE,Talla: M,55.57,0.00
+__import__.product_template_bl_rive_wh,BL-RIVE-WH-/L,BL-RIVE-WH-/L,BLUSA RIVERA WHITE,Talla: L,55.57,0.00
+__import__.product_template_bl_rive_cel,BL-RIVE-CEL-/XL,BL-RIVE-CEL-/XL,BLUSA RIVERA CELESTE,Talla: XL,55.57,0.00
+__import__.product_template_bl_rive_cel,BL-RIVE-CEL-/M,BL-RIVE-CEL-/M,BLUSA RIVERA CELESTE,Talla: M,55.57,0.00
+__import__.product_template_bl_rive_cel,BL-RIVE-CEL-/L,BL-RIVE-CEL-/L,BLUSA RIVERA CELESTE,Talla: L,55.57,0.00
+__import__.product_template_bl_vale_mok,BL-VALE-MOK-S,BL-VALE-MOK-S,BLUSA VALENTINE MOKA,Talla: S,69.48,0.00
+__import__.product_template_bl_vale_mok,BL-VALE-MOK-M,BL-VALE-MOK-M,BLUSA VALENTINE MOKA,Talla: M,69.48,0.00
+__import__.product_template_bl_vale_mok,BL-VALE-MOK-L,BL-VALE-MOK-L,BLUSA VALENTINE MOKA,Talla: L,69.48,0.00
+__import__.product_template_bl_butt_wh,BL-BUTT-WH/XL,BL-BUTT-WH/XL,BLUSA BUTTERFLY WHITE,Talla: XL,55.57,0.00
+__import__.product_template_bl_butt_wh,BL-BUTT-WH/M,BL-BUTT-WH/M,BLUSA BUTTERFLY WHITE,Talla: M,55.57,0.00
+__import__.product_template_bl_butt_wh,BL-BUTT-WH/L,BL-BUTT-WH/L,BLUSA BUTTERFLY WHITE,Talla: L,55.57,0.00
+__import__.product_template_pt_24e510097_5,PT-24E510097-5/46,PT-24E510097-5/46,Pantalon PT-24E510097-5,Talla: 46,65.13,0.00
+__import__.product_template_pt_23e312010_4,PT-23E312010-4/40,PT-23E312010-4/40,Pantalon PT-23E312010-4,Talla: 40,47.74,0.00
+__import__.product_template_pt_24c29918_20,PT-24C29918-20/38,PT-24C29918-20/38,Pantalon PT-24C29918-20,Talla: 38,47.74,0.00
+__import__.product_template_pt_23c25168_220,PT-23C25168-220/34,PT-23C25168-220/34,Pantalon PT-23C25168-220,Talla: 34,56.43,0.00
+__import__.product_template_pt_24e2712_3,PT-24E2712-3/36,PT24E27123/36,Pantalon PT-24E2712-3,Talla: 36,56.43,0.00
+__import__.product_template_25c0905_81bc_2,25C0905-81BC-2/52,2509058125095234,Terno 25C0905-81BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c29375_56bc_2,25C29375-56BC-2/46,2529375562594628,Terno 25C29375-56BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25c29375_56bc_2,25C29375-56BC-2/48,2529375562594830,Terno 25C29375-56BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25c29375_56bc_2,25C29375-56BC-2/50,2529375562595032,Terno 25C29375-56BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25c29375_56bc_2,25C29375-56BC-2/52,2529375562595234,Terno 25C29375-56BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c29375_56bc_2,25C29375-56BC-2/54,2529375562595436,Terno 25C29375-56BC-2,Talla: 54,260.78,0.00
+__import__.product_template_ch_25b231291_1,CH-25B231291-1/58,252312911C125958,Chaleco CH-25B231291-1,Talla: 58,43.39,0.00
+__import__.product_template_ch_25b231291_1,CH-25B231291-1/56,252312911C125956,Chaleco CH-25B231291-1,Talla: 56,43.39,0.00
+__import__.product_template_ch_25c0905_101,CH-25C0905-101/50,250905101C1250950,Chaleco CH-25C0905-101,Talla: 50,43.39,0.00
+__import__.product_template_25c0905_81bc_2,25C0905-81BC-2/58,2509058125095840,Terno 25C0905-81BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c29375_56bc_2,25C29375-56BC-2/56,2529375562595638,Terno 25C29375-56BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25c29375_56bc_2,25C29375-56BC-2/58,2529375562595840,Terno 25C29375-56BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c0905_101bc_2,25C0905-101BC-2/48,25090510125094830,Terno 25C0905-101BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25c0905_101bc_2,25C0905-101BC-2/50,25090510125095032,Terno 25C0905-101BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25c0905_101bc_2,25C0905-101BC-2/52,25090510125095234,Terno 25C0905-101BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c0905_101bc_2,25C0905-101BC-2/54,25090510125095436,Terno 25C0905-101BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25c0905_101bc_2,25C0905-101BC-2/56,25090510125095638,Terno 25C0905-101BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25c0905_101bc_2,25C0905-101BC-2/58,25090510125095840,Terno 25C0905-101BC-2,Talla: 58,260.78,0.00
+__import__.product_template_ch_25c0905_101,CH-25C0905-101/46,250905101C1250946,Chaleco CH-25C0905-101,Talla: 46,43.39,0.00
+__import__.product_template_ch_25c35289_93,CH-25C35289-93/48,253528993C125948,Chaleco CH-25C35289-93,Talla: 48,43.39,0.00
+__import__.product_template_ch_25c29375_56,CH-25C29375-56/58,252937556C125958,Chaleco CH-25C29375-56,Talla: 58,43.39,0.00
+__import__.product_template_ch_25c35289_93,CH-25C35289-93/46,253528993C125946,Chaleco CH-25C35289-93,Talla: 46,43.39,0.00
+__import__.product_template_ch_25c29375_56,CH-25C29375-56/54,252937556C125954,Chaleco CH-25C29375-56,Talla: 54,43.39,0.00
+__import__.product_template_ch_25c29375_56,CH-25C29375-56/52,252937556C125952,Chaleco CH-25C29375-56,Talla: 52,43.39,0.00
+__import__.product_template_ch_25c29375_56,CH-25C29375-56/56,252937556C125956,Chaleco CH-25C29375-56,Talla: 56,43.39,0.00
+__import__.product_template_25b231291_1bc_2,25B231291-1BC-2/54,2523129112595436,Terno 25B231291-1BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25b231291_1bc_2,25B231291-1BC-2/56,2523129112595638,Terno 25B231291-1BC-2,Talla: 56,260.78,0.00
+__import__.product_template_ch_25b231291_1,CH-25B231291-1/48,252312911C125948,Chaleco CH-25B231291-1,Talla: 48,43.39,0.00
+__import__.product_template_25b231291_1bc_2,25B231291-1BC-2/58,2523129112595840,Terno 25B231291-1BC-2,Talla: 58,260.78,0.00
+__import__.product_template_ch_25c35289_93,CH-25C35289-93/56,253528993C125956,Chaleco CH-25C35289-93,Talla: 56,43.39,0.00
+__import__.product_template_ch_25c35289_93,CH-25C35289-93/54,253528993C125954,Chaleco CH-25C35289-93,Talla: 54,43.39,0.00
+__import__.product_template_25c0905_81bc_2,25C0905-81BC-2/46,2509058125094628,Terno 25C0905-81BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25c0905_81bc_2,25C0905-81BC-2/48,2509058125094830,Terno 25C0905-81BC-2,Talla: 48,260.78,0.00
+__import__.product_template_ch_25c29375_56,CH-25C29375-56/50,252937556C125950,Chaleco CH-25C29375-56,Talla: 50,43.39,0.00
+__import__.product_template_ch_25c35289_93,CH-25C35289-93/52,253528993C125952,Chaleco CH-25C35289-93,Talla: 52,43.39,0.00
+__import__.product_template_ch_25c35289_93,CH-25C35289-93/50,253528993C125950,Chaleco CH-25C35289-93,Talla: 50,43.39,0.00
+__import__.product_template_ch_25c29375_56,CH-25C29375-56/48,252937556C125948,Chaleco CH-25C29375-56,Talla: 48,43.39,0.00
+__import__.product_template_ch_25c0905_101,CH-25C0905-101/52,250905101C1250952,Chaleco CH-25C0905-101,Talla: 52,43.39,0.00
+__import__.product_template_ch_25c0905_101,CH-25C0905-101/54,250905101C1250954,Chaleco CH-25C0905-101,Talla: 54,43.39,0.00
+__import__.product_template_25c0905_81bc_2,25C0905-81BC-2/50,2509058125095032,Terno 25C0905-81BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25b231291_1bc_2,25B231291-1BC-2/46,2523129112594628,Terno 25B231291-1BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25b231291_1bc_2,25B231291-1BC-2/50,2523129112595032,Terno 25B231291-1BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25c0905_101bc_2,25C0905-101BC-2/46,25090510125094628,Terno 25C0905-101BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25b231291_1bc_2,25B231291-1BC-2/52,2523129112595234,Terno 25B231291-1BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c35289_93bc_2,25C35289-93BC-2/58,2535289932595840,Terno 25C35289-93BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c0905_81bc_2,25C0905-81BC-2/56,2509058125095638,Terno 25C0905-81BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25c0905_81bc_2,25C0905-81BC-2/54,2509058125095436,Terno 25C0905-81BC-2,Talla: 54,260.78,0.00
+__import__.product_template_ch_25c35289_93,CH-25C35289-93/58,253528993C125958,Chaleco CH-25C35289-93,Talla: 58,43.39,0.00
+__import__.product_template_ch_25c0905_101,CH-25C0905-101/58,250905101C1250958,Chaleco CH-25C0905-101,Talla: 58,43.39,0.00
+__import__.product_template_25b231291_1bc_2,25B231291-1BC-2/48,2523129112594830,Terno 25B231291-1BC-2,Talla: 48,260.78,0.00
+__import__.product_template_ch_25c0905_101,CH-25C0905-101/56,250905101C1250956,Chaleco CH-25C0905-101,Talla: 56,43.39,0.00
+__import__.product_template_ch_25c29375_56,CH-25C29375-56/46,252937556C125946,Chaleco CH-25C29375-56,Talla: 46,43.39,0.00
+__import__.product_template_ch_25b231291_1,CH-25B231291-1/52,252312911C125952,Chaleco CH-25B231291-1,Talla: 52,43.39,0.00
+__import__.product_template_ch_25c0905_101,CH-25C0905-101/48,250905101C1250948,Chaleco CH-25C0905-101,Talla: 48,43.39,0.00
+__import__.product_template_ch_25b231291_1,CH-25B231291-1/46,252312911C125946,Chaleco CH-25B231291-1,Talla: 46,43.39,0.00
+__import__.product_template_ch_25b231291_1,CH-25B231291-1/50,252312911C125950,Chaleco CH-25B231291-1,Talla: 50,43.39,0.00
+__import__.product_template_ch_25b231291_1,CH-25B231291-1/54,252312911C125954,Chaleco CH-25B231291-1,Talla: 54,43.39,0.00
+__import__.product_template_25e27112_6bc_2,25E27112-6BC-2/58,2527112625095840,Terno 25E27112-6BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c35289_93bc_2,25C35289-93BC-2/46,2535289932594628,Terno 25C35289-93BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25c35289_93bc_2,25C35289-93BC-2/48,2535289932594830,Terno 25C35289-93BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25c35289_93bc_2,25C35289-93BC-2/50,2535289932595032,Terno 25C35289-93BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25c35289_93bc_2,25C35289-93BC-2/52,2535289932595234,Terno 25C35289-93BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c35289_93bc_2,25C35289-93BC-2/54,2535289932595436,Terno 25C35289-93BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25e27112_6bc_2,25E27112-6BC-2/50,2527112625095032,Terno 25E27112-6BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25e27112_6bc_2,25E27112-6BC-2/48,2527112625094830,Terno 25E27112-6BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25c35289_93bc_2,25C35289-93BC-2/56,2535289932595638,Terno 25C35289-93BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25e27112_6bc_2,25E27112-6BC-2/46,2527112625094628,Terno 25E27112-6BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25e27112_6bc_2,25E27112-6BC-2/52,2527112625095234,Terno 25E27112-6BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25e27112_6bc_2,25E27112-6BC-2/56,2527112625095638,Terno 25E27112-6BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25e27112_6bc_2,25E27112-6BC-2/54,2527112625095436,Terno 25E27112-6BC-2,Talla: 54,260.78,0.00
+__import__.product_template_sh_nap_wh_bg,SH-NAP-WH-BG/XS,SHNAPWHBG/OXS,M. SHORT P/DAMA NAPOLE BLANCO/BEIGE,Talla: XS,47.74,0.00
+__import__.product_template_sh_nap_wh_bg,SH-NAP-WH-BG/S,SHNAPWHBG/OS,M. SHORT P/DAMA NAPOLE BLANCO/BEIGE,Talla: S,47.74,0.00
+__import__.product_template_sh_nap_wh_bg,SH-NAP-WH-BG/M,SHNAPWHBG/OM,M. SHORT P/DAMA NAPOLE BLANCO/BEIGE,Talla: M,47.74,0.00
+__import__.product_template_sh_nap_wh_bg,SH-NAP-WH-BG/L,SHNAPWHBG/OL,M. SHORT P/DAMA NAPOLE BLANCO/BEIGE,Talla: L,47.74,0.00
+__import__.product_template_sh_nap_wh_az,SH-NAP-WH-AZ/XS,SHNAPWHAZ/OXS,M. SHORT P/DAMA NAPOLE BLANCO/AZUL,Talla: XS,47.74,0.00
+__import__.product_template_sh_nap_wh_az,SH-NAP-WH-AZ/S,SHNAPWHAZ/OS,M. SHORT P/DAMA NAPOLE BLANCO/AZUL,Talla: S,47.74,0.00
+__import__.product_template_sh_nap_wh_az,SH-NAP-WH-AZ/M,SHNAPWHAZ/OM,M. SHORT P/DAMA NAPOLE BLANCO/AZUL,Talla: M,47.74,0.00
+__import__.product_template_sh_nap_wh_az,SH-NAP-WH-AZ/L,SHNAPWHAZ/OL,M. SHORT P/DAMA NAPOLE BLANCO/AZUL,Talla: L,47.74,0.00
+__import__.product_template_cam_nap_ov_az,CAM-NAP-OV-AZ/S,CAMNAPOVAZ/OS,M. CAMISA P/DAMA NAPOLI OVERSIDE AZUL,Talla: S,65.13,0.00
+__import__.product_template_cam_nap_ov_az,CAM-NAP-OV-AZ/M,CAMNAPOVAZ/OM,M. CAMISA P/DAMA NAPOLI OVERSIDE AZUL,Talla: M,65.13,0.00
+__import__.product_template_cam_nap_ov_bg,CAM-NAP-OV-BG/M,CAMNAPOVBG/OM,M. CAMISA P/DAMA NAPOLI OVERSIDE BEIGE,Talla: M,65.13,0.00
+__import__.product_template_cam_nap_ov_bg,CAM-NAP-OV-BG/S,CAMNAPOVBG/OS,M. CAMISA P/DAMA NAPOLI OVERSIDE BEIGE,Talla: S,65.13,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/6,ZPCASSINIPSPTBLK/O6,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 6,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/5.5,ZPCASSINIPSPTBLK/O5.5,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 5.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/10,ZP-50224-CASSINI-VN/10,Zapato ZP-50224-CASSINI-VN,Talla: 10,152.09,0.00
+__import__.product_template_pt_25c29118_13,PT-25C29118-13/38,PT-25C29118-13/38,Pantalon PT-25C29118-13,Talla: 38,47.74,0.00
+__import__.product_template_lv_25c29118_13,LV-25C29118-13/54,LV-25C29118-13/54,Leva LV-25C29118-13,Talla: 54,173.83,0.00
+__import__.product_template_pt_25e27122_42,PT-25E27122-42/38,PT25E2712242/38,Pantalon PT-25E27122-42,Talla: 38,47.74,0.00
+__import__.product_template_pt_25e27122_42,PT-25E27122-42/36,PT25E2712242/36,Pantalon PT-25E27122-42,Talla: 36,47.74,0.00
+__import__.product_template_pt_25e27122_42,PT-25E27122-42/34,PT25E2712242/34,Pantalon PT-25E27122-42,Talla: 34,47.74,0.00
+__import__.product_template_17605dc,17605DC-14.5-S1,17605DC202591451,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17605dc,17605DC-15-S1,17605DC202591501,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17605dc,17605DC-15-S2,17605DC202591502,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17605dc,17605DC-15.5-S1,17605DC202591551,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17605dc,17605DC-15.5-S2,17605DC202591552,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17605dc,17605DC-16-S1,17605DC202591601,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17605dc,17605DC-16-S2,17605DC202591602,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17605dc,17605DC-17-S2,17605DC202591702,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17605dc,17605DC-16.5-S2,17605DC202591652,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17605dc,17605DC-17-S1,17605DC202591701,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17605dc,17605DC-16.5-S1,17605DC202591651,H. CAMISA D/P BLACK BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_18001,18001-17.5-S2,18001202591752,Camisa 18001,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_18001,18001-16.5-S1,18001202591651,Camisa 18001,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5010,5010-16.5-S1,5010202591651,Camisa 5010,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5010,5010-16.5-S2,5010202591652,Camisa 5010,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5010,5010-17-S1,5010202591701,Camisa 5010,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8020_1,8020-1/M,8020120259M01,H. CAMISA P/S BRUNO CASSINI LINO WHITE,Talla: M,104.26,0.00
+__import__.product_template_11303,11303-14.5-S1,11303202591451,Camisa 11303,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11303,11303-15-S1,11303202591501,Camisa 11303,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11303,11303-15-S2,11303202591502,Camisa 11303,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11303,11303-15.5-S1,11303202591551,Camisa 11303,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11303,11303-15.5-S2,11303202591552,Camisa 11303,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5010,5010-17.5-S2,5010202591752,Camisa 5010,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5010,5010-17-S2,5010202591702,Camisa 5010,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11303,11303-16-S1,11303202591601,Camisa 11303,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11303,11303-16-S2,11303202591602,Camisa 11303,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11303,11303-16.5-S1,11303202591651,Camisa 11303,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11303,11303-16.5-S2,11303202591652,Camisa 11303,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11303,11303-17-S1,11303202591701,Camisa 11303,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11303,11303-17-S2,11303202591702,Camisa 11303,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11303,11303-17.5-S2,11303202591752,Camisa 11303,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11304,11304-14.5-S1,11304202591451,Camisa 11304,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11304,11304-15-S1,11304202591501,Camisa 11304,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11304,11304-15-S2,11304202591502,Camisa 11304,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11304,11304-15.5-S1,11304202591551,Camisa 11304,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11304,11304-15.5-S2,11304202591552,Camisa 11304,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11304,11304-16-S1,11304202591601,Camisa 11304,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11304,11304-16-S2,11304202591602,Camisa 11304,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11304,11304-16.5-S1,11304202591651,Camisa 11304,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11304,11304-16.5-S2,11304202591652,Camisa 11304,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11304,11304-17-S1,11304202591701,Camisa 11304,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11304,11304-17-S2,11304202591702,Camisa 11304,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11304,11304-17.5-S2,11304202591752,Camisa 11304,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8020_1,8020-1/S,8020120259S01,H. CAMISA P/S BRUNO CASSINI LINO WHITE,Talla: S,104.26,0.00
+__import__.product_template_18001,18001-15-S1,18001202591501,Camisa 18001,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_18001,18001-15-S2,18001202591502,Camisa 18001,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_18001,18001-16-S1,18001202591601,Camisa 18001,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_18001,18001-16-S2,18001202591602,Camisa 18001,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_18001,18001-17-S2,18001202591702,Camisa 18001,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_18001,18001-15.5-S2,18001202591552,Camisa 18001,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_18001,18001-15.5-S1,18001202591551,Camisa 18001,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_18001,18001-17-S1,18001202591701,Camisa 18001,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_18001,18001-16.5-S2,18001202591652,Camisa 18001,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_18001,18001-14.5-S1,18001202591451,Camisa 18001,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_17604bg_dc,17604BG-DC-18.5-S1,1760425BGDC1851,H. CAMISA D/P BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 18.5, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_17604bg_dc,17604BG-DC-19-S2,1760425BGDC1902,H. CAMISA D/P BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 19, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_8020_55,8020-55/M,8020552259M01,H. CAMISA P/S BRUNO CASSINI LINO OLIVO,Talla: M,104.26,0.00
+__import__.product_template_17604bg_dc,17604BG-DC-20-S2,1760425BGDC2002,H. CAMISA D/P BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 20, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17604dc,17604DC-14.5-S1,17604DC202491451,H. CAMISA D/P DARK BLUE BRUNO CASSINI 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8020_105,8020-105/L,8020105259L01,H. CAMISA P/S BRUNO CASSINI LINO BROWN,Talla: L,104.26,0.00
+__import__.product_template_8020_105,8020-105/M,8020105259M01,H. CAMISA P/S BRUNO CASSINI LINO BROWN,Talla: M,104.26,0.00
+__import__.product_template_17604dc,17604DC-15-S2,17604DC202491502,H. CAMISA D/P DARK BLUE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8020_55,8020-55/L,8020552259L01,H. CAMISA P/S BRUNO CASSINI LINO OLIVO,Talla: L,104.26,0.00
+__import__.product_template_17601bg_dc,17601BG-DC-18-S1,1760125BGDC1801,H. CAMISA D/P BIG SIZE BRUNO CASSINI WHITE 32-33,"Talla: 18, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_17601bg_dc,17601BG-DC-18-S2,1760125BGDC1802,H. CAMISA D/P BIG SIZE BRUNO CASSINI WHITE 32-33,"Talla: 18, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17601bg_dc,17601BG-DC-18.5-S1,1760125BGDC1851,H. CAMISA D/P BIG SIZE BRUNO CASSINI WHITE 32-33,"Talla: 18.5, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_17604bg,17604BG-19-S1,176042022011901,H. CAMISA P/S BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 19, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17604bg,17604BG-19-S2,176042022011902,H. CAMISA P/S BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 19, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_8020_3,8020-3/XXL,8020320259XXL1,H. CAMISA P/S BRUNO CASSINI LINO BLACK,Talla: XXL,104.26,0.00
+__import__.product_template_17604bg,17604BG-18-S2,176042022011802,H. CAMISA P/S BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 18, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601bg_dc,17601BG-DC-20-S2,1760125BGDC2002,H. CAMISA D/P BIG SIZE BRUNO CASSINI WHITE 32-33,"Talla: 20, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_8020_3,8020-3/XL,8020320259XL1,H. CAMISA P/S BRUNO CASSINI LINO BLACK,Talla: XL,104.26,0.00
+__import__.product_template_8020_3,8020-3/S,8020320259S01,H. CAMISA P/S BRUNO CASSINI LINO BLACK,Talla: S,104.26,0.00
+__import__.product_template_8020_4,8020-4/M,8020420259M01,H. CAMISA P/S BRUNO CASSINI LINO NAVY,Talla: M,104.26,0.00
+__import__.product_template_8020_3,8020-3/M,8020320259M01,H. CAMISA P/S BRUNO CASSINI LINO BLACK,Talla: M,104.26,0.00
+__import__.product_template_17601bg_dc,17601BG-DC-19-S2,1760125BGDC1902,H. CAMISA D/P BIG SIZE BRUNO CASSINI WHITE 32-33,"Talla: 19, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_8020_55,8020-55/XL,8020552259XL1,H. CAMISA P/S BRUNO CASSINI LINO OLIVO,Talla: XL,104.26,0.00
+__import__.product_template_8020_1,8020-1/L,8020120259L01,H. CAMISA P/S BRUNO CASSINI LINO WHITE,Talla: L,104.26,0.00
+__import__.product_template_8020_4,8020-4/L,8020420259L01,H. CAMISA P/S BRUNO CASSINI LINO NAVY,Talla: L,104.26,0.00
+__import__.product_template_17601bg_dc,17601BG-DC-18.5-S2,1760125BGDC1852,H. CAMISA D/P BIG SIZE BRUNO CASSINI WHITE 32-33,"Talla: 18.5, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_8020_55,8020-55/S,8020552259S01,H. CAMISA P/S BRUNO CASSINI LINO OLIVO,Talla: S,104.26,0.00
+__import__.product_template_8020_4,8020-4/XXL,8020420259XXL1,H. CAMISA P/S BRUNO CASSINI LINO NAVY,Talla: XXL,104.26,0.00
+__import__.product_template_8020_4,8020-4/S,8020420259S01,H. CAMISA P/S BRUNO CASSINI LINO NAVY,Talla: S,104.26,0.00
+__import__.product_template_17604dc,17604DC-15-S1,17604DC202491501,H. CAMISA D/P DARK BLUE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17604bg_dc,17604BG-DC-19.5-S2,1760425BGDC1952,H. CAMISA D/P BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 19.5, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17604bg_dc,17604BG-DC-19-S1,1760425BGDC1901,H. CAMISA D/P BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 19, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_17604bg_dc,17604BG-DC-18.5-S2,1760425BGDC1852,H. CAMISA D/P BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 18.5, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17604bg_dc,17604BG-DC-18-S1,1760425BGDC1801,H. CAMISA D/P BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 18, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_17604bg,17604BG-19.5-S2,176042022011952,H. CAMISA P/S BIG SIZE BRUNO CASSINI DARK BLUE 32-33,"Talla: 19.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17604dc,17604DC-15.5-S1,17604DC202491551,H. CAMISA D/P DARK BLUE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17604dc,17604DC-16-S1,17604DC202491601,H. CAMISA D/P DARK BLUE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17604dc,17604DC-16.5-S2,17604DC202491652,H. CAMISA D/P DARK BLUE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17604dc,17604DC-17-S2,17604DC202491702,H. CAMISA D/P DARK BLUE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-20-S2,1760525BGDC2002,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 20, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-19-S2,1760525BGDC1902,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 19, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-19.5-S2,1760525BGDC1952,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 19.5, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-19-S1,1760525BGDC1901,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 19, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-18.5-S2,1760525BGDC1852,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 18.5, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-18-S2,1760525BGDC1802,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 18, Manga de Camisa: S2 - 34/35",91.22,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-18.5-S1,1760525BGDC1851,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 18.5, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_17605bg_dc,17605BG-DC-18-S1,1760525BGDC1801,H. CAMISA D/P BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 18, Manga de Camisa: S1 - 32/33",91.22,0.00
+__import__.product_template_ht8811_2,HT8811-2-15-S2,HT88112202591502,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-15-S1,HT88112202591501,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-14.5-S1,HT88112202591451,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1739_5,HT1739-5-17.5-S2,HT17395202591752,H. CAMISA P/S STRIPE BLUE BRUNO CASSINI 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1739_5,HT1739-5-17-S2,HT17395202591702,H. CAMISA P/S STRIPE BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1739_5,HT1739-5-17-S1,HT17395202591701,H. CAMISA P/S STRIPE BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1739_5,HT1739-5-16.5-S2,HT17395202591652,H. CAMISA P/S STRIPE BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-17-S1,HT88112202591701,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-16.5-S2,HT88112202591652,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-16.5-S1,HT88112202591651,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-16-S2,HT88112202591602,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-16-S1,HT88112202591601,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-15.5-S2,HT88112202591552,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-15.5-S1,HT88112202591551,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1739_5,HT1739-5-16.5-S1,HT17395202591651,H. CAMISA P/S STRIPE BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-17-S2,HT88112202591702,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_2,HT8811-2-17.5-S2,HT88112202591752,H. CAMISA P/S ROSE BRUNO CASSINI 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-16.5-S2,HT1965202591652,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-16.5-S1,HT1965202591651,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-16-S1,HT1965202591601,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-16-S2,HT1965202591602,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-17-S1,HT1965202591701,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-17.5-S2,HT1965202591752,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-14.5-S1,HT20813202591451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-15.5-S2,HT1965202591552,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-15-S1,HT20813202591501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5010,5010-15-S1,5010202591501,Camisa 5010,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5010,5010-15-S2,5010202591502,Camisa 5010,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-17-S2,HT1965202591702,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-16-S1,HT20813202591601,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5011,5011-16-S2,5011202591602,Camisa 5011,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-15.5-S1,HT20813202591551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5011,5011-17-S1,5011202591701,Camisa 5011,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-15-S2,HT20813202591502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5011,5011-16.5-S1,5011202591651,Camisa 5011,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_4,HT1840-4-14.5-S1,HT18404202591451,H. CAMISA P/S BLUE BRUNO CASSINI 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-15-S1,HT1965202591501,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11704,11704-17.5-S2,11704202591752,Camisa 11704,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11704,11704-17-S2,11704202591702,Camisa 11704,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11704,11704-17-S1,11704202591701,Camisa 11704,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11704,11704-16.5-S2,11704202591652,Camisa 11704,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11704,11704-16.5-S1,11704202591651,Camisa 11704,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11704,11704-16-S2,11704202591602,Camisa 11704,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11704,11704-16-S1,11704202591601,Camisa 11704,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11704,11704-15.5-S2,11704202591552,Camisa 11704,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11704,11704-15.5-S1,11704202591551,Camisa 11704,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11704,11704-15-S2,11704202591502,Camisa 11704,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_11704,11704-15-S1,11704202591501,Camisa 11704,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_11704,11704-14.5-S1,11704202591451,Camisa 11704,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-15-S2,HT20823202591502,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-15-S1,HT20823202591501,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-14.5-S1,HT20823202591451,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-17.5-S2,HT20813202591752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-17-S2,HT20813202591702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-17-S1,HT20813202591701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-16.5-S2,HT20813202591652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-16.5-S1,HT20813202591651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-16-S2,HT20813202591602,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-15.5-S1,HT20823202591551,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-17-S2,HT2101812591702,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-17.5-S2,HT2101812591752,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5011,5011-17.5-S2,5011202591752,Camisa 5011,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-17-S1,HT2101812591701,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5010,5010-15.5-S2,5010202591552,Camisa 5010,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5011,5011-14.5-S1,5011202591451,Camisa 5011,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5011,5011-17-S2,5011202591702,Camisa 5011,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5011,5011-15-S1,5011202591501,Camisa 5011,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5011,5011-16.5-S2,5011202591652,Camisa 5011,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_1509,1509-16-S1,1509202591601,Camisa 1509,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_1509,1509-15.5-S2,1509202591552,Camisa 1509,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_1509,1509-15.5-S1,1509202591551,Camisa 1509,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_1509,1509-15-S2,1509202591502,Camisa 1509,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_1509,1509-15-S1,1509202591501,Camisa 1509,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_1509,1509-14.5-S1,1509202591451,Camisa 1509,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_1509,1509-16-S2,1509202591602,Camisa 1509,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_1509,1509-16.5-S1,1509202591651,Camisa 1509,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_1509,1509-16.5-S2,1509202591652,Camisa 1509,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_1509,1509-17-S1,1509202591701,Camisa 1509,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_1509,1509-17-S2,1509202591702,Camisa 1509,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_1509,1509-17.5-S2,1509202591752,Camisa 1509,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_4,HT1840-4-17-S2,HT18404202591702,H. CAMISA P/S BLUE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5010,5010-15.5-S1,5010202591551,Camisa 5010,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_3,HT8811-3-16-S1,HT88113202591601,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (ht8811_3),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_4,HT1840-4-17-S1,HT18404202591701,H. CAMISA P/S BLUE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5011,5011-15-S2,5011202591502,Camisa 5011,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5010,5010-16-S2,5010202591602,Camisa 5010,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5010,5010-16-S1,5010202591601,Camisa 5010,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-16.5-S2,HT20823202591652,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-17-S1,HT20823202591701,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-17-S2,HT20823202591702,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-17.5-S2,HT20823202591752,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-15.5-S1,HT1965202591551,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1965_2,HT1965-2-15-S2,HT1965202591502,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-16.5-S1,HT20823202591651,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2081_3,HT2081-3-15.5-S2,HT20813202591552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-16-S1,HT20823202591601,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_3,HT8811-3-15-S1,HT88113202591501,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (ht8811_3),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2082_3,HT2082-3-16-S2,HT20823202591602,H. CAMISA P/S SQUARE BLUE BRUNO CASSINI 34-35 (ht2082_3),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_3,HT8811-3-15-S2,HT88113202591502,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (ht8811_3),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-16-S1,HT2231125091601,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-16.5-S1,HT88111202591651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-17.5-S2,HT88111202591752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-17-S1,HT18401202591701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-14.5-S1,HT18401202591451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-15-S2,HT18402202591502,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-15-S2,HT18401202591502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-16-S2,HT18401202591602,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-14.5-S1,HT2231725091451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-15.5-S1,HT2231725091551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-16-S2,HT2231125091602,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-14.5-S1,HT2231125091451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-15-S2,HT2231725091502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-15-S1,HT2231725091501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-16-S1,HT18402202591601,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-16.5-S2,HT18402202591652,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-16.5-S1,HT18402202591651,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-16-S2,HT18402202591602,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-15.5-S2,HT2231725091552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-15.5-S1,HT18401202591551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-16.5-S1,HT2231725091651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-15-S1,HT88111202591501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-16-S2,HT88111202591602,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-16.5-S2,HT88111202591652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-17-S1,HT88111202591701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-17-S2,HT88111202591702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-16-S1,HT88111202591601,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-15.5-S2,HT88111202591552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-15.5-S1,HT88111202591551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-14.5-S1,HT2101812591451,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-15-S1,HT2101812591501,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-15-S2,HT2101812591502,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-15.5-S1,HT2101812591551,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-16.5-S1,HT2101812591651,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-16-S2,HT2101812591602,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-17.5-S2,HT2231125091752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-16.5-S2,HT2231125091652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-15-S1,HT18401202591501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-16-S1,HT18401202591601,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-15.5-S2,HT2231125091552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-16.5-S2,HT2101812591652,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-16.5-S1,HT2231125091651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-17-S2,HT2231125091702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-17-S1,HT2231125091701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-15.5-S2,HT2101812591552,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2102_81,HT2102-81-16-S1,HT2101812591601,H. CAMISA P/S WHITE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-14.5-S1,HT88111202591451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-17.5-S2,HT2231725091752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-17-S2,HT2231725091702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht8811_1,HT8811-1-15-S2,HT88111202591502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht8811_1),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-17-S1,HT2231725091701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-15-S1,HT2231125091501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-16.5-S2,HT18401202591652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-16.5-S1,HT18401202591651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-15.5-S2,HT18401202591552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-14.5-S1,HT18402202591451,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-15.5-S2,HT18402202591552,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-15-S1,HT18402202591501,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-15.5-S1,HT18402202591551,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-17-S2,HT18401202591702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-16.5-S2,HT2231725091652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-15-S2,HT2231125091502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-17-S1,HT18402202591701,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-17.5-S2,HT18402202591752,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_2,HT1840-2-17-S2,HT18402202591702,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (ht1840_2),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht1840_1,HT1840-1-17.5-S2,HT18401202591752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht1840_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_1,HT2231-1-15.5-S1,HT2231125091551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_1),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-16-S2,HT2231725091602,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_ht2231_7,HT2231-7-16-S1,HT2231725091601,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (ht2231_7),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_c008_black_2_bc_2,C008-BLACK-2-BC-2/58,C008B22022065840,Terno C008-BLACK-2-BC-2,Talla: 58,304.26,0.00
+__import__.product_template_c24es296_4_bc_2,C24ES296-4-BC-2/54,C24ES296424095436,Terno C24ES296-4-BC-2,Talla: 54,304.26,0.00
+__import__.product_template_c24es296_4_bc_2,C24ES296-4-BC-2/52,C24ES296424095234,Terno C24ES296-4-BC-2,Talla: 52,304.26,0.00
+__import__.product_template_c24es296_4_bc_2,C24ES296-4-BC-2/58,C24ES296424095840,Terno C24ES296-4-BC-2,Talla: 58,304.26,0.00
+__import__.product_template_c008_black_2_bc_2,C008-BLACK-2-BC-2/52,C008B22022065234,Terno C008-BLACK-2-BC-2,Talla: 52,304.26,0.00
+__import__.product_template_c008_black_2_bc_2,C008-BLACK-2-BC-2/54,C008B22022065436,Terno C008-BLACK-2-BC-2,Talla: 54,304.26,0.00
+__import__.product_template_c008_black_2_bc_2,C008-BLACK-2-BC-2/56,C008B22022065638,Terno C008-BLACK-2-BC-2,Talla: 56,304.26,0.00
+__import__.product_template_c24es296_4_bc_2,C24ES296-4-BC-2/56,C24ES296424095638,Terno C24ES296-4-BC-2,Talla: 56,304.26,0.00
+__import__.product_template_c008_black_2_bc_2,C008-BLACK-2-BC-2/48,C008B22022064830,Terno C008-BLACK-2-BC-2,Talla: 48,304.26,0.00
+__import__.product_template_c008_black_2_bc_2,C008-BLACK-2-BC-2/50,C008B22022065032,Terno C008-BLACK-2-BC-2,Talla: 50,304.26,0.00
+__import__.product_template_c008_black_2_bc_2,C008-BLACK-2-BC-2/46,C008B22022064628,Terno C008-BLACK-2-BC-2,Talla: 46,304.26,0.00
+__import__.product_template_c24es296_4_bc_2,C24ES296-4-BC-2/46,C24ES296424094628,Terno C24ES296-4-BC-2,Talla: 46,304.26,0.00
+__import__.product_template_c24es296_4_bc_2,C24ES296-4-BC-2/48,C24ES296424094830,Terno C24ES296-4-BC-2,Talla: 48,304.26,0.00
+__import__.product_template_c25b231291_24bc_2,C25B231291-24BC-2/52,C25231291242595234,Terno C25B231291-24BC-2,Talla: 52,304.26,0.00
+__import__.product_template_c25b231291_24bc_2,C25B231291-24BC-2/58,C25231291242595840,Terno C25B231291-24BC-2,Talla: 58,304.26,0.00
+__import__.product_template_c25b231291_24bc_2,C25B231291-24BC-2/56,C25231291242595638,Terno C25B231291-24BC-2,Talla: 56,304.26,0.00
+__import__.product_template_c25b231291_24bc_2,C25B231291-24BC-2/50,C25231291242595032,Terno C25B231291-24BC-2,Talla: 50,304.26,0.00
+__import__.product_template_c25b231291_24bc_2,C25B231291-24BC-2/54,C25231291242595436,Terno C25B231291-24BC-2,Talla: 54,304.26,0.00
+__import__.product_template_c25c29118_13bc_2,C25C29118-13BC-2/50,C2529118132595032,Terno C25C29118-13BC-2,Talla: 50,304.26,0.00
+__import__.product_template_c25c29118_13bc_2,C25C29118-13BC-2/48,C2529118132594830,Terno C25C29118-13BC-2,Talla: 48,304.26,0.00
+__import__.product_template_c25c29118_13bc_2,C25C29118-13BC-2/46,C2529118132594628,Terno C25C29118-13BC-2,Talla: 46,304.26,0.00
+__import__.product_template_c25c0905_25bc_2,C25C0905-25BC-2/58,C250905252595840,Terno C25C0905-25BC-2,Talla: 58,304.26,0.00
+__import__.product_template_c25c29118_13bc_2,C25C29118-13BC-2/56,C2529118132595638,Terno C25C29118-13BC-2,Talla: 56,304.26,0.00
+__import__.product_template_c25c29118_13bc_2,C25C29118-13BC-2/54,C2529118132595436,Terno C25C29118-13BC-2,Talla: 54,304.26,0.00
+__import__.product_template_c25c29118_13bc_2,C25C29118-13BC-2/58,C2529118132595840,Terno C25C29118-13BC-2,Talla: 58,304.26,0.00
+__import__.product_template_c25c0905_11bc_2,C25C0905-11BC-2/48,C2509051125094830,Terno C25C0905-11BC-2,Talla: 48,304.26,0.00
+__import__.product_template_c25c0905_11bc_2,C25C0905-11BC-2/46,C2509051125094628,Terno C25C0905-11BC-2,Talla: 46,304.26,0.00
+__import__.product_template_c25c0905_25bc_2,C25C0905-25BC-2/56,C250905252595638,Terno C25C0905-25BC-2,Talla: 56,304.26,0.00
+__import__.product_template_c25c0905_25bc_2,C25C0905-25BC-2/46,C250905252594628,Terno C25C0905-25BC-2,Talla: 46,304.26,0.00
+__import__.product_template_c25c0905_11bc_2,C25C0905-11BC-2/54,C2509051125095436,Terno C25C0905-11BC-2,Talla: 54,304.26,0.00
+__import__.product_template_c25c0905_11bc_2,C25C0905-11BC-2/56,C2509051125095638,Terno C25C0905-11BC-2,Talla: 56,304.26,0.00
+__import__.product_template_c25c0905_11bc_2,C25C0905-11BC-2/58,C2509051125095840,Terno C25C0905-11BC-2,Talla: 58,304.26,0.00
+__import__.product_template_c25c0905_11bc_2,C25C0905-11BC-2/52,C2509051125095234,Terno C25C0905-11BC-2,Talla: 52,304.26,0.00
+__import__.product_template_c25c0905_11bc_2,C25C0905-11BC-2/50,C2509051125095032,Terno C25C0905-11BC-2,Talla: 50,304.26,0.00
+__import__.product_template_c25c29118_13bc_2,C25C29118-13BC-2/52,C2529118132595234,Terno C25C29118-13BC-2,Talla: 52,304.26,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/31,008B120220631,Pantalon PT-008-BLACK,Talla: 31,56.43,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/33,008B120220633,Pantalon PT-008-BLACK,Talla: 33,56.43,0.00
+__import__.product_template_25c29118_10bc_2,25C29118-10BC-2/46,25291181025094628,Terno 25C29118-10BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25b231291_24bc_2,25B231291-24BC-2/56,25231291242595638,Terno 25B231291-24BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25b231291_24bc_2,25B231291-24BC-2/54,25231291242595436,Terno 25B231291-24BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25b231291_24bc_2,25B231291-24BC-2/52,25231291242595234,Terno 25B231291-24BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c0905_11bc_2,25C0905-11BC-2/48,2509051125094830,Terno 25C0905-11BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25b231291_24bc_2,25B231291-24BC-2/50,25231291242595032,Terno 25B231291-24BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25b231291_24bc_2,25B231291-24BC-2/48,25231291242594830,Terno 25B231291-24BC-2,Talla: 48,260.78,0.00
+__import__.product_template_ch_25c0905_25,CH-25C0905-25/46,25090525C125946,Chaleco CH-25C0905-25,Talla: 46,43.39,0.00
+__import__.product_template_pt_008_3,PT-008-3/38,008B320250638,Pantalon PT-008-3,Talla: 38,56.43,0.00
+__import__.product_template_008_14bc_2,008-14BC-2/46,008B14202594628,Terno 008-14BC-2,Talla: 46,304.26,0.00
+__import__.product_template_008_14bc_2,008-14BC-2/48,008B14202594830,Terno 008-14BC-2,Talla: 48,304.26,0.00
+__import__.product_template_008_14bc_2,008-14BC-2/50,008B14202595032,Terno 008-14BC-2,Talla: 50,304.26,0.00
+__import__.product_template_008_14bc_2,008-14BC-2/52,008B14202595234,Terno 008-14BC-2,Talla: 52,304.26,0.00
+__import__.product_template_008_14bc_2,008-14BC-2/54,008B14202595436,Terno 008-14BC-2,Talla: 54,304.26,0.00
+__import__.product_template_008_14bc_2,008-14BC-2/56,008B14202595638,Terno 008-14BC-2,Talla: 56,304.26,0.00
+__import__.product_template_008_14bc_2,008-14BC-2/58,008B14202595840,Terno 008-14BC-2,Talla: 58,304.26,0.00
+__import__.product_template_008_3bc_1,008-3BC-1/46,008B32025094628,Terno 008-3BC-1,Talla: 46,304.26,0.00
+__import__.product_template_008_3bc_1,008-3BC-1/48,008B32025094850,Terno 008-3BC-1,Talla: 48,304.26,0.00
+__import__.product_template_008_3bc_1,008-3BC-1/50,008B32025095032,Terno 008-3BC-1,Talla: 50,304.26,0.00
+__import__.product_template_008_3bc_1,008-3BC-1/52,008B32025095234,Terno 008-3BC-1,Talla: 52,304.26,0.00
+__import__.product_template_008_3bc_1,008-3BC-1/54,008B32025095436,Terno 008-3BC-1,Talla: 54,304.26,0.00
+__import__.product_template_008_3bc_1,008-3BC-1/56,008B32025095638,Terno 008-3BC-1,Talla: 56,304.26,0.00
+__import__.product_template_008_3bc_1,008-3BC-1/58,008B32025095840,Terno 008-3BC-1,Talla: 58,304.26,0.00
+__import__.product_template_25c29118_10bc_2,25C29118-10BC-2/58,25291181025095840,Terno 25C29118-10BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c29118_10bc_2,25C29118-10BC-2/56,25291181025095638,Terno 25C29118-10BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25c29118_10bc_2,25C29118-10BC-2/54,25291181025095436,Terno 25C29118-10BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25c29118_10bc_2,25C29118-10BC-2/52,25291181025095234,Terno 25C29118-10BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c29118_10bc_2,25C29118-10BC-2/50,25291181025095032,Terno 25C29118-10BC-2,Talla: 50,260.78,0.00
+__import__.product_template_pt_008_3,PT-008-3/32,008B320250632,Pantalon PT-008-3,Talla: 32,56.43,0.00
+__import__.product_template_pt_008_3,PT-008-3/33,008B320250633,Pantalon PT-008-3,Talla: 33,56.43,0.00
+__import__.product_template_pt_008_3,PT-008-3/34,008B320250634,Pantalon PT-008-3,Talla: 34,56.43,0.00
+__import__.product_template_pt_008_3,PT-008-3/36,008B320250636,Pantalon PT-008-3,Talla: 36,56.43,0.00
+__import__.product_template_24b3931_1bc_2,24B3931-1BC-2/56,243931125095638,Terno 24B3931-1BC-2,Talla: 56,260.78,0.00
+__import__.product_template_24b3931_1bc_2,24B3931-1BC-2/58,243931125095840,Terno 24B3931-1BC-2,Talla: 58,260.78,0.00
+__import__.product_template_24b3931_1bc_2,24B3931-1BC-2/54,243931125095436,Terno 24B3931-1BC-2,Talla: 54,260.78,0.00
+__import__.product_template_24b3931_1bc_2,24B3931-1BC-2/52,243931125095234,Terno 24B3931-1BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25b231291_24bc_2,25B231291-24BC-2/46,25231291242594628,Terno 25B231291-24BC-2,Talla: 46,260.78,0.00
+__import__.product_template_pt_008_14,PT-008-14/36,008B142025936,Pantalon PT-008-14,Talla: 36,56.43,0.00
+__import__.product_template_ch_25c29118_13,CH-25C29118-13/46,252911813C125946,Chaleco CH-25C29118-13,Talla: 46,43.39,0.00
+__import__.product_template_25e27122_42bc_2,25E27122-42BC-2/54,25271224225095436,Terno 25E27122-42BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25e27122_42bc_2,25E27122-42BC-2/52,25271224225095234,Terno 25E27122-42BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25e27122_42bc_2,25E27122-42BC-2/50,25271224225095032,Terno 25E27122-42BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25e27122_42bc_2,25E27122-42BC-2/48,25271224225094830,Terno 25E27122-42BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25e27122_42bc_2,25E27122-42BC-2/46,25271224225094628,Terno 25E27122-42BC-2,Talla: 46,260.78,0.00
+__import__.product_template_ch_25c29118_13,CH-25C29118-13/48,252911813C125948,Chaleco CH-25C29118-13,Talla: 48,43.39,0.00
+__import__.product_template_25c0905_11bc_2,25C0905-11BC-2/50,2509051125095032,Terno 25C0905-11BC-2,Talla: 50,260.78,0.00
+__import__.product_template_ch_25c29118_13,CH-25C29118-13/58,252911813C125958,Chaleco CH-25C29118-13,Talla: 58,43.39,0.00
+__import__.product_template_25b231291_24bc_2,25B231291-24BC-2/58,25231291242595840,Terno 25B231291-24BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c0905_11bc_2,25C0905-11BC-2/46,2509051125094628,Terno 25C0905-11BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25c29118_10bc_2,25C29118-10BC-2/48,25291181025094830,Terno 25C29118-10BC-2,Talla: 48,260.78,0.00
+__import__.product_template_ch_25c0905_25,CH-25C0905-25/54,25090525C125954,Chaleco CH-25C0905-25,Talla: 54,43.39,0.00
+__import__.product_template_ch_25c0905_25,CH-25C0905-25/52,25090525C125952,Chaleco CH-25C0905-25,Talla: 52,43.39,0.00
+__import__.product_template_ch_25c0905_25,CH-25C0905-25/50,25090525C125950,Chaleco CH-25C0905-25,Talla: 50,43.39,0.00
+__import__.product_template_pt_008_14,PT-008-14/31,008B142025931,Pantalon PT-008-14,Talla: 31,56.43,0.00
+__import__.product_template_pt_008_14,PT-008-14/30,008B142025930,Pantalon PT-008-14,Talla: 30,56.43,0.00
+__import__.product_template_pt_008_14,PT-008-14/33,008B142025933,Pantalon PT-008-14,Talla: 33,56.43,0.00
+__import__.product_template_pt_008_14,PT-008-14/32,008B142025932,Pantalon PT-008-14,Talla: 32,56.43,0.00
+__import__.product_template_ch_25c29118_13,CH-25C29118-13/50,252911813C125950,Chaleco CH-25C29118-13,Talla: 50,43.39,0.00
+__import__.product_template_ch_25c29118_13,CH-25C29118-13/52,252911813C125952,Chaleco CH-25C29118-13,Talla: 52,43.39,0.00
+__import__.product_template_ch_25c29118_13,CH-25C29118-13/54,252911813C125954,Chaleco CH-25C29118-13,Talla: 54,43.39,0.00
+__import__.product_template_ch_25c29118_13,CH-25C29118-13/56,252911813C125956,Chaleco CH-25C29118-13,Talla: 56,43.39,0.00
+__import__.product_template_pt_008_14,PT-008-14/40,008B142025940,Pantalon PT-008-14,Talla: 40,56.43,0.00
+__import__.product_template_pt_008_14,PT-008-14/38,008B142025938,Pantalon PT-008-14,Talla: 38,56.43,0.00
+__import__.product_template_pt_008_14,PT-008-14/34,008B142025934,Pantalon PT-008-14,Talla: 34,56.43,0.00
+__import__.product_template_25c0905_11bc_2,25C0905-11BC-2/54,2509051125095436,Terno 25C0905-11BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25c0905_11bc_2,25C0905-11BC-2/58,2509051125095840,Terno 25C0905-11BC-2,Talla: 58,260.78,0.00
+__import__.product_template_pt_008_3,PT-008-3/31,008B320250631,Pantalon PT-008-3,Talla: 31,56.43,0.00
+__import__.product_template_pt_008_3,PT-008-3/30,008B320250630,Pantalon PT-008-3,Talla: 30,56.43,0.00
+__import__.product_template_25c0905_11bc_2,25C0905-11BC-2/52,2509051125095234,Terno 25C0905-11BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c0905_11bc_2,25C0905-11BC-2/56,2509051125095638,Terno 25C0905-11BC-2,Talla: 56,260.78,0.00
+__import__.product_template_pt_008_3,PT-008-3/40,008B320250640,Pantalon PT-008-3,Talla: 40,56.43,0.00
+__import__.product_template_25e27122_42bc_2,25E27122-42BC-2/56,25271224225095638,Terno 25E27122-42BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25e27122_42bc_2,25E27122-42BC-2/58,25271224225095840,Terno 25E27122-42BC-2,Talla: 58,260.78,0.00
+__import__.product_template_ch_25c0905_25,CH-25C0905-25/48,25090525C125948,Chaleco CH-25C0905-25,Talla: 48,43.39,0.00
+__import__.product_template_ch_24es296_4,CH-24ES296-4/50,24ES2964C1240950,Chaleco CH-24ES296-4,Talla: 50,43.39,0.00
+__import__.product_template_24b3931_1bc_2,24B3931-1BC-2/48,243931125094830,Terno 24B3931-1BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25c29118_13bc_2,25C29118-13BC-2/52,2529118132595234,Terno 25C29118-13BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c29118_13bc_2,25C29118-13BC-2/50,2529118132595032,Terno 25C29118-13BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25c29118_13bc_2,25C29118-13BC-2/48,2529118132594830,Terno 25C29118-13BC-2,Talla: 48,260.78,0.00
+__import__.product_template_24b3931_1bc_2,24B3931-1BC-2/50,243931125095032,Terno 24B3931-1BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25c29118_13bc_2,25C29118-13BC-2/46,2529118132594628,Terno 25C29118-13BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25c0905_25bc_2,25C0905-25BC-2/52,250905252595234,Terno 25C0905-25BC-2,Talla: 52,260.78,0.00
+__import__.product_template_25c0905_25bc_2,25C0905-25BC-2/50,250905252595032,Terno 25C0905-25BC-2,Talla: 50,260.78,0.00
+__import__.product_template_25c0905_25bc_2,25C0905-25BC-2/48,250905252594830,Terno 25C0905-25BC-2,Talla: 48,260.78,0.00
+__import__.product_template_25c0905_25bc_2,25C0905-25BC-2/46,250905252594628,Terno 25C0905-25BC-2,Talla: 46,260.78,0.00
+__import__.product_template_24b3931_1bc_2,24B3931-1BC-2/46,243931125094628,Terno 24B3931-1BC-2,Talla: 46,260.78,0.00
+__import__.product_template_25c0905_25bc_2,25C0905-25BC-2/58,250905252595840,Terno 25C0905-25BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c0905_25bc_2,25C0905-25BC-2/56,250905252595638,Terno 25C0905-25BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25c0905_25bc_2,25C0905-25BC-2/54,250905252595436,Terno 25C0905-25BC-2,Talla: 54,260.78,0.00
+__import__.product_template_25c29118_13bc_2,25C29118-13BC-2/58,2529118132595840,Terno 25C29118-13BC-2,Talla: 58,260.78,0.00
+__import__.product_template_25c29118_13bc_2,25C29118-13BC-2/56,2529118132595638,Terno 25C29118-13BC-2,Talla: 56,260.78,0.00
+__import__.product_template_25c29118_13bc_2,25C29118-13BC-2/54,2529118132595436,Terno 25C29118-13BC-2,Talla: 54,260.78,0.00
+__import__.product_template_pt_24c28061_76,PT-24C28061-76/30,PT24C2806176/30,Pantalon PT-24C28061-76,Talla: 30,47.74,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/6.5,ZPCASSPSPTBRW/6.5,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 6.5,152.09,0.00
+__import__.product_template_pt_24c28061_76,PT-24C28061-76/32,PT24C2806176/32,Pantalon PT-24C28061-76,Talla: 32,47.74,0.00
+__import__.product_template_lv_24b11210_100,LV-24B11210-100/50,LV24B11210100/50,Leva LV-24B11210-100,Talla: 50,173.83,0.00
+__import__.product_template_cha_milano_blanco,CHA-MILANO BLANCO-L,CHA-MILANO BLANCO-L,CHALECO MILANO BLANCO,Talla: L,52.09,0.00
+__import__.product_template_bl_str_grn,BL-STR-GRN-S,BL-STR-GRN-S,T SHIRT STRETCH GREEN MINT,Talla: S,23.39,0.00
+__import__.product_template_bl_str_grn,BL-STR-GRN-L,BL-STR-GRN-L,T SHIRT STRETCH GREEN MINT,Talla: L,23.39,0.00
+__import__.product_template_bsut_str_az,BSUT-STR-AZ-S,BSUT-STR-AZ-S,BODYSUITE STRETCH AZUL,Talla: S,23.39,0.00
+__import__.product_template_bsut_str_az,BSUT-STR-AZ-L,BSUT-STR-AZ-L,BODYSUITE STRETCH AZUL,Talla: L,23.39,0.00
+__import__.product_template_bsut_str_wh,BSUT-STR-WH-S,BSUT-STR-WH-S,BODYSUITE STRETCH WHITE,Talla: S,23.39,0.00
+__import__.product_template_bsut_str_wh,BSUT-STR-WH-M,BSUT-STR-WH-M,BODYSUITE STRETCH WHITE,Talla: M,23.39,0.00
+__import__.product_template_bsut_str_vn,BSUT-STR-VN-XS,BSUT-STR-VN-XS,BODYSUITE STRETCH VINO,Talla: XS,23.39,0.00
+__import__.product_template_bsut_str_vn,BSUT-STR-VN-S,BSUT-STR-VN-S,BODYSUITE STRETCH VINO,Talla: S,23.39,0.00
+__import__.product_template_bsut_str_vn,BSUT-STR-VN-M,BSUT-STR-VN-M,BODYSUITE STRETCH VINO,Talla: M,23.39,0.00
+__import__.product_template_bsut_str_vn,BSUT-STR-VN-L,BSUT-STR-VN-L,BODYSUITE STRETCH VINO,Talla: L,23.39,0.00
+__import__.product_template_cha_milano_pr,CHA-MILANO-PR-XS,CHA-MILANO-PR-XS,CHALECO MILANO PRINT,Talla: XS,52.09,0.00
+__import__.product_template_cha_milano_pr,CHA-MILANO-PR-S,CHA-MILANO-PR-S,CHALECO MILANO PRINT,Talla: S,52.09,0.00
+__import__.product_template_cha_milano_pr,CHA-MILANO-PR-M,CHA-MILANO-PR-M,CHALECO MILANO PRINT,Talla: M,52.09,0.00
+__import__.product_template_cha_milano_pr,CHA-MILANO-PR-L,CHA-MILANO-PR-L,CHALECO MILANO PRINT,Talla: L,52.09,0.00
+__import__.product_template_pant_milano_pr,PANT-MILANO-PR-XS,PANT-MILANO-PR-XS,PANTALON MILANO PRINT,Talla: XS,67.74,0.00
+__import__.product_template_pant_milano_pr,PANT-MILANO-PR-S,PANT-MILANO-PR-S,PANTALON MILANO PRINT,Talla: S,67.74,0.00
+__import__.product_template_pant_milano_pr,PANT-MILANO-PR-M,PANT-MILANO-PR-M,PANTALON MILANO PRINT,Talla: M,67.74,0.00
+__import__.product_template_pant_roma_cl,PANT-ROMA-CL/XS,PANT-ROMA-CL/XS,PANTALON ROMA CELESTE,Talla: XS,60.78,0.00
+__import__.product_template_pant_roma_cl,PANT-ROMA-CL/S,PANT-ROMA-CL/S,PANTALON ROMA CELESTE,Talla: S,60.78,0.00
+__import__.product_template_pant_roma_cl,PANT-ROMA-CL/M,PANT-ROMA-CL/M,PANTALON ROMA CELESTE,Talla: M,60.78,0.00
+__import__.product_template_pant_roma_cl,PANT-ROMA-CL/L,PANT-ROMA-CL/L,PANTALON ROMA CELESTE,Talla: L,60.78,0.00
+__import__.product_template_pant_roma_az,PANT-ROMA-AZ/XS,PANT-ROMA-AZ/XS,PANTALON ROMA AZUL,Talla: XS,60.78,0.00
+__import__.product_template_pant_roma_az,PANT-ROMA-AZ/XL,PANT-ROMA-AZ/XL,PANTALON ROMA AZUL,Talla: XL,60.78,0.00
+__import__.product_template_pant_roma_az,PANT-ROMA-AZ/S,PANT-ROMA-AZ/S,PANTALON ROMA AZUL,Talla: S,60.78,0.00
+__import__.product_template_pant_roma_az,PANT-ROMA-AZ/M,PANT-ROMA-AZ/M,PANTALON ROMA AZUL,Talla: M,60.78,0.00
+__import__.product_template_pant_roma_az,PANT-ROMA-AZ/L,PANT-ROMA-AZ/L,PANTALON ROMA AZUL,Talla: L,60.78,0.00
+__import__.product_template_cam_m_l_firenze_cl,CAM-M/L-FIRENZE-CL/S,CAM-M/L-FIRENZE-CL/S,CAMISA M/L FIRENZE CELESTE,Talla: S,65.13,0.00
+__import__.product_template_cam_m_l_firenze_cl,CAM-M/L-FIRENZE-CL/M,CAM-M/L-FIRENZE-CL/M,CAMISA M/L FIRENZE CELESTE,Talla: M,65.13,0.00
+__import__.product_template_cam_m_l_firenze_cl,CAM-M/L-FIRENZE-CL/L,CAM-M/L-FIRENZE-CL/L,CAMISA M/L FIRENZE CELESTE,Talla: L,65.13,0.00
+__import__.product_template_cam_m_l_firenze_azul,CAM-M/L-FIRENZE-AZUL/XS,CAM-M/L-FIRENZE-AZUL/XS,CAMISA M/L FIRENZE AZUL,Talla: XS,65.13,0.00
+__import__.product_template_cam_m_l_firenze_azul,CAM-M/L-FIRENZE-AZUL/S,CAM-M/L-FIRENZE-AZUL/S,CAMISA M/L FIRENZE AZUL,Talla: S,65.13,0.00
+__import__.product_template_cam_m_l_firenze_cl,CAM-M/L-FIRENZE-CL/XS,CAM-M/L-FIRENZE-CL/XS,CAMISA M/L FIRENZE CELESTE,Talla: XS,60.90,0.00
+__import__.product_template_sl,SL-007,SL-007,H CORBATA P/CABALLERO NAVY LABRADO PUNTO,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_sl,SL-006,SL-006,H CORBATA P/CABALLERO NAVY LABRADO PUNTO,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_ve_milenag_grn,VE-MILENAG-GRN/M,VEMILENAGRN/M,VESTIDO MILENA GREEN,Talla: M,52.96,0.00
+__import__.product_template_lbpc_d04_207s_dkol,LBPC-D04-207S-DKOL/XL,0743682195601,CAMISA P/H M/L DK. OLIVE LONG BEACH,Talla: XL,50.35,0.00
+__import__.product_template_lbpc_d04_207s_dkol,LBPC-D04-207S-DKOL/M,0743682195588,CAMISA P/H M/L DK. OLIVE LONG BEACH,Talla: M,50.35,0.00
+__import__.product_template_lbpc_d04_207s_dkol,LBPC-D04-207S-DKOL/L,0743682195595,CAMISA P/H M/L DK. OLIVE LONG BEACH,Talla: L,50.35,0.00
+__import__.product_template_cuwff020_112,CUWFF020-112/S,051054427947,CAMISA M/C P/H BRILLIANT WHITE CUBAVERA,Talla: S,84.26,0.00
+__import__.product_template_cuwff020_112,CUWFF020-112/M,051054427954,CAMISA M/C P/H BRILLIANT WHITE CUBAVERA,Talla: M,84.26,0.00
+__import__.product_template_cuwff020_112,CUWFF020-112/L,051054427961,CAMISA M/C P/H BRILLIANT WHITE CUBAVERA,Talla: L,84.26,0.00
+__import__.product_template_cuwfd040_112,CUWFD040-112/XL,713610971133,CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: XL,106.87,0.00
+__import__.product_template_cuwfd040_112,CUWFD040-112/S,713610971102,CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: S,106.87,0.00
+__import__.product_template_fa_35_1071_sd,FA-35-1071-SD/46,0743682310103,Leva FA-35-1071-SD,Talla: 46,165.13,0.00
+__import__.product_template_fa_35_1071_sd,FA-35-1071-SD/42,0743682310080,Leva FA-35-1071-SD,Talla: 42,165.13,0.00
+__import__.product_template_cuwff020_112,CUWFF020-112/XL,051054427978,CAMISA M/C P/H BRILLIANT WHITE CUBAVERA,Talla: XL,84.26,0.00
+__import__.product_template_cuwmf006_119,CUWMF006-119/M,738946427994,CAMISA M/C P/H EGRET CUBAVERA,Talla: M,85.13,0.00
+__import__.product_template_cuwmf006_119,CUWMF006-119/S,738946427987,CAMISA M/C P/H EGRET CUBAVERA,Talla: S,85.13,0.00
+__import__.product_template_cuwmf006_119,CUWMF006-119/L,738946428007,CAMISA M/C P/H EGRET CUBAVERA,Talla: L,85.13,0.00
+__import__.product_template_fa_35_1071_sd,FA-35-1071-SD/44,0743682310097,Leva FA-35-1071-SD,Talla: 44,165.13,0.00
+__import__.product_template_fa_35_1071_wi,FA-35-1071-WI/40,0743682310134,Leva FA-35-1071-WI,Talla: 40,165.13,0.00
+__import__.product_template_fa_35_1071_sd,FA-35-1071-SD/36,0743682310059,Leva FA-35-1071-SD,Talla: 36,165.13,0.00
+__import__.product_template_fa_35_1073_sk,FA-35-1073-SK/44,0743682310554,Leva FA-35-1073-SK,Talla: 44,165.13,0.00
+__import__.product_template_fa_35_1073_sk,FA-35-1073-SK/42,0743682310547,Leva FA-35-1073-SK,Talla: 42,165.13,0.00
+__import__.product_template_cuwmf006_119,CUWMF006-119/XL,738946428014,CAMISA M/C P/H EGRET CUBAVERA,Talla: XL,85.13,0.00
+__import__.product_template_fa_35_1071_wi,FA-35-1071-WI/46,0743682310165,Leva FA-35-1071-WI,Talla: 46,165.13,0.00
+__import__.product_template_fa_35_1071_wi,FA-35-1071-WI/44,0743682310158,Leva FA-35-1071-WI,Talla: 44,165.13,0.00
+__import__.product_template_fa_35_1071_wi,FA-35-1071-WI/42,0743682310141,Leva FA-35-1071-WI,Talla: 42,165.13,0.00
+__import__.product_template_fa_35_1071_sd,FA-35-1071-SD/40,0743682310073,Leva FA-35-1071-SD,Talla: 40,165.13,0.00
+__import__.product_template_fa_35_1071_wi,FA-35-1071-WI/38,0743682310127,Leva FA-35-1071-WI,Talla: 38,165.13,0.00
+__import__.product_template_fa_35_1071_sd,FA-35-1071-SD/38,0743682310066,Leva FA-35-1071-SD,Talla: 38,165.13,0.00
+__import__.product_template_fa_35_1071_wi,FA-35-1071-WI/36,0743682310110,Leva FA-35-1071-WI,Talla: 36,165.13,0.00
+__import__.product_template_fa_35_1073_wi,FA-35-1073-WI/42,0743682310646,Leva FA-35-1073-WI,Talla: 42,165.13,0.00
+__import__.product_template_fa_35_1073_wi,FA-35-1073-WI/40,0743682310639,Leva FA-35-1073-WI,Talla: 40,165.13,0.00
+__import__.product_template_fa_35_1073_sk,FA-35-1073-SK/40,0743682310530,Leva FA-35-1073-SK,Talla: 40,165.13,0.00
+__import__.product_template_fa_35_1073_wi,FA-35-1073-WI/46,0743682310660,Leva FA-35-1073-WI,Talla: 46,165.13,0.00
+__import__.product_template_fa_35_1073_sk,FA-35-1073-SK/36,0743682310516,Leva FA-35-1073-SK,Talla: 36,165.13,0.00
+__import__.product_template_fa_35_1073_wi,FA-35-1073-WI/36,0743682310615,Leva FA-35-1073-WI,Talla: 36,165.13,0.00
+__import__.product_template_fa_35_1073_sk,FA-35-1073-SK/38,0743682310523,Leva FA-35-1073-SK,Talla: 38,165.13,0.00
+__import__.product_template_fa_35_1073_wi,FA-35-1073-WI/38,0743682310622,Leva FA-35-1073-WI,Talla: 38,165.13,0.00
+__import__.product_template_fa_35_1073_sk,FA-35-1073-SK/46,0743682310561,Leva FA-35-1073-SK,Talla: 46,165.13,0.00
+__import__.product_template_fa_35_1073_wi,FA-35-1073-WI/44,0743682310653,Leva FA-35-1073-WI,Talla: 44,165.13,0.00
+__import__.product_template_cuwfd040_112,CUWFD040-112/L,713610971126,CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: L,106.87,0.00
+__import__.product_template_cuwfd040_112,CUWFD040-112/M,713610971119,CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: M,106.87,0.00
+__import__.product_template_lbpc_d04_216s_wh,LBPC-D04-216S-WH/M,0743682196547,CAMISA P/H M/L WHITE LONG BEACH,Talla: M,50.35,0.00
+__import__.product_template_lbpc_d04_217s_wh,LBPC-D04-217S-WH/M,0743682196783,CAMISA P/H M/L WHITE LONG BEACH (lbpc_d04_217s_wh),Talla: M,50.35,0.00
+__import__.product_template_lbpc_c03_232s_nv,LBPC-C03-232S-NV/L,743682044398,CAMISA P/H M/C NAVY LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_d04_217s_wh,LBPC-D04-217S-WH/XL,0743682196806,CAMISA P/H M/L WHITE LONG BEACH (lbpc_d04_217s_wh),Talla: XL,50.35,0.00
+__import__.product_template_lbpc_c03_232s_iv,LBPC-C03-232S-IV/M,743682044343,CAMISA P/H M/C IVORY LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b03_102s_wh,LBPC-B03-102S-WH/S,7448336185160,CAMISA P/H M/C WHITE LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b03_102s_wh,LBPC-B03-102S-WH/XL,7448339665669,CAMISA P/H M/C WHITE LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_c03_232s_iv,LBPC-C03-232S-IV/S,743682044336,CAMISA P/H M/C IVORY LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b03_102s_wh,LBPC-B03-102S-WH/M,7448335844808,CAMISA P/H M/C WHITE LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_fa_20_678u_ch,FA-20-678U-CH/30,0743682127619,Terno FA-20-678U-CH,Talla: 30,56.43,0.00
+__import__.product_template_fa_20_678u_ch,FA-20-678U-CH/32,0743682127626,Terno FA-20-678U-CH,Talla: 32,56.43,0.00
+__import__.product_template_fa_20_678u_ch,FA-20-678U-CH/34,0743682127633,Terno FA-20-678U-CH,Talla: 34,56.43,0.00
+__import__.product_template_lbpc_c03_232s_nv,LBPC-C03-232S-NV/M,743682044381,CAMISA P/H M/C NAVY LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_c03_232s_nv,LBPC-C03-232S-NV/S,743682044374,CAMISA P/H M/C NAVY LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_d04_217s_wh,LBPC-D04-217S-WH/L,0743682196790,CAMISA P/H M/L WHITE LONG BEACH (lbpc_d04_217s_wh),Talla: L,50.35,0.00
+__import__.product_template_fa_35_1073_nv,FA-35-1073-NV/36,0743682310318,Leva FA-35-1073-NV,Talla: 36,165.13,0.00
+__import__.product_template_fa_35_1073_nv,FA-35-1073-NV/38,0743682310312,Leva FA-35-1073-NV,Talla: 38,165.13,0.00
+__import__.product_template_fa_35_1073_nv,FA-35-1073-NV/40,0743682310332,Leva FA-35-1073-NV,Talla: 40,165.13,0.00
+__import__.product_template_fa_35_1073_nv,FA-35-1073-NV/42,0743682310349,Leva FA-35-1073-NV,Talla: 42,165.13,0.00
+__import__.product_template_fa_35_1073_nv,FA-35-1073-NV/44,0743682310356,Leva FA-35-1073-NV,Talla: 44,165.13,0.00
+__import__.product_template_fa_35_1073_nv,FA-35-1073-NV/46,0743682310363,Leva FA-35-1073-NV,Talla: 46,165.13,0.00
+__import__.product_template_lbpc_d04_207s_dkol,LBPC-D04-207S-DKOL/S,0743682195571,CAMISA P/H M/L DK. OLIVE LONG BEACH,Talla: S,50.35,0.00
+__import__.product_template_lbpc_d04_213s_nv,LBPC-D04-213S-NV/L,0743682196073,CAMISA P/H M/L NAVY LONG BEACH,Talla: L,50.35,0.00
+__import__.product_template_lbpc_d04_213s_nv,LBPC-D04-213S-NV/M,0743682196066,CAMISA P/H M/L NAVY LONG BEACH,Talla: M,50.35,0.00
+__import__.product_template_lbpc_d04_213s_nv,LBPC-D04-213S-NV/S,0743682196059,CAMISA P/H M/L NAVY LONG BEACH,Talla: S,50.35,0.00
+__import__.product_template_lbpc_d04_216s_wh,LBPC-D04-216S-WH/L,0743682196554,CAMISA P/H M/L WHITE LONG BEACH,Talla: L,50.35,0.00
+__import__.product_template_lbpc_d04_213s_nv,LBPC-D04-213S-NV/XL,0743682196080,CAMISA P/H M/L NAVY LONG BEACH,Talla: XL,50.35,0.00
+__import__.product_template_fa_35_1071_ht,FA-35-1071-HT/38,0743682309909,Leva FA-35-1071-HT,Talla: 38,165.13,0.00
+__import__.product_template_fa_35_1071_ht,FA-35-1071-HT/36,0743682309893,Leva FA-35-1071-HT,Talla: 36,165.13,0.00
+__import__.product_template_fa_20_678u_ch,FA-20-678U-CH/40,0743682127664,Terno FA-20-678U-CH,Talla: 40,56.43,0.00
+__import__.product_template_fa_20_678u_ch,FA-20-678U-CH/38,0743682127657,Terno FA-20-678U-CH,Talla: 38,56.43,0.00
+__import__.product_template_fa_35_1071_ht,FA-35-1071-HT/42,0743682309923,Leva FA-35-1071-HT,Talla: 42,165.13,0.00
+__import__.product_template_fa_35_1071_ht,FA-35-1071-HT/44,0743682309930,Leva FA-35-1071-HT,Talla: 44,165.13,0.00
+__import__.product_template_lbpc_c03_232s_iv,LBPC-C03-232S-IV/XL,743682044367,CAMISA P/H M/C IVORY LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_cuwsf021_119,CUWSF021-119/S,713610972130,CAMISA M/C P/H EGRET CUBAVERA (cuwsf021_119),Talla: S,86.87,0.00
+__import__.product_template_cuwsf021_119,CUWSF021-119/M,713610972147,CAMISA M/C P/H EGRET CUBAVERA (cuwsf021_119),Talla: M,86.87,0.00
+__import__.product_template_cuwsf021_119,CUWSF021-119/L,713610972154,CAMISA M/C P/H EGRET CUBAVERA (cuwsf021_119),Talla: L,86.87,0.00
+__import__.product_template_cuwsf021_119,CUWSF021-119/XL,713610972161,CAMISA M/C P/H EGRET CUBAVERA (cuwsf021_119),Talla: XL,86.87,0.00
+__import__.product_template_cuwsp501_475l,CUWSP501-475L/XL,0743682135478,CAMISA P/H M/C LT. BLUE CUBAVERA,Talla: XL,90.35,0.00
+__import__.product_template_cuwsp501_475l,CUWSP501-475L/S,0743682135447,CAMISA P/H M/C LT. BLUE CUBAVERA,Talla: S,90.35,0.00
+__import__.product_template_cuwsp501_475l,CUWSP501-475L/M,0743682135454,CAMISA P/H M/C LT. BLUE CUBAVERA,Talla: M,90.35,0.00
+__import__.product_template_cuwsp501_475l,CUWSP501-475L/L,0743682135461,CAMISA P/H M/C LT. BLUE CUBAVERA,Talla: L,90.35,0.00
+__import__.product_template_cuwsp501_100s,CUWSP501-100S/XL,0743682135324,CAMISA P/H M/C WHITE CUBAVERA,Talla: XL,86.87,0.00
+__import__.product_template_cuwsp501_100s,CUWSP501-100S/S,0743682135294,CAMISA P/H M/C WHITE CUBAVERA,Talla: S,86.87,0.00
+__import__.product_template_cuwsp501_100s,CUWSP501-100S/M,0743682135300,CAMISA P/H M/C WHITE CUBAVERA,Talla: M,86.87,0.00
+__import__.product_template_cuwf2111_118,CUWF2111-118/XXL,0743682127152,CAMISA P/H M/L BRIGHT WHITE CUBAVERA,Talla: XXL,112.96,0.00
+__import__.product_template_cuwf2111_118,CUWF2111-118/XL,0743682127145,CAMISA P/H M/L BRIGHT WHITE CUBAVERA,Talla: XL,112.96,0.00
+__import__.product_template_cuwf2111_118,CUWF2111-118/S,0743682127114,CAMISA P/H M/L BRIGHT WHITE CUBAVERA,Talla: S,112.96,0.00
+__import__.product_template_cuwbp0035_454,CUWBP0035-454/M,0743682135003,CAMISA P/H M/L CASHEMERE BLUE CUBAVERA,Talla: M,112.96,0.00
+__import__.product_template_cuwbp0035_454,CUWBP0035-454/L,0743682135010,CAMISA P/H M/L CASHEMERE BLUE CUBAVERA,Talla: L,112.96,0.00
+__import__.product_template_cuwsp501_485s,CUWSP501-485S/XL,0743682135171,CAMISA P/H M/C AQCUA CUBAVERA,Talla: XL,86.87,0.00
+__import__.product_template_cuwsp501_485s,CUWSP501-485S/S,0743682135140,CAMISA P/H M/C AQCUA CUBAVERA,Talla: S,86.87,0.00
+__import__.product_template_cuwsp501_485s,CUWSP501-485S/M,0743682136157,CAMISA P/H M/C AQCUA CUBAVERA,Talla: M,86.87,0.00
+__import__.product_template_cuwsp501_485s,CUWSP501-485S/L,0743682135164,CAMISA P/H M/C AQCUA CUBAVERA,Talla: L,86.87,0.00
+__import__.product_template_cuwfd040_457,CUWFD040-457/XL,713610971188,CAMISA P/H M/C CLEAR SKY CUBAVERA,Talla: XL,106.87,0.00
+__import__.product_template_cuwfd040_457,CUWFD040-457/S,713610971157,CAMISA P/H M/C CLEAR SKY CUBAVERA,Talla: S,106.87,0.00
+__import__.product_template_cuwfd040_457,CUWFD040-457/M,713610971164,CAMISA P/H M/C CLEAR SKY CUBAVERA,Talla: M,106.87,0.00
+__import__.product_template_cuwfd040_457,CUWFD040-457/L,713610971171,CAMISA P/H M/C CLEAR SKY CUBAVERA,Talla: L,106.87,0.00
+__import__.product_template_cuwhe007_450,CUWHE007-450/XL,713610973786,CAMISA P/H M/C DREAM BLUE CUBAVERA,Talla: XL,93.83,0.00
+__import__.product_template_cuwhe007_450,CUWHE007-450/M,713610973762,CAMISA P/H M/C DREAM BLUE CUBAVERA,Talla: M,93.83,0.00
+__import__.product_template_cuwhe007_450,CUWHE007-450/S,713610973755,CAMISA P/H M/C DREAM BLUE CUBAVERA,Talla: S,93.83,0.00
+__import__.product_template_cuwhe007_450,CUWHE007-450/L,713610973779,CAMISA P/H M/C DREAM BLUE CUBAVERA,Talla: L,93.83,0.00
+__import__.product_template_cuwbp0035_454,CUWBP0035-454/S,0743682134990,CAMISA P/H M/L CASHEMERE BLUE CUBAVERA,Talla: S,112.96,0.00
+__import__.product_template_cuwf2109_118,CUWF2109-118/L,0743682126834,CAMISA P/H M/C BRIGHT WHITE CUBAVERA,Talla: L,112.96,0.00
+__import__.product_template_cuwf2109_118,CUWF2109-118/M,0743682126827,CAMISA P/H M/C BRIGHT WHITE CUBAVERA,Talla: M,112.96,0.00
+__import__.product_template_cuwf2109_118,CUWF2109-118/S,0743682126810,CAMISA P/H M/C BRIGHT WHITE CUBAVERA,Talla: S,112.96,0.00
+__import__.product_template_cuwf2109_118,CUWF2109-118/XXL,0743682126858,CAMISA P/H M/C BRIGHT WHITE CUBAVERA,Talla: XXL,112.96,0.00
+__import__.product_template_cuwf2109_118,CUWF2109-118/XL,0743682126841,CAMISA P/H M/C BRIGHT WHITE CUBAVERA,Talla: XL,112.96,0.00
+__import__.product_template_cuwf2111_118,CUWF2111-118/L,0743682127138,CAMISA P/H M/L BRIGHT WHITE CUBAVERA,Talla: L,112.96,0.00
+__import__.product_template_cuwf2111_118,CUWF2111-118/M,0743682127121,CAMISA P/H M/L BRIGHT WHITE CUBAVERA,Talla: M,112.96,0.00
+__import__.product_template_cuwsp501_100s,CUWSP501-100S/L,0743682135317,CAMISA P/H M/C WHITE CUBAVERA,Talla: L,86.87,0.00
+__import__.product_template_cuwsf025_477,CUWSF025-477/XL,713610964289,CAMISA P/H M/L PARISIAN BLUE CUBAVERA,Talla: XL,99.91,0.00
+__import__.product_template_cuwsf025_477,CUWSF025-477/S,713610967471,CAMISA P/H M/L PARISIAN BLUE CUBAVERA,Talla: S,99.91,0.00
+__import__.product_template_cuwsf025_477,CUWSF025-477/M,713610964265,CAMISA P/H M/L PARISIAN BLUE CUBAVERA,Talla: M,99.91,0.00
+__import__.product_template_cuwsf025_477,CUWSF025-477/L,713510964272,CAMISA P/H M/L PARISIAN BLUE CUBAVERA,Talla: L,99.91,0.00
+__import__.product_template_cuwmd027_415,CUWMD027-415/L,713610970792,CAMISA P/H M/C DARK BLUE CUBAVERA,Talla: L,84.26,0.00
+__import__.product_template_cuwmd027_415,CUWMD027-415/M,713610970785,CAMISA P/H M/C DARK BLUE CUBAVERA,Talla: M,84.26,0.00
+__import__.product_template_cuwmd027_415,CUWMD027-415/S,713610970778,CAMISA P/H M/C DARK BLUE CUBAVERA,Talla: S,84.26,0.00
+__import__.product_template_cuwmd027_415,CUWMD027-415/XL,713610970808,CAMISA P/H M/C DARK BLUE CUBAVERA,Talla: XL,84.26,0.00
+__import__.product_template_ve_marce_bl,VE-MARCE-BL/M,VE-MARCE-BL/M,VESTIDO MARCELA ZOLEY BLACK,Talla: M,102.52,0.00
+__import__.product_template_ve_marce_bl,VE-MARCE-BL/L,VE-MARCE-BL/L,VESTIDO MARCELA ZOLEY BLACK,Talla: L,102.52,0.00
+__import__.product_template_ve_marce_wh,VE-MARCE-WH/S,VE-MARCE-WH/S,VESTIDO MARCELA ZOLEY WHITE,Talla: S,102.52,0.00
+__import__.product_template_ve_marce_wh,VE-MARCE-WH/M,VE-MARCE-WH/M,VESTIDO MARCELA ZOLEY WHITE,Talla: M,102.52,0.00
+__import__.product_template_ve_marce_wh,VE-MARCE-WH/L,VE-MARCE-WH/L,VESTIDO MARCELA ZOLEY WHITE,Talla: L,102.52,0.00
+__import__.product_template_ve_stela_az,VE-STELA-AZ/L,VE-STELA-AZ/L,VESTIDO STELA AZUL,Talla: L,147.74,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/44,7448331641616,Terno CB-H22-006NV,Talla: 44,82.52,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/42,7448335090083,Terno CB-H22-006NV,Talla: 42,82.52,0.00
+__import__.product_template_pt_008_black_1,PT-008-BLACK-1/36,PT008BLACK1/36,Pantalon PT-008-BLACK-1,Talla: 36,60.80,0.00
+__import__.product_template_pt_6158_a7,PT-6158-A7/34,PT-6158-A7/34,Pantalon PT-6158-A7,Talla: 34,60.80,0.00
+__import__.product_template_lv_smoking_1bc,LV-SMOKING-1BC/56,LV-SMOKING-1BC/56,Leva LV-SMOKING-1BC,Talla: 56,217.30,0.00
+__import__.product_template_pant_sub_cn_bl,PANT-SUB-CN-BL/S,PANTSUBCNBL/S,PANTALON P/DAMA SUBLIME CINTA BLACK,Talla: S,45.13,0.00
+__import__.product_template_pant_sub_cn_bl,PANT-SUB-CN-BL/M,PANTSUBCNBL/M,PANTALON P/DAMA SUBLIME CINTA BLACK,Talla: M,45.13,0.00
+__import__.product_template_pant_sub_cn_bl,PANT-SUB-CN-BL/L,PANTSUBCNBL/L,PANTALON P/DAMA SUBLIME CINTA BLACK,Talla: L,45.13,0.00
+__import__.product_template_pant_sub_cn_bge,PANT-SUB-CN-BGE/S,PANTSUBCNBGE/S,PANTALON P/DAMA SUBLIME CINTA BEIGE,Talla: S,45.13,0.00
+__import__.product_template_pant_sub_cn_bge,PANT-SUB-CN-BGE/M,PANTSUBCNBGE/M,PANTALON P/DAMA SUBLIME CINTA BEIGE,Talla: M,45.13,0.00
+__import__.product_template_pant_sub_cn_bge,PANT-SUB-CN-BGE/L,PANTSUBCNBGE/L,PANTALON P/DAMA SUBLIME CINTA BEIGE,Talla: L,45.13,0.00
+__import__.product_template_pant_sublim_rd,PANT-SUBLIM-RD/S,PANTSUBLIMRD/S,PANTALON P/DAMA SUBLIME RED,Talla: S,53.83,0.00
+__import__.product_template_pant_sublim_rd,PANT-SUBLIM-RD/M,PANTSUBLIMRD/M,PANTALON P/DAMA SUBLIME RED,Talla: M,53.83,0.00
+__import__.product_template_pant_sublim_rd,PANT-SUBLIM-RD/L,PANTSUBLIMRD/L,PANTALON P/DAMA SUBLIME RED,Talla: L,53.83,0.00
+__import__.product_template_pant_sublim_bl,PANT-SUBLIM-BL/S,PANTSUBLIMBL/S,PANTALON P/DAMA SUBLIME BLACK,Talla: S,50.35,0.00
+__import__.product_template_pant_sublim_bl,PANT-SUBLIM-BL/M,PANTSUBLIMBL/M,PANTALON P/DAMA SUBLIME BLACK,Talla: M,50.35,0.00
+__import__.product_template_pant_sublim_bl,PANT-SUBLIM-BL/L,PANTSUBLIMBL/L,PANTALON P/DAMA SUBLIME BLACK,Talla: L,50.35,0.00
+__import__.product_template_pant_sublim_bge,PANT-SUBLIM-BGE/S,PANTSUBLIMBGE/S,PANTALON P/DAMA SUBLIME BEIGE,Talla: S,50.35,0.00
+__import__.product_template_pant_sublim_bge,PANT-SUBLIM-BGE/M,PANTSUBLIMBGE/M,PANTALON P/DAMA SUBLIME BEIGE,Talla: M,50.35,0.00
+__import__.product_template_pant_sublim_bge,PANT-SUBLIM-BGE/L,PANTSUBLIMBGE/L,PANTALON P/DAMA SUBLIME BEIGE,Talla: L,50.35,0.00
+__import__.product_template_bl_cot_3but_ol,BL-COT-3BUT-OL/S,BLCOT3BUTOL/S,BLUSA 3 BUTTONS COTTON OLIVE,Talla: S,70.35,0.00
+__import__.product_template_bl_cot_3but_ol,BL-COT-3BUT-OL/M,BLCOT3BUTOL/M,BLUSA 3 BUTTONS COTTON OLIVE,Talla: M,70.35,0.00
+__import__.product_template_bl_cot_3but_ol,BL-COT-3BUT-OL/L,BLCOT3BUTOL/L,BLUSA 3 BUTTONS COTTON OLIVE,Talla: L,70.35,0.00
+__import__.product_template_bl_cot_3but_blu,BL-COT-3BUT-BLU/S,BLCOT3BUTBLU/S,BLUSA 3 BUTTONS COTTON BLUE,Talla: S,70.35,0.00
+__import__.product_template_bl_cot_3but_blu,BL-COT-3BUT-BLU/M,BLCOT3BUTBLU/M,BLUSA 3 BUTTONS COTTON BLUE,Talla: M,70.35,0.00
+__import__.product_template_bl_cot_3but_blu,BL-COT-3BUT-BLU/L,BLCOT3BUTBLU/L,BLUSA 3 BUTTONS COTTON BLUE,Talla: L,70.35,0.00
+__import__.product_template_bl_org_wh,BL-ORG-WH/S,BL-ORG-WH/S,BLUSA ORGANZA SATIN WHITE,Talla: S,66.87,0.00
+__import__.product_template_bl_org_wh,BL-ORG-WH/M,BLORGWH/M,BLUSA ORGANZA SATIN WHITE,Talla: M,66.87,0.00
+__import__.product_template_bl_org_wh,BL-ORG-WH/L,BLORGWH/L,BLUSA ORGANZA SATIN WHITE,Talla: L,66.87,0.00
+__import__.product_template_bl_org_moc,BL-ORG-MOC/S,BLORGMOC/S,BLUSA ORGANZA SATIN MOCHA,Talla: S,66.87,0.00
+__import__.product_template_bl_org_moc,BL-ORG-MOC/M,BLORGMOC/M,BLUSA ORGANZA SATIN MOCHA,Talla: M,66.87,0.00
+__import__.product_template_bl_org_moc,BL-ORG-MOC/L,BLORGMOC/L,BLUSA ORGANZA SATIN MOCHA,Talla: L,66.87,0.00
+__import__.product_template_bl_org_blu,BL-ORG-BLU/S,BLORGBLU/S,BLUSA ORGANZA SATIN BLUE,Talla: S,66.87,0.00
+__import__.product_template_bl_org_blu,BL-ORG-BLU/M,BLORGBLU/M,BLUSA ORGANZA SATIN BLUE,Talla: M,66.87,0.00
+__import__.product_template_bl_org_blu,BL-ORG-BLU/L,BLORGBLU/L,BLUSA ORGANZA SATIN BLUE,Talla: L,66.87,0.00
+__import__.product_template_bl_satin_lgr,BL-SATIN-LGR/S,BLSATINLGR/S,BLUSA SATIN CIEN L/GRAY,Talla: S,66.87,0.00
+__import__.product_template_bl_satin_lgr,BL-SATIN-LGR/M,BLSATINLGR/M,BLUSA SATIN CIEN L/GRAY,Talla: M,66.87,0.00
+__import__.product_template_bl_satin_lgr,BL-SATIN-LGR/L,BL-SATIN-LGR/L,BLUSA SATIN CIEN L/GRAY,Talla: L,66.87,0.00
+__import__.product_template_set_cien_bl,SET-CIEN-BL/S,SETCIENBL/S,SET VEST & PANT CIEN BLACK,Talla: S,106.87,0.00
+__import__.product_template_set_cien_bl,SET-CIEN-BL/M,SETCIENBL/M,SET VEST & PANT CIEN BLACK,Talla: M,106.87,0.00
+__import__.product_template_set_cien_bl,SET-CIEN-BL/L,SET-CIEN-BL/L,SET VEST & PANT CIEN BLACK,Talla: L,106.87,0.00
+__import__.product_template_top_halneck_ivo,TOP-HALNECK-IVO/S,TOPHALNECKIVO/S,TOP HALTER NECK IVORY,Talla: S,64.26,0.00
+__import__.product_template_top_halneck_ivo,TOP-HALNECK-IVO/M,TOPHALNECKIVO/M,TOP HALTER NECK IVORY,Talla: M,64.26,0.00
+__import__.product_template_top_halneck_ivo,TOP-HALNECK-IVO/L,TOPHALNECKIVO/L,TOP HALTER NECK IVORY,Talla: L,64.26,0.00
+__import__.product_template_top_oshoul_dnvy,TOP-OSHOUL-DNVY/S,TOPOSHOULDNVY/S,TOP ONE SHOULD DARK NAVY,Talla: S,59.91,0.00
+__import__.product_template_top_oshoul_dnvy,TOP-OSHOUL-DNVY/M,TOPOSHOULDNVY/M,TOP ONE SHOULD DARK NAVY,Talla: M,59.91,0.00
+__import__.product_template_top_oshoul_dnvy,TOP-OSHOUL-DNVY/L,TOPOSHOULDNVY/L,TOP ONE SHOULD DARK NAVY,Talla: L,59.91,0.00
+__import__.product_template_top_oshoul_bl,TOP-OSHOUL-BL/S,TOPOSHOULBL/S,TOP ONE SHOULD BLACK,Talla: S,52.96,0.00
+__import__.product_template_top_oshoul_bl,TOP-OSHOUL-BL/M,TOPOSHOULBL/M,TOP ONE SHOULD BLACK,Talla: M,52.96,0.00
+__import__.product_template_top_oshoul_bl,TOP-OSHOUL-BL/L,TOPOSHOULBL/L,TOP ONE SHOULD BLACK,Talla: L,52.96,0.00
+__import__.product_template_top_lsleves_nta,TOP-LSLEVES-NTA/S,TOP-LSLEVES-NTA/S,TOP LONG SLEEVES NAVY TAUPE,Talla: S,66.87,0.00
+__import__.product_template_top_lsleves_nta,TOP-LSLEVES-NTA/M,TOPLSLEVESNTA/M,TOP LONG SLEEVES NAVY TAUPE,Talla: M,66.87,0.00
+__import__.product_template_top_lsleves_nta,TOP-LSLEVES-NTA/L,TOPLSLEVESNTA/L,TOP LONG SLEEVES NAVY TAUPE,Talla: L,66.87,0.00
+__import__.product_template_bsut_sleves_ch,BSUT-SLEVES-CH/S,BSUT-SLEVES-CH/S,BODYSUITE CHARCOAL,Talla: S,40.78,0.00
+__import__.product_template_bsut_sleves_ch,BSUT-SLEVES-CH/M,BSUT-SLEVES-CH/M,BODYSUITE CHARCOAL,Talla: M,40.78,0.00
+__import__.product_template_bsut_sleves_ch,BSUT-SLEVES-CH/L,BSUT-SLEVES-CH/L,BODYSUITE CHARCOAL,Talla: L,40.78,0.00
+__import__.product_template_bsut_sleves_lts,BSUT-SLEVES-LTS/S,BSUTSLEVESLTS/S,BODYSUITE LT SAGE,Talla: S,39.91,0.00
+__import__.product_template_bsut_sleves_lts,BSUT-SLEVES-LTS/M,BSUTSLEVESLTS/M,BODYSUITE LT SAGE,Talla: M,39.91,0.00
+__import__.product_template_bsut_sleves_lts,BSUT-SLEVES-LTS/L,BSUTSLEVESLTS/L,BODYSUITE LT SAGE,Talla: L,39.91,0.00
+__import__.product_template_top_sleves_esm,TOP-SLEVES-ESM/S,TOPSLEVESESM/S,TOP SLEVES KNIT EMERALD,Talla: S,52.09,0.00
+__import__.product_template_top_sleves_esm,TOP-SLEVES-ESM/M,TOPSLEVESESM/M,TOP SLEVES KNIT EMERALD,Talla: M,52.09,0.00
+__import__.product_template_top_sleves_esm,TOP-SLEVES-ESM/L,TOPSLEVESESM/L,TOP SLEVES KNIT EMERALD,Talla: L,52.09,0.00
+__import__.product_template_top_sleves_burg,TOP-SLEVES-BURG/S,TOPSLEVESBURG/S,TOP SLEVES BURGUNDY,Talla: S,58.17,0.00
+__import__.product_template_top_sleves_burg,TOP-SLEVES-BURG/M,TOPSLEVESBURG/M,TOP SLEVES BURGUNDY,Talla: M,58.17,0.00
+__import__.product_template_top_sleves_burg,TOP-SLEVES-BURG/L,TOPSLEVESBURG/L,TOP SLEVES BURGUNDY,Talla: L,58.17,0.00
+__import__.product_template_top_sleves_bl,TOP-SLEVES-BL/S,TOPSLEVESBL/S,TOP SLEVES BLACK,Talla: S,66.00,0.00
+__import__.product_template_top_sleves_bl,TOP-SLEVES-BL/M,TOPSLEVESBL/M,TOP SLEVES BLACK,Talla: M,66.00,0.00
+__import__.product_template_top_sleves_bl,TOP-SLEVES-BL/L,TOPSLEVESBL/L,TOP SLEVES BLACK,Talla: L,0.00,0.00
+__import__.product_template_top_rayon_mm,TOP-RAYON-MM/S,TOPRAYONMM/S,TOP RAYON MOCHA MOUSSE,Talla: S,66.00,0.00
+__import__.product_template_top_rayon_mm,TOP-RAYON-MM/M,TOPRAYONMM/M,TOP RAYON MOCHA MOUSSE,Talla: M,66.00,0.00
+__import__.product_template_top_rayon_mm,TOP-RAYON-MM/L,TOPRAYONMM/L,TOP RAYON MOCHA MOUSSE,Talla: L,66.00,0.00
+__import__.product_template_fa_rayon_mm,FA-RAYON-MM/S,FARAYONMM/S,FALDA MINI MOCHA MOUSSE,Talla: S,53.83,0.00
+__import__.product_template_fa_rayon_mm,FA-RAYON-MM/M,FARAYONMM/M,FALDA MINI MOCHA MOUSSE,Talla: M,53.83,0.00
+__import__.product_template_fa_rayon_mm,FA-RAYON-MM/L,FARAYONMM/L,FALDA MINI MOCHA MOUSSE,Talla: L,53.83,0.00
+__import__.product_template_ve_midi_maxi_bl,VE-MIDI-MAXI-BL/S,VEMIDIMAXIBL/S,VESTIDO MIDI/MAXI BLACK,Talla: S,77.30,0.00
+__import__.product_template_ve_midi_maxi_bl,VE-MIDI-MAXI-BL/M,VEMIDIMAXIBL/M,VESTIDO MIDI/MAXI BLACK,Talla: M,77.30,0.00
+__import__.product_template_ve_midi_maxi_bl,VE-MIDI-MAXI-BL/L,VEMIDIMAXIBL/L,VESTIDO MIDI/MAXI BLACK,Talla: L,77.30,0.00
+__import__.product_template_bsut_ar,BSUT-AR/S,BSUT-AR/S,BODYSUITE ASH ROSE,Talla: S,48.61,0.00
+__import__.product_template_bsut_ar,BSUT-AR/M,BSUT-AR/M,BODYSUITE ASH ROSE,Talla: M,48.61,0.00
+__import__.product_template_bsut_ar,BSUT-AR/L,BSUT-AR/L,BODYSUITE ASH ROSE,Talla: L,48.61,0.00
+__import__.product_template_ve_viviene_ol,VE-VIVIENE-OL/L,VEVIVIENEOL/L,VESTIDO VIVIENE OLIVO,Talla: L,130.35,0.00
+__import__.product_template_ve_viviene_ol,VE-VIVIENE-OL/M,VEVIVIENEOL/M,VESTIDO VIVIENE OLIVO,Talla: M,130.35,0.00
+__import__.product_template_ve_beatrice_rd,VE-BEATRICE-RD/L,VEBEATRICERD/L,VESTIDO BEATRICE RED,Talla: L,147.74,0.00
+__import__.product_template_ve_beatrice_rd,VE-BEATRICE-RD/M,VEBEATRICERD/M,VESTIDO BEATRICE RED,Talla: M,147.74,0.00
+__import__.product_template_ve_ariadna_rd,VE-ARIADNA-RD/L,VEARIADNARD/L,VESTIDO ARIADNA RED,Talla: L,139.91,0.00
+__import__.product_template_ve_ariadna_rd,VE-ARIADNA-RD/M,VEARIADNARD/M,VESTIDO ARIADNA RED,Talla: M,139.91,0.00
+__import__.product_template_ve_ariadna_bge,VE-ARIADNA-BGE/S,VEARIADNABGE/S,VESTIDO ARIADNA BEIGE,Talla: S,139.91,0.00
+__import__.product_template_pt_6158_a7,PT-6158-A7/30,PT-6158-A7/30,Pantalon PT-6158-A7,Talla: 30,60.80,0.00
+__import__.product_template_mr_10845_1,MR-10845-1/7,MR-10845-1/7,Terno MR-10845-1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_lv_smoking_1bc,LV-SMOKING-1BC/52,LV-SMOKING-1BC/O52,Leva LV-SMOKING-1BC,Talla: 52,217.30,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/6.5,ZP-50224CASBRW/6.5,Zapato ZP-50224-CASSINI-BRW,Talla: 6.5,152.09,0.00
+__import__.product_template_lv_24c28061_76,LV-24C28061-76/56,LV-24C28061-76/O56,Leva LV-24C28061-76,Talla: 56,165.13,0.00
+__import__.product_template_pt_24c28061_76,PT-24C28061-76/36,PT-24C28061-76/O36,Pantalon PT-24C28061-76,Talla: 36,56.43,0.00
+__import__.product_template_lv_22c0905_4c,LV-22C0905-4C/54,LV-22C0905-4C/O54,Leva LV-22C0905-4C,Talla: 54,173.83,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/6.5,ZPCASSPSPTVN/O6.5,Zapato ZP-CASSINI-PS-PT-VN,Talla: 6.5,152.09,0.00
+__import__.product_template_pt_23c25168_220,PT-23C25168-220/48,PT-23C25168-220/48,Pantalon PT-23C25168-220,Talla: 48,56.43,0.00
+__import__.product_template_pt_2070_2,PT-2070-2/28,PT-2070-2/28,Pantalon PT-2070-2,Talla: 28,39.04,0.00
+__import__.product_template_lv_23a29607_32,LV-23A29607-32/56,LV-23A29607-32/56,Leva LV-23A29607-32,Talla: 56,173.83,0.00
+__import__.product_template_zp_cassini_ambar_ml,ZP-CASSINI-AMBAR-ML/6.5,ZPCASSINIAMBARML/65,Zapato ZP-CASSINI-AMBAR-ML,Talla: 6.5,152.09,0.00
+__import__.product_template_zp_cassini_ambar_ml,ZP-CASSINI-AMBAR-ML/6,ZP-CASSINI-AMBAR-ML/O6,Zapato ZP-CASSINI-AMBAR-ML,Talla: 6,152.09,0.00
+__import__.product_template_fld_freda_cof,FLD-FREDA-COF-S,FLD-FREDA-COF-S,FALDA FREDA COFFE-WHITE,Talla: S,100.78,0.00
+__import__.product_template_fld_freda_cof,FLD-FREDA-COF-M,FLD-FREDA-COF-M,FALDA FREDA COFFE-WHITE,Talla: M,100.78,0.00
+__import__.product_template_fld_freda_cof,FLD-FREDA-COF-L,FLD-FREDA-COF-L,FALDA FREDA COFFE-WHITE,Talla: L,100.78,0.00
+__import__.product_template_set_dana_nvy,SET-DANA-NVY-M,SET-DANA-NVY-M,SET DANA NAVY,Talla: M,149.48,0.00
+__import__.product_template_set_dana_nvy,SET-DANA-NVY-L,SET-DANA-NVY-L,SET DANA NAVY,Talla: L,149.48,0.00
+__import__.product_template_set_canela_crd,SET-CANELA-CRD-S,SET-CANELA-CRD-S,SET CANELA CRUDO,Talla: S,148.61,0.00
+__import__.product_template_set_canela_crd,SET-CANELA-CRD-M,SET-CANELA-CRD-M,SET CANELA CRUDO,Talla: M,148.61,0.00
+__import__.product_template_set_canela_crd,SET-CANELA-CRD-L,SET-CANELA-CRD-L,SET CANELA CRUDO,Talla: L,148.61,0.00
+__import__.product_template_ve_paulina_mag,VE-PAULINA-MAG-S,VE-PAULINA-MAG-S,VESTIDO PAULINA MAGENTA,Talla: S,159.04,0.00
+__import__.product_template_ve_gaia_tur,VE-GAIA-TUR-S,VE-GAIA-TUR-S,VESTIDO GAIA TURQUESA,Talla: S,166.00,0.00
+__import__.product_template_ve_gaia_tur,VE-GAIA-TUR-M,VE-GAIA-TUR-M,VESTIDO GAIA TURQUESA,Talla: M,166.00,0.00
+__import__.product_template_ve_ines_red,VE-INES-RED-S,VE-INES-RED-S,VESTIDO INES RED,Talla: S,164.26,0.00
+__import__.product_template_ve_ines_red,VE-INES-RED-M,VE-INES-RED-M,VESTIDO INES RED,Talla: M,164.26,0.00
+__import__.product_template_ve_ines_az,VE-INES-AZ-S,VE-INES-AZ-S,VESTIDO INES FLORES AZUL,Talla: S,164.26,0.00
+__import__.product_template_ve_ines_az,VE-INES-AZ-M,VE-INES-AZ-M,VESTIDO INES FLORES AZUL,Talla: M,164.26,0.00
+__import__.product_template_ve_chenoa_wh,VE-CHENOA-WH-S,VE-CHENOA-WH-S,VESTIDO CHENOA WHITE,Talla: S,119.04,0.00
+__import__.product_template_ve_chenoa_wh,VE-CHENOA-WH-M,VE-CHENOA-WH-M,VESTIDO CHENOA WHITE,Talla: M,119.04,0.00
+__import__.product_template_ve_chenoa_wh,VE-CHENOA-WH-L,VE-CHENOA-WH-L,VESTIDO CHENOA WHITE,Talla: L,121.65,0.00
+__import__.product_template_ve_stella_vn,VE-STELLA-VN-S,VE-STELLA-VN-S,VESTIDO STELLA VINO,Talla: S,152.96,0.00
+__import__.product_template_ve_stella_vn,VE-STELLA-VN-M,VE-STELLA-VN-M,VESTIDO STELLA VINO,Talla: M,152.96,0.00
+__import__.product_template_ve_stella_vn,VE-STELLA-VN-L,VE-STELLA-VN-L,VESTIDO STELLA VINO,Talla: L,152.96,0.00
+__import__.product_template_ve_stella_choc,VE-STELLA-CHOC-S,VE-STELLA-CHOC-S,VESTIDO STELLA CHOCOLATE,Talla: S,152.96,0.00
+__import__.product_template_ve_stella_choc,VE-STELLA-CHOC-M,VE-STELLA-CHOC-M,VESTIDO STELLA CHOCOLATE,Talla: M,152.96,0.00
+__import__.product_template_ve_stella_choc,VE-STELLA-CHOC-L,VE-STELLA-CHOC-L,VESTIDO STELLA CHOCOLATE,Talla: L,152.96,0.00
+__import__.product_template_ve_lea_vn,VE-LEA-VN-S,VE-LEA-VN-S,VESTIDO LEA VINO TINTO,Talla: S,122.52,0.00
+__import__.product_template_ve_lea_vn,VE-LEA-VN-M,VE-LEA-VN-M,VESTIDO LEA VINO TINTO,Talla: M,122.52,0.00
+__import__.product_template_ve_lea_vn,VE-LEA-VN-L,VE-LEA-VN-L,VESTIDO LEA VINO TINTO,Talla: L,122.52,0.00
+__import__.product_template_pt_23c25168_220,PT-23C25168-220/32,PT-23C25168-220/32,Pantalon PT-23C25168-220,Talla: 32,56.43,0.00
+__import__.product_template_lv_008_black_2,LV-008-BLACK-2/46,LV-008-BLACK-2/46,Leva LV-008-BLACK-2,Talla: 46,173.83,0.00
+__import__.product_template_pt_24c29918_20,PT-24C29918-20/30,PT-24C29918-20/30,Pantalon PT-24C29918-20,Talla: 30,47.74,0.00
+__import__.product_template_lv_23c25168_220,LV-23C25168-220/50,LV-23C25168-220/50,Leva LV-23C25168-220,Talla: 50,173.83,0.00
+__import__.product_template_zp_0907_brw,ZP-0907-BRW/8,ZP-0907-BRW/8,Zapato ZP-0907-BRW,Talla: 8,152.09,0.00
+__import__.product_template_ref_aida_hb,REF-AIDA-HB/M,REF-AIDA-HB/OM,M. SET MOPA HABANO,Talla: M,192.09,0.00
+__import__.product_template_ref_aida_hb,REF-AIDA-HB/S,REF-AIDA-HB/OS,M. SET MOPA HABANO,Talla: S,192.09,0.00
+__import__.product_template_ref_clara_ve,REF-CLARA-VE/M,REF-CLARA-VE/OM,M. VESTIDO MOPA VERDE,Talla: M,156.43,0.00
+__import__.product_template_ref_margarita_rj,REF-MARGARITA-RJ/S,REF-MARGARITA-RJ/OS,M. VESTIDO MOPA ESTAMPADO ROJO,Talla: S,166.00,0.00
+__import__.product_template_ref_vera_ve,REF-VERA-VE/M,REF-VERA-VE/OM,M. VESTIDO ESTAMPADO VERDE,Talla: M,137.30,0.00
+__import__.product_template_ref_roxana_az,REF-ROXANA-AZ/L,REF-ROXANA-AZ/OL,M. VESTIDO MOPA AZUL,Talla: L,146.87,0.00
+__import__.product_template_ref_margarita_am,REF-MARGARITA-AM/L,REF-MARGARITA-AM/OL,M. VESTIDO UNICOLOR AMARILLO,Talla: L,155.57,0.00
+__import__.product_template_ref_margarita_am,REF-MARGARITA-AM/S,REF-MARGARITA-AM/OS,M. VESTIDO UNICOLOR AMARILLO,Talla: S,155.57,0.00
+__import__.product_template_ref_margarita_am,REF-MARGARITA-AM/M,REF-MARGARITA-AM/OM,M. VESTIDO UNICOLOR AMARILLO,Talla: M,155.57,0.00
+__import__.product_template_ref_elena_rj,REF-ELENA-RJ/L,REF-ELENA-RJ/OL,M. VESTIDO MOPA ROJO,Talla: L,139.91,0.00
+__import__.product_template_ref_roxana_az,REF-ROXANA-AZ/M,REF-ROXANA-AZ/OM,M. VESTIDO MOPA AZUL,Talla: M,146.87,0.00
+__import__.product_template_ref_roxana_az,REF-ROXANA-AZ/S,REF-ROXANA-AZ/OS,M. VESTIDO MOPA AZUL,Talla: S,146.87,0.00
+__import__.product_template_ref_elena_rj,REF-ELENA-RJ/M,REF-ELENA-RJ/OM,M. VESTIDO MOPA ROJO,Talla: M,139.91,0.00
+__import__.product_template_ref_clavel_ve,REF-CLAVEL-VE/L,REF-CLAVEL-VE/OL,M. VESTIDO MOPA VERDE (ref_clavel_ve),Talla: L,155.57,0.00
+__import__.product_template_ref_elena_az,REF-ELENA-AZ/M,REF-ELENA-AZ/OM,M. VESTIDO MOPA AZUL (ref_elena_az),Talla: M,139.91,0.00
+__import__.product_template_ref_clavel_ve,REF-CLAVEL-VE/S,REF-CLAVEL-VE/OS,M. VESTIDO MOPA VERDE (ref_clavel_ve),Talla: S,155.57,0.00
+__import__.product_template_ref_clavel_ro,REF-CLAVEL-RO/S,REF-CLAVEL-RO/OS,M. VESTIDO MOPA ROSADO,Talla: S,155.57,0.00
+__import__.product_template_ref_clavel_ro,REF-CLAVEL-RO/L,REF-CLAVEL-RO/OL,M. VESTIDO MOPA ROSADO,Talla: L,155.57,0.00
+__import__.product_template_ref_amira_es_az,REF-AMIRA-ES-AZ/S,REF-AMIRA-ES-AZ/OS,M. VESTIDO ESTAMPADO LILA,Talla: S,148.61,0.00
+__import__.product_template_ref_amira_es_az,REF-AMIRA-ES-AZ/M,REF-AMIRA-ES-AZ/OM,M. VESTIDO ESTAMPADO LILA,Talla: M,148.61,0.00
+__import__.product_template_ve_roxana_wh,VE-ROXANA-WH/M,VE-ROXANA-WH/M,VESTIDO ROXANA WHITE,Talla: M,146.87,0.00
+__import__.product_template_ve_roxana_wh,VE-ROXANA-WH/L,VE-ROXANA-WH/L,VESTIDO ROXANA WHITE,Talla: L,146.87,0.00
+__import__.product_template_ref_narel_ne,REF-NAREL-NE/M,REF-NAREL-NE/OM,M. VESTIDO MOPA NEGRO,Talla: M,146.87,0.00
+__import__.product_template_ref_narel_ne,REF-NAREL-NE/S,REF-NAREL-NE/OS,M. VESTIDO MOPA NEGRO,Talla: S,146.87,0.00
+__import__.product_template_ref_leila_li,REF-LEILA-LI/S,REF-LEILA-LI/OS,M. VESTIDO MOPA LINO ESTAMPADO,Talla: S,172.09,0.00
+__import__.product_template_ref_narel_ne,REF-NAREL-NE/L,REF-NAREL-NE/OL,M. VESTIDO MOPA NEGRO,Talla: L,146.87,0.00
+__import__.product_template_ref_leila_li,REF-LEILA-LI/XL,REF-LEILA-LI/OXL,M. VESTIDO MOPA LINO ESTAMPADO,Talla: XL,172.09,0.00
+__import__.product_template_ref_leila_li,REF-LEILA-LI/M,REF-LEILA-LI/OM,M. VESTIDO MOPA LINO ESTAMPADO,Talla: M,172.09,0.00
+__import__.product_template_ref_leila_li,REF-LEILA-LI/L,REF-LEILA-LI/OL,M. VESTIDO MOPA LINO ESTAMPADO,Talla: L,172.09,0.00
+__import__.product_template_ref_ivana_je,REF-IVANA-JE/S,REF-IVANA-JE/OS,M. VESTIDO MOPA JEANS,Talla: S,166.00,0.00
+__import__.product_template_ref_hortensia_vi,REF-HORTENSIA-VI/L,REF-HORTENSIA-VI/OL,M. VESTIDO ESTAMPADO VINO,Talla: L,142.52,0.00
+__import__.product_template_ref_hortensia_vi,REF-HORTENSIA-VI/XL,REF-HORTENSIA-VI/OXL,M. VESTIDO ESTAMPADO VINO,Talla: XL,142.52,0.00
+__import__.product_template_ref_ivana_je,REF-IVANA-JE/L,REF-IVANA-JE/OL,M. VESTIDO MOPA JEANS,Talla: L,166.00,0.00
+__import__.product_template_ref_ivana_je,REF-IVANA-JE/M,REF-IVANA-JE/OM,M. VESTIDO MOPA JEANS,Talla: M,166.00,0.00
+__import__.product_template_ref_vera_ve,REF-VERA-VE/L,REF-VERA-VE/OL,M. VESTIDO ESTAMPADO VERDE,Talla: L,137.30,0.00
+__import__.product_template_lv_smoking_1bc,LV-SMOKING-1BC/54,LVSMOKINGBC54,Leva LV-SMOKING-1BC,Talla: 54,217.30,0.00
+__import__.product_template_lv_smoking_1bc,LV-SMOKING-1BC/50,LVSMOKINGBC50,Leva LV-SMOKING-1BC,Talla: 50,217.30,0.00
+__import__.product_template_pt_6158_a7,PT-6158-A7/32,PT-6158-A7/32,Pantalon PT-6158-A7,Talla: 32,60.80,0.00
+__import__.product_template_ve_passion_esl,VE-PASSION-ESL/10,VEPASSIONESL10,Terno VE-PASSION-ESL,Talla: 10,344.26,0.00
+__import__.product_template_ve_passion_bl_a,VE-PASSION-BL-A/10,VEPASSIONBLA10,Terno VE-PASSION-BL-A,Talla: 10,239.91,0.00
+__import__.product_template_ve_passion_dro,VE-PASSION-DRO/8,VEPASSIONDRO8,Terno VE-PASSION-DRO,Talla: 8,292.09,0.00
+__import__.product_template_ve_passion_ol,VE-PASSION-OL/8,VEPASSIONOL8,Terno VE-PASSION-OL,Talla: 8,344.26,0.00
+__import__.product_template_pant_cien_wh,PANT-CIEN-WH/S,PANT-CIEN-WH/S,PANTALON P/DAMA CIEN WHITE,Talla: S,61.65,0.00
+__import__.product_template_pant_cien_wh,PANT-CIEN-WH/M,PANT-CIEN-WH/M,PANTALON P/DAMA CIEN WHITE,Talla: M,61.65,0.00
+__import__.product_template_pant_cien_wh,PANT-CIEN-WH/L,PANT-CIEN-WH/L,PANTALON P/DAMA CIEN WHITE,Talla: L,61.65,0.00
+__import__.product_template_pant_cien_bg,PANT-CIEN-BG/S,PANT-CIEN-BG/S,PANTALON P/DAMA CIEN BEIGE,Talla: S,61.65,0.00
+__import__.product_template_pant_cien_bg,PANT-CIEN-BG/M,PANT-CIEN-BG/M,PANTALON P/DAMA CIEN BEIGE,Talla: M,61.65,0.00
+__import__.product_template_pant_cien_bg,PANT-CIEN-BG/L,PANT-CIEN-BG/L,PANTALON P/DAMA CIEN BEIGE,Talla: L,61.65,0.00
+__import__.product_template_zp_cassini_oxford_ml,ZP-CASSINI-OXFORD-ML/7,ZPCASSINIOXFORDML7,Zapato ZP-CASSINI-OXFORD-ML,Talla: 7,152.09,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/6.5,ZP-50224-CAS-VN/O6.5,Zapato ZP-50224-CASSINI-VN,Talla: 6.5,152.09,0.00
+__import__.product_template_zp_cassini_oxford_ml,ZP-CASSINI-OXFORD-ML/9.5,ZPCASSINIOXFORDML95,Zapato ZP-CASSINI-OXFORD-ML,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_cassini_oxford_ml,ZP-CASSINI-OXFORD-ML/9,ZPCASSINIOXFORDML9,Zapato ZP-CASSINI-OXFORD-ML,Talla: 9,152.09,0.00
+__import__.product_template_zp_cassini_oxford_ml,ZP-CASSINI-OXFORD-ML/8.5,ZPCASSINIOXFORDML85,Zapato ZP-CASSINI-OXFORD-ML,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_cassini_oxford_ml,ZP-CASSINI-OXFORD-ML/8,ZPCASSINIOXFORDML8,Zapato ZP-CASSINI-OXFORD-ML,Talla: 8,152.09,0.00
+__import__.product_template_zp_cassini_oxford_ml,ZP-CASSINI-OXFORD-ML/7.5,ZPCASSINIOXFORDML7.5,Zapato ZP-CASSINI-OXFORD-ML,Talla: 7.5,152.09,0.00
+__import__.product_template_pt_3705_25,PT-3705-25/10,PT-3705-25/10,Pantalon PT-3705-25,Talla: 10,57.99,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/58,24E5100975245840,Terno 24E510097-5BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24b11210_100bc_2,24B11210-100BC-2/58,24B11210100245840,Terno 24B11210-100BC-2,Talla: 58,260.78,0.00
+__import__.product_template_24b11210_100bc_2,24B11210-100BC-2/46,24B11210100244628,Terno 24B11210-100BC-2,Talla: 46,260.78,0.00
+__import__.product_template_24b11210_100bc_2,24B11210-100BC-2/48,24B11210100244830,Terno 24B11210-100BC-2,Talla: 48,260.78,0.00
+__import__.product_template_24b11210_100bc_2,24B11210-100BC-2/50,24B11210100245032,Terno 24B11210-100BC-2,Talla: 50,260.78,0.00
+__import__.product_template_24b11210_100bc_2,24B11210-100BC-2/52,24B11210100245234,Terno 24B11210-100BC-2,Talla: 52,260.78,0.00
+__import__.product_template_24b11210_100bc_2,24B11210-100BC-2/54,24B11210100245436,Terno 24B11210-100BC-2,Talla: 54,260.78,0.00
+__import__.product_template_24b11210_100bc_2,24B11210-100BC-2/56,24B11210100245638,Terno 24B11210-100BC-2,Talla: 56,260.78,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/70,24E2712320247052,Terno 24E2712-3BC-2,Talla: 70,304.26,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/68,24E2712320246850,Terno 24E2712-3BC-2,Talla: 68,304.26,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/56,24E5100975245638,Terno 24E510097-5BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/64,24E510097520246446,Terno 24E510097-5BC-2,Talla: 64,304.26,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/60,24E510097520246042,Terno 24E510097-5BC-2,Talla: 60,304.26,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/62,24E510097520246244,Terno 24E510097-5BC-2,Talla: 62,304.26,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/54,24E5100975245436,Terno 24E510097-5BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/66,24E510097520246648,Terno 24E510097-5BC-2,Talla: 66,304.26,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/68,24E510097520246850,Terno 24E510097-5BC-2,Talla: 68,304.26,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/70,24E510097520247052,Terno 24E510097-5BC-2,Talla: 70,304.26,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/52,24E5100975245234,Terno 24E510097-5BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24e312010_6bc_2,24E312010-6BC-2/46,24E3120106244628,Terno 24E312010-6BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c28061_76bc_2,24C28061-76BC-2/54,24C2806176245436,Terno 24C28061-76BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24e312010_6bc_2,24E312010-6BC-2/48,24E3120106244830,Terno 24E312010-6BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c28061_76bc_2,24C28061-76BC-2/58,24C2806176245840,Terno 24C28061-76BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24e312010_6bc_2,24E312010-6BC-2/50,24E3120106245032,Terno 24E312010-6BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c28061_76bc_2,24C28061-76BC-2/56,24C2806176245638,Terno 24C28061-76BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c28061_76bc_2,24C28061-76BC-2/50,24C2806176245032,Terno 24C28061-76BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c28061_76bc_2,24C28061-76BC-2/46,24C2806176244628,Terno 24C28061-76BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c29118_12bc_2,24C29118-12BC-2/60,24C29911812246042,Terno 24C29118-12BC-2,Talla: 60,304.26,0.00
+__import__.product_template_24c29118_12bc_2,24C29118-12BC-2/68,24C29911812246850,Terno 24C29118-12BC-2,Talla: 68,304.26,0.00
+__import__.product_template_24c29118_12bc_2,24C29118-12BC-2/66,24C29911812246648,Terno 24C29118-12BC-2,Talla: 66,304.26,0.00
+__import__.product_template_24c29118_12bc_2,24C29118-12BC-2/64,24C29911812246446,Terno 24C29118-12BC-2,Talla: 64,304.26,0.00
+__import__.product_template_24c29118_12bc_2,24C29118-12BC-2/70,24C29911812247052,Terno 24C29118-12BC-2,Talla: 70,304.26,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/66,24E2712320246648,Terno 24E2712-3BC-2,Talla: 66,304.26,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/60,24E2712320246042,Terno 24E2712-3BC-2,Talla: 60,304.26,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/64,24E2712320246446,Terno 24E2712-3BC-2,Talla: 64,304.26,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/62,24E2712320246244,Terno 24E2712-3BC-2,Talla: 62,304.26,0.00
+__import__.product_template_24c29118_12bc_2,24C29118-12BC-2/62,24C29911812246244,Terno 24C29118-12BC-2,Talla: 62,304.26,0.00
+__import__.product_template_24e312010_6bc_2,24E312010-6BC-2/52,24E3120106245234,Terno 24E312010-6BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24e312010_6bc_2,24E312010-6BC-2/54,24E3120106245436,Terno 24E312010-6BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24e312010_6bc_2,24E312010-6BC-2/56,24E3120106245638,Terno 24E312010-6BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/50,24E5100975245032,Terno 24E510097-5BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/48,24E5100975244830,Terno 24E510097-5BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24e510097_5bc_2,24E510097-5BC-2/46,24E5100975244628,Terno 24E510097-5BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24e312010_6bc_2,24E312010-6BC-2/58,24E3120106245840,Terno 24E312010-6BC-2,Talla: 58,243.39,0.00
+__import__.product_template_23a0402_2,23A0402-2/48,23A04022202448,Leva 23A0402-2,Talla: 48,165.13,0.00
+__import__.product_template_23a0402_2,23A0402-2/50,23A04022202450,Leva 23A0402-2,Talla: 50,165.13,0.00
+__import__.product_template_23a0402_2,23A0402-2/52,23A04022202452,Leva 23A0402-2,Talla: 52,165.13,0.00
+__import__.product_template_23a0402_2,23A0402-2/54,23A04022202454,Leva 23A0402-2,Talla: 54,165.13,0.00
+__import__.product_template_23a0402_2,23A0402-2/56,23A04022202456,Leva 23A0402-2,Talla: 56,165.13,0.00
+__import__.product_template_23a0402_2,23A0402-2/58,23A04022202458,Leva 23A0402-2,Talla: 58,165.13,0.00
+__import__.product_template_23a0402_2,23A0402-2/60,23A04022202460,Leva 23A0402-2,Talla: 60,165.13,0.00
+__import__.product_template_23a0402_5,23A0402-5/46,23A04025202446,Leva 23A0402-5,Talla: 46,165.13,0.00
+__import__.product_template_23a0402_5,23A0402-5/48,23A04025202448,Leva 23A0402-5,Talla: 48,165.13,0.00
+__import__.product_template_23a0402_5,23A0402-5/50,23A04025202450,Leva 23A0402-5,Talla: 50,165.13,0.00
+__import__.product_template_23a0402_5,23A0402-5/52,23A04025202452,Leva 23A0402-5,Talla: 52,165.13,0.00
+__import__.product_template_23a0402_5,23A0402-5/54,23A04025202454,Leva 23A0402-5,Talla: 54,165.13,0.00
+__import__.product_template_23a0402_1,23A0402-1/52,23A04021202452,Leva 23A0402-1,Talla: 52,165.13,0.00
+__import__.product_template_23a0402_1,23A0402-1/54,23A04021202454,Leva 23A0402-1,Talla: 54,165.13,0.00
+__import__.product_template_23a0402_1,23A0402-1/56,23A04021202456,Leva 23A0402-1,Talla: 56,165.13,0.00
+__import__.product_template_23a0402_1,23A0402-1/58,23A04021202458,Leva 23A0402-1,Talla: 58,165.13,0.00
+__import__.product_template_23a0402_1,23A0402-1/60,23A04021202460,Leva 23A0402-1,Talla: 60,165.13,0.00
+__import__.product_template_23a0402_2,23A0402-2/46,23A04022202446,Leva 23A0402-2,Talla: 46,165.13,0.00
+__import__.product_template_23a0402_5,23A0402-5/56,23A04025202456,Leva 23A0402-5,Talla: 56,165.13,0.00
+__import__.product_template_24c28061_76bc_2,24C28061-76BC-2/48,24C2806176244830,Terno 24C28061-76BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c28061_76bc_2,24C28061-76BC-2/52,24C2806176245234,Terno 24C28061-76BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23a0402_1,23A0402-1/46,23A04021202446,Leva 23A0402-1,Talla: 46,165.13,0.00
+__import__.product_template_23a0402_1,23A0402-1/48,23A04021202448,Leva 23A0402-1,Talla: 48,165.13,0.00
+__import__.product_template_23a0402_1,23A0402-1/50,23A04021202450,Leva 23A0402-1,Talla: 50,165.13,0.00
+__import__.product_template_23e4246_15,23E4246-15/46,23E424615202446,Leva 23E4246-15,Talla: 46,165.13,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/46,24E2712320244628,Terno 24E2712-3BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/48,24E2712320244830,Terno 24E2712-3BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/50,24E2712320245032,Terno 24E2712-3BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/52,24E2712320245234,Terno 24E2712-3BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/54,24E2712320245436,Terno 24E2712-3BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/56,24E2712320245638,Terno 24E2712-3BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24e2712_3bc_2,24E2712-3BC-2/58,24E2712320245840,Terno 24E2712-3BC-2,Talla: 58,304.26,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/46,23C25168220244628,Terno 23C25168-220BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/48,23C25168220244830,Terno 23C25168-220BC-2,Talla: 48,243.39,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/50,23C25168220245032,Terno 23C25168-220BC-2,Talla: 50,243.39,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/52,23C25168220245234,Terno 23C25168-220BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/54,23C25168220245436,Terno 23C25168-220BC-2,Talla: 54,243.39,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/56,23C25168220245638,Terno 23C25168-220BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/58,23C25168220245840,Terno 23C25168-220BC-2,Talla: 58,243.39,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/60,23C25168220246042,Terno 23C25168-220BC-2,Talla: 60,304.26,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/62,23C25168220246244,Terno 23C25168-220BC-2,Talla: 62,304.26,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/64,23C25168220246446,Terno 23C25168-220BC-2,Talla: 64,304.26,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/66,23C25168220246648,Terno 23C25168-220BC-2,Talla: 66,304.26,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/68,23C25168220246850,Terno 23C25168-220BC-2,Talla: 68,304.26,0.00
+__import__.product_template_23c25168_220bc_2,23C25168-220BC-2/70,23C25168220247052,Terno 23C25168-220BC-2,Talla: 70,304.26,0.00
+__import__.product_template_ve_ginb_fuc,VE-GINB-FUC/L,VE-GINB-FUC/L,VESTIDO GINEBRA FUCSIA,Talla: L,157.32,0.00
+__import__.product_template_ve_maia_blk,VE-MAIA-BLK/M,VE-MAIA-BLK/M,VESTIDO MAIA BLACK,Talla: M,134.70,0.00
+__import__.product_template_ve_maia_blk,VE-MAIA-BLK/S,VE-MAIA-BLK/S,VESTIDO MAIA BLACK,Talla: S,134.70,0.00
+__import__.product_template_ve_maia_pl,VE-MAIA-PL/M,VE-MAIA-PL/M,VESTIDO MAIA PLATA,Talla: M,134.70,0.00
+__import__.product_template_ve_maia_pl,VE-MAIA-PL/S,VE-MAIA-PL/S,VESTIDO MAIA PLATA,Talla: S,134.70,0.00
+__import__.product_template_ve_maia_lnt_grn,VE-MAIA-LNT-GRN/M,VE-MAIA-LNT-GRN/M,VESTIDO LENTEJUELA MAIA GREEN,Talla: M,143.39,0.00
+__import__.product_template_ve_joli_tur,VE-JOLI-TUR/M,VE-JOLI-TUR/M,VESTIDO JOLIE TURQUESA,Talla: M,134.70,0.00
+__import__.product_template_ve_joli_tur,VE-JOLI-TUR/S,VE-JOLI-TUR/S,VESTIDO JOLIE TURQUESA,Talla: S,134.70,0.00
+__import__.product_template_ve_tani_pur,VE-TANI-PUR/M,VE-TANI-PUR/M,VESTIDO TANIA PURPURA,Talla: M,112.09,0.00
+__import__.product_template_ve_tani_pur,VE-TANI-PUR/S,VE-TANI-PUR/S,VESTIDO TANIA PURPURA,Talla: S,112.09,0.00
+__import__.product_template_sd040_2b_ch,SD040-2B-CH/8,SD040-2B-CH/8,Terno SD040-2B-CH,Talla: 8,133.84,0.00
+__import__.product_template_cj_pia_skb,CJ-PIA-SKB/S,CJPIASKB-S,CONJUNTO PIA SKY BLUE MOPA,Talla: S,147.74,0.00
+__import__.product_template_cj_pia_skb,CJ-PIA-SKB/M,CJPIASKB-M,CONJUNTO PIA SKY BLUE MOPA,Talla: M,147.74,0.00
+__import__.product_template_pt_24c29918_16,PT-24C29918-16/38,PT-24C29918-16/38,Pantalon PT-24C29918-16,Talla: 38,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/48,23C2938686202448,Pantalon PT-23C29386-86,Talla: 48,47.74,0.00
+__import__.product_template_sh_ml_ryg,SH-ML-RYG/M,SH-ML-RYG/OM,M. SHORT MILANO RAYA GRIS,Talla: M,45.45,0.00
+__import__.product_template_sh_ml_ryg,SH-ML-RYG/L,SH-ML-RYG/OL,M. SHORT MILANO RAYA GRIS,Talla: L,45.45,0.00
+__import__.product_template_top_ol_azm,TOP-OL-AZM/M,TOP-OL-AZM/OM,M. TOP OLIVIA AZUL MARINO,Talla: M,35.63,0.00
+__import__.product_template_top_ol_azm,TOP-OL-AZM/L,TOP-OL-AZM/OL,M. TOP OLIVIA AZUL MARINO,Talla: L,35.63,0.00
+__import__.product_template_ch_ml_ryg,CH-ML-RYG/S,CH-ML-RYG/OS,M. CHALECO MILANO RAYA GRIS,Talla: S,40.98,0.00
+__import__.product_template_ch_ml_ryg,CH-ML-RYG/L,CH-ML-RYG/OL,M. CHALECO MILANO RAYA GRIS,Talla: L,40.98,0.00
+__import__.product_template_ch_ml_ryg,CH-ML-RYG/M,CH-ML-RYG/OM,M. CHALECO MILANO RAYA GRIS,Talla: M,40.98,0.00
+__import__.product_template_pat_al_azm,PAT-AL-AZM/L,PAT-AL-AZM/OL,M. PANTALON AZUL MARINO,Talla: L,57.95,0.00
+__import__.product_template_top_ol_azm,TOP-OL-AZM/S,TOP-OL-AZM/OS,M. TOP OLIVIA AZUL MARINO,Talla: S,35.63,0.00
+__import__.product_template_top_ol_azm,TOP-OL-AZM/XL,TOP-OL-AZM/OXL,M. TOP OLIVIA AZUL MARINO,Talla: XL,35.63,0.00
+__import__.product_template_top_ol_azm,TOP-OL-AZM/XS,TOP-OL-AZM/OXS,M. TOP OLIVIA AZUL MARINO,Talla: XS,35.63,0.00
+__import__.product_template_pat_al_azm,PAT-AL-AZM/XS,PAT-AL-AZM/OXS,M. PANTALON AZUL MARINO,Talla: XS,57.95,0.00
+__import__.product_template_pat_al_azm,PAT-AL-AZM/XL,PAT-AL-AZM/OXL,M. PANTALON AZUL MARINO,Talla: XL,57.95,0.00
+__import__.product_template_pat_al_azm,PAT-AL-AZM/S,PAT-AL-AZM/OS,M. PANTALON AZUL MARINO,Talla: S,57.95,0.00
+__import__.product_template_pat_al_azm,PAT-AL-AZM/M,PAT-AL-AZM/OM,M. PANTALON AZUL MARINO,Talla: M,57.95,0.00
+__import__.product_template_sh_ml_ryg,SH-ML-RYG/S,SH-ML-RYG/OS,M. SHORT MILANO RAYA GRIS,Talla: S,45.45,0.00
+__import__.product_template_cam_andrea_az_no_consig,CAM-ANDREA-AZ-NO-CONSIG/S,CAMANDREAAZNOCONSIG-S,CAMISA ANDREA AZUL NOCHE,Talla: S,46.00,0.00
+__import__.product_template_cam_andrea_az_no_consig,CAM-ANDREA-AZ-NO-CONSIG/L,CAMANDREAAZNOCONSIG-L,CAMISA ANDREA AZUL NOCHE,Talla: L,46.00,0.00
+__import__.product_template_cam_andrea_az_no_consig,CAM-ANDREA-AZ-NO-CONSIG/M,CAMANDREAAZNOCONSIG-M,CAMISA ANDREA AZUL NOCHE,Talla: M,46.00,0.00
+__import__.product_template_cam_andrea_wht_consig,CAM-ANDREA-WHT-CONSIG/XS,CAMANDREAWHTCONSIG-XS,CAMISA ANDREA WHITE,Talla: XS,46.00,0.00
+__import__.product_template_cam_andrea_wht_consig,CAM-ANDREA-WHT-CONSIG/XL,CAMANDREAWHTCONSIG-XL,CAMISA ANDREA WHITE,Talla: XL,46.00,0.00
+__import__.product_template_cam_andrea_wht_consig,CAM-ANDREA-WHT-CONSIG/S,CAMANDREAWHTCONSIG-S,CAMISA ANDREA WHITE,Talla: S,46.00,0.00
+__import__.product_template_cam_andrea_wht_consig,CAM-ANDREA-WHT-CONSIG/L,CAMANDREAWHTCONSIG-L,CAMISA ANDREA WHITE,Talla: L,46.00,0.00
+__import__.product_template_cam_andrea_wht_consig,CAM-ANDREA-WHT-CONSIG/M,CAMANDREAWHTCONSIG-M,CAMISA ANDREA WHITE,Talla: M,46.00,0.00
+__import__.product_template_cam_andrea_azn_consig,CAM-ANDREA-AZN-CONSIG/XS,CANDREAAZNCONSIG-XS,CAMISA ANDREA AZUL MARINO,Talla: XS,46.00,0.00
+__import__.product_template_cam_andrea_azn_consig,CAM-ANDREA-AZN-CONSIG/XL,CANDREAAZNCONSIG-XL,CAMISA ANDREA AZUL MARINO,Talla: XL,46.00,0.00
+__import__.product_template_cam_andrea_azn_consig,CAM-ANDREA-AZN-CONSIG/S,CAMANDREAAZNCONSIG-S,CAMISA ANDREA AZUL MARINO,Talla: S,46.00,0.00
+__import__.product_template_cam_andrea_azn_consig,CAM-ANDREA-AZN-CONSIG/L,CAMANDREAAZNCONSIG-L,CAMISA ANDREA AZUL MARINO,Talla: L,46.00,0.00
+__import__.product_template_cam_andrea_azn_consig,CAM-ANDREA-AZN-CONSIG/M,CAMANDREAAZNCONSIG-M,CAMISA ANDREA AZUL MARINO,Talla: M,46.00,0.00
+__import__.product_template_ent_gloria_wht_consig,ENT-GLORIA-WHT-CONSIG/S,ENTGLORIAWHTCONSIG-S,ENTERIZO GLORIA WHITE,Talla: S,74.70,0.00
+__import__.product_template_ent_gloria_wht_consig,ENT-GLORIA-WHT-CONSIG/L,ENTGLORIAWHTCONSIG-L,ENTERIZO GLORIA WHITE,Talla: L,74.70,0.00
+__import__.product_template_ent_gloria_wht_consig,ENT-GLORIA-WHT-CONSIG/M,ENTGLORIAWHTCONSIG-M,ENTERIZO GLORIA WHITE,Talla: M,74.70,0.00
+__import__.product_template_pt_carol_wht_consig,PT-CAROL-WHT-CONSIG/XS,PTCAROLWHTCONSIG-XS,PANTALON CAROLINA WHITE,Talla: XS,59.04,0.00
+__import__.product_template_pt_carol_wht_consig,PT-CAROL-WHT-CONSIG/XL,PTCAROLWHTCONSIG-XL,PANTALON CAROLINA WHITE,Talla: XL,59.04,0.00
+__import__.product_template_pt_carol_wht_consig,PT-CAROL-WHT-CONSIG/S,PTCAROLWHTCONSIG-S,PANTALON CAROLINA WHITE,Talla: S,59.04,0.00
+__import__.product_template_pt_carol_wht_consig,PT-CAROL-WHT-CONSIG/L,PTCAROLWHTCONSIG-L,PANTALON CAROLINA WHITE,Talla: L,59.04,0.00
+__import__.product_template_pt_carol_wht_consig,PT-CAROL-WHT-CONSIG/M,PTCAROLWHTCONSIG-M,PANTALON CAROLINA WHITE,Talla: M,59.04,0.00
+__import__.product_template_pt_carol_azn_consig,PT-CAROL-AZN-CONSIG/XS,PTCAROLAZNCONSIG-XS,PANTALON CAROLINA AZUL MARINO,Talla: XS,59.04,0.00
+__import__.product_template_pt_carol_azn_consig,PT-CAROL-AZN-CONSIG/XL,PTCAROLAZNCONSIG-XL,PANTALON CAROLINA AZUL MARINO,Talla: XL,59.04,0.00
+__import__.product_template_pt_carol_azn_consig,PT-CAROL-AZN-CONSIG/S,PTCAROLAZNCONSIG-S,PANTALON CAROLINA AZUL MARINO,Talla: S,59.04,0.00
+__import__.product_template_pt_carol_azn_consig,PT-CAROL-AZN-CONSIG/L,PTCAROLAZNCONSIG-L,PANTALON CAROLINA AZUL MARINO,Talla: L,59.04,0.00
+__import__.product_template_pt_carol_azn_consig,PT-CAROL-AZN-CONSIG/M,PTCAROLAZNCONSIG-M,PANTALON CAROLINA AZUL MARINO,Talla: M,59.04,0.00
+__import__.product_template_sh_cami_wht_consig,SH-CAMI-WHT-CONSIG/XS,SHCAMIWHTCONSIG-XS,SHORT CAMI WHITE,Talla: XS,42.52,0.00
+__import__.product_template_sh_cami_wht_consig,SH-CAMI-WHT-CONSIG/XL,SHCAMIWHTCONSIG-XL,SHORT CAMI WHITE,Talla: XL,42.52,0.00
+__import__.product_template_sh_cami_wht_consig,SH-CAMI-WHT-CONSIG/S,SHCAMIWHTCONSIG-S,SHORT CAMI WHITE,Talla: S,42.52,0.00
+__import__.product_template_sh_cami_wht_consig,SH-CAMI-WHT-CONSIG/L,SHCAMIWHTCONSIG-L,SHORT CAMI WHITE,Talla: L,42.52,0.00
+__import__.product_template_sh_cami_wht_consig,SH-CAMI-WHT-CONSIG/M,SHCAMIWHTCONSIG-M,SHORT CAMI WHITE,Talla: M,42.52,0.00
+__import__.product_template_sh_cami_azn_consig,SH-CAMI-AZN-CONSIG/XS,SHCAMIAZNCONSIG-XS,SHORT CAMI AZUL MARINO,Talla: XS,42.52,0.00
+__import__.product_template_sh_cami_azn_consig,SH-CAMI-AZN-CONSIG/XL,SHCAMIAZNCONSIG-XL,SHORT CAMI AZUL MARINO,Talla: XL,42.52,0.00
+__import__.product_template_sh_cami_azn_consig,SH-CAMI-AZN-CONSIG/S,SHCAMIAZNCONSIG-S,SHORT CAMI AZUL MARINO,Talla: S,42.52,0.00
+__import__.product_template_sh_cami_azn_consig,SH-CAMI-AZN-CONSIG/L,SHCAMIAZNCONSIG-L,SHORT CAMI AZUL MARINO,Talla: L,42.52,0.00
+__import__.product_template_sh_cami_azn_consig,SH-CAMI-AZN-CONSIG/M,SHCAMIAZNCONSIG-M,SHORT CAMI AZUL MARINO,Talla: M,42.52,0.00
+__import__.product_template_zp_hjvb_gam_gr,ZP-HJVB-GAM-GR/42,ZP-HJVB-GAM-GR/42,Zapato ZP-HJVB-GAM-GR,Talla: 42,73.83,0.00
+__import__.product_template_vest_elsa_wh,VEST-ELSA-WH/S,VEST-ELSA-WH/S,VESTIDO ELSA WHITE,Talla: S,165.13,0.00
+__import__.product_template_vest_elsa_wh,VEST-ELSA-WH/L,VEST-ELSA-WH/L,VESTIDO ELSA WHITE,Talla: L,165.13,0.00
+__import__.product_template_vest_elsa_wh,VEST-ELSA-WH/M,VEST-ELSA-WH/M,VESTIDO ELSA WHITE,Talla: M,165.13,0.00
+__import__.product_template_cj_paula_crm,CJ-PAULA-CRM/S,CJ-PAULA-CRM/S,CONJUNTO PAULA CREMA,Talla: S,130.35,0.00
+__import__.product_template_cj_paula_crm,CJ-PAULA-CRM/L,CJ-PAULA-CRM/L,CONJUNTO PAULA CREMA,Talla: L,130.35,0.00
+__import__.product_template_cj_paula_crm,CJ-PAULA-CRM/M,CJ-PAULA-CRM/M,CONJUNTO PAULA CREMA,Talla: M,130.35,0.00
+__import__.product_template_cj_alana_crm,CJ-ALANA-CRM/S,CJ-ALANA-CRM/S,CONJUNTO ALANA CREMA,Talla: S,160.78,0.00
+__import__.product_template_cj_alana_crm,CJ-ALANA-CRM/L,CJ-ALANA-CRM/L,CONJUNTO ALANA CREMA,Talla: L,160.78,0.00
+__import__.product_template_cj_alana_crm,CJ-ALANA-CRM/M,CJ-ALANA-CRM/M,CONJUNTO ALANA CREMA,Talla: M,160.78,0.00
+__import__.product_template_bl_luna_azn,BL-LUNA-AZN/S,BL-LUNA-AZN/S,BLUSA LUNA AZUL,Talla: S,65.13,0.00
+__import__.product_template_bl_luna_azn,BL-LUNA-AZN/L,BL-LUNA-AZN/L,BLUSA LUNA AZUL,Talla: L,65.13,0.00
+__import__.product_template_bl_luna_azn,BL-LUNA-AZN/M,BL-LUNA-AZN/M,BLUSA LUNA AZUL,Talla: M,65.13,0.00
+__import__.product_template_bl_luna_cl,BL-LUNA-CL/S,BL-LUNA-CL/S,BLUSA LUNA CELESTE,Talla: S,65.13,0.00
+__import__.product_template_bl_luna_cl,BL-LUNA-CL/L,BL-LUNA-CL/L,BLUSA LUNA CELESTE,Talla: L,65.13,0.00
+__import__.product_template_bl_luna_cl,BL-LUNA-CL/M,BL-LUNA-CL/M,BLUSA LUNA CELESTE,Talla: M,65.13,0.00
+__import__.product_template_vest_kenya_tr,VEST-KENYA-TR/L,VEST-KENYA-TR/L,VESTIDO KENYA TERRACOTA,Talla: L,165.13,0.00
+__import__.product_template_vest_kenya_tr,VEST-KENYA-TR/M,VEST-KENYA-TR/M,VESTIDO KENYA TERRACOTA,Talla: M,165.13,0.00
+__import__.product_template_vest_elda_blk,VEST-ELDA-BLK/L,VEST-ELDA-BLK/L,VESTIDO ELDA BLACK,Talla: L,142.52,0.00
+__import__.product_template_vest_elda_blk,VEST-ELDA-BLK/M,VEST-ELDA-BLK/M,VESTIDO ELDA BLACK,Talla: M,142.52,0.00
+__import__.product_template_vest_anast_bge,VEST-ANAST-BGE/M,VEST-ANAST-BGE/M,VESTIDO ANASTACIA BEIGE,Talla: M,142.52,0.00
+__import__.product_template_vest_hortensi_rd,VEST-HORTENSI-RD/XL,VEST-HORTENSI-RD/XL,VESTIDO HORTENCIA RED,Talla: XL,153.83,0.00
+__import__.product_template_vest_hortensi_rd,VEST-HORTENSI-RD/L,VEST-HORTENSI-RD/L,VESTIDO HORTENCIA RED,Talla: L,153.83,0.00
+__import__.product_template_vest_hortensi_rd,VEST-HORTENSI-RD/M,VEST-HORTENSI-RD/M,VESTIDO HORTENCIA RED,Talla: M,153.83,0.00
+__import__.product_template_vest_amapola_cof,VEST-AMAPOLA-COF/S,VEST-AMAPOLA-COF/S,VESTIDO AMAPOLA CAFÉ,Talla: S,117.30,0.00
+__import__.product_template_vest_amapola_cof,VEST-AMAPOLA-COF/M,VEST-AMAPOLA-COF/M,VESTIDO AMAPOLA CAFÉ,Talla: M,117.30,0.00
+__import__.product_template_vest_amapola_cof,VEST-AMAPOLA-COF/L,VEST-AMAPOLA-COF/L,VESTIDO AMAPOLA CAFÉ,Talla: L,117.30,0.00
+__import__.product_template_bl_encanto_wh,BL-ENCANTO-WH/S,BL-ENCANTO-WH/S,BLUSA NARANJA-ROSA 2025 BLANCO,Talla: S,77.30,0.00
+__import__.product_template_bl_encanto_wh,BL-ENCANTO-WH/M,BL-ENCANTO-WH/M,BLUSA NARANJA-ROSA 2025 BLANCO,Talla: M,77.30,0.00
+__import__.product_template_bl_encanto_wh,BL-ENCANTO-WH/L,BL-ENCANTO-WH/L,BLUSA NARANJA-ROSA 2025 BLANCO,Talla: L,77.30,0.00
+__import__.product_template_bl_encanto_ter,BL-ENCANTO-TER/S,BL-ENCANTO-TER/S,BLUSA NARANJA-ROSA 2025 TERRACOTA,Talla: S,77.30,0.00
+__import__.product_template_bl_encanto_ter,BL-ENCANTO-TER/M,BL-ENCANTO-TER/M,BLUSA NARANJA-ROSA 2025 TERRACOTA,Talla: M,77.30,0.00
+__import__.product_template_bl_encanto_ter,BL-ENCANTO-TER/L,BL-ENCANTO-TER/L,BLUSA NARANJA-ROSA 2025 TERRACOTA,Talla: L,77.30,0.00
+__import__.product_template_vest_palomino_wh,VEST-PALOMINO-WH/S,VEST-PALOMINO-WH/S,VESTIDO PALOMINO BLANCO,Talla: S,153.83,0.00
+__import__.product_template_vest_palomino_wh,VEST-PALOMINO-WH/M,VEST-PALOMINO-WH/M,VESTIDO PALOMINO BLANCO,Talla: M,153.83,0.00
+__import__.product_template_vest_palomino_wh,VEST-PALOMINO-WH/L,VEST-PALOMINO-WH/L,VESTIDO PALOMINO BLANCO,Talla: L,153.83,0.00
+__import__.product_template_pant_milano_blanco,PANT-MILANO BLANCO-XS,PANT-MILANO BLANCO-XS,PANTALON ELEGANTE MILANO BLANCO,Talla: XS,67.74,0.00
+__import__.product_template_pant_capri_blanco,PANT-CAPRI BLANCO-XS,PANT-CAPRI BLANCO-XS,PANTALON CON ELASTICO CAPRI BLANCO,Talla: XS,65.13,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-44,PT-CV-T11-031-NV-44,H. PANTALON P/CABALLERO CARVEN,Talla: 44,47.74,0.00
+__import__.product_template_zp_gam_ol_s_f_cassini,ZP-GAM-OL-S/F-CASSINI/8,ZPGAMOLGSFCAS/O8,Zapato ZP-GAM-OL-S/F-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/6.5,ZPCASCHAROLINA/6.5,Zapato ZP-CASSSINI-CHAROLINA,Talla: 6.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/6.5,ZPCASSINIPSPTBLK/6.5,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 6.5,152.09,0.00
+__import__.product_template_nt_s20220403_red,NT-S20220403-RED-S,NT-S20220403-RED-S,MALETA CARRY ON NAUTICA RED PEQUEÑA,Talla: S,73.91,0.00
+__import__.product_template_nt_s20220403_red,NT-S20220403-RED-M,NT-S20220403-RED-M,MALETA CARRY ON NAUTICA RED PEQUEÑA,Talla: M,95.65,0.00
+__import__.product_template_pt_6158_a7,PT-6158-A7/36,PT-6158-A7/36,Pantalon PT-6158-A7,Talla: 36,60.80,0.00
+__import__.product_template_pant_milano_beige,PANT-MILANO BEIGE-XS,PANT-MILANO BEIGE-XS,PANTALON ELEGANTE MILANO BEIGE,Talla: XS,71.22,0.00
+__import__.product_template_cha_milano_azul,CHA-MILANO AZUL-XS,CHA-MILANO AZUL-XS,CHALECO MILANO AZUL,Talla: XS,52.09,0.00
+__import__.product_template_cha_milano_beige,CHA-MILANO BEIGE-XS,CHA-MILANO BEIGE-XS,CHALECO MILANO BEIGE,Talla: XS,58.17,0.00
+__import__.product_template_vest_rose_bl,VEST-ROSE-BL/S,VEST-ROSE-BL/S,VESTIDO MOPA 2023-2 BLACK,Talla: S,117.30,0.00
+__import__.product_template_pt_3705_25,PT-3705-25/14,PT-3705-25/14,Pantalon PT-3705-25,Talla: 14,57.99,0.00
+__import__.product_template_lv_23e3705_25,LV-23E3705-25/46,LV-23E3705-25/46,Leva LV-23E3705-25,Talla: 46,165.13,0.00
+__import__.product_template_cha_milano_beige,CHA-MILANO BEIGE-S,CHA-MILANO BEIGE-S,CHALECO MILANO BEIGE,Talla: S,58.17,0.00
+__import__.product_template_cha_milano_beige,CHA-MILANO BEIGE-XL,CHA-MILANO BEIGE-XL,CHALECO MILANO BEIGE,Talla: XL,58.17,0.00
+__import__.product_template_pant_milano_beige,PANT-MILANO BEIGE-XL,PANT-MILANO BEIGE-XL,PANTALON ELEGANTE MILANO BEIGE,Talla: XL,71.22,0.00
+__import__.product_template_pt_10036a_8_495,PT-10036A-8-495/38,PT-10036A-8-495/38,Pantalon PT-10036A-8-495,Talla: 38,56.43,0.00
+__import__.product_template_pt_9c29386_80,PT-9C29386-80/32,PT-9C29386-80/O32,Pantalon PT-9C29386-80,Talla: 32,47.74,0.00
+__import__.product_template_pt_17001_7,PT-17001-7/28,PT-17001-7/O28,Pantalon PT-17001-7,Talla: 28,47.74,0.00
+__import__.product_template_pt_3742_1,PT-3742-1/20,PT-3742-1/O20,Pantalon PT-3742-1,Talla: 20,47.74,0.00
+__import__.product_template_pt_312010_4,PT-312010-4/44,PT-312010-4/O44,Pantalon PT-312010-4,Talla: 44,47.74,0.00
+__import__.product_template_pt_cv_b90_002wi,PT-CV-B90-002WI/S,PTCVB90002WI/OS,H. PANTALON P/CABALLERO CARVEN (pt_cv_b90_002wi),Talla: S,8.61,0.00
+__import__.product_template_pt_cv_b90_002gu,PT-CV-B90-002GU/S,PTCVB90002GU/OS,H. PANTALON P/CABALLERO CARVEN (pt_cv_b90_002gu),Talla: S,8.61,0.00
+__import__.product_template_pt_cv_b90_001rd,PT-CV-B90-001RD/S,PTCVB90001RD/OS,H. PANTALON P/CABALLERO CARVEN (pt_cv_b90_001rd),Talla: S,8.61,0.00
+__import__.product_template_pt_cv_b90_001rd,PT-CV-B90-001RD/M,PTCVB90001RD/OM,H. PANTALON P/CABALLERO CARVEN (pt_cv_b90_001rd),Talla: M,8.61,0.00
+__import__.product_template_pt_cv_b90_001hgr,PT-CV-B90-001HGR/S,PTCVB90001HGR/OS,H. PANTALON P/CABALLERO CARVEN (pt_cv_b90_001hgr),Talla: S,8.61,0.00
+__import__.product_template_cmst_cv_b90_002wi,CMST-CV-B90-002WI/S,CMSTCVB90002WI/OS,H. CAMISETA P/CABALLEROS WINE CARVEN,Talla: S,8.61,0.00
+__import__.product_template_cmst_cv_b90_002gu,CMST-CV-B90-002GU/S,CMSTCVB90002GU/OS,H. CAMISETA P/CABALLEROS CARVEN,Talla: S,8.61,0.00
+__import__.product_template_cmst_cv_b90_001rd,CMST-CV-B90-001RD/S,CMSTCVB90001RD/OS,H. CAMISETA CARVEN RED CARVEN,Talla: S,8.61,0.00
+__import__.product_template_cmst_cv_b90_001rd,CMST-CV-B90-001RD/M,CMSTCVB90001RD/OM,H. CAMISETA CARVEN RED CARVEN,Talla: M,8.61,0.00
+__import__.product_template_24c25168_219_bc_2,24C25168-219-BC-2/46,24C25168219094628,Terno 24C25168-219-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c27428_65_bc_2,24C27428-65-BC-2/46,24C27428652494628,Terno 24C27428-65-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c27428_65_bc_2,24C27428-65-BC-2/48,24C27428652494830,Terno 24C27428-65-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c27428_65_bc_2,24C27428-65-BC-2/50,24C27428652495032,Terno 24C27428-65-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c27428_65_bc_2,24C27428-65-BC-2/52,24C27428652495234,Terno 24C27428-65-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c27428_65_bc_2,24C27428-65-BC-2/54,24C27428652495436,Terno 24C27428-65-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c27428_65_bc_2,24C27428-65-BC-2/56,24C27428652495638,Terno 24C27428-65-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c27428_65_bc_2,24C27428-65-BC-2/58,24C27428652495840,Terno 24C27428-65-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24c25168_219_bc_2,24C25168-219-BC-2/58,24C25168219095840,Terno 24C25168-219-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24c29918_10_bc_2,24C29918-10-BC-2/54,24C29918102495436,Terno 24C29918-10-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c29918_10_bc_2,24C29918-10-BC-2/56,24C29918102495638,Terno 24C29918-10-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c29918_10_bc_2,24C29918-10-BC-2/58,24C29918102495840,Terno 24C29918-10-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24c29918_12_bc_2,24C29918-12-BC-2/46,24C29918122494628,Terno 24C29918-12-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c29918_12_bc_2,24C29918-12-BC-2/48,24C29918122494830,Terno 24C29918-12-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c29918_12_bc_2,24C29918-12-BC-2/50,24C29918122495032,Terno 24C29918-12-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c29918_12_bc_2,24C29918-12-BC-2/52,24C29918122495234,Terno 24C29918-12-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c29918_12_bc_2,24C29918-12-BC-2/54,24C29918122495436,Terno 24C29918-12-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c29918_12_bc_2,24C29918-12-BC-2/56,24C29918122495638,Terno 24C29918-12-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c29918_12_bc_2,24C29918-12-BC-2/58,24C29918122495840,Terno 24C29918-12-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24c29918_13_bc_2,24C29918-13-BC-2/46,24C29918132494628,Terno 24C29918-13-BC-2,Talla: 46,260.78,0.00
+__import__.product_template_24c29918_13_bc_2,24C29918-13-BC-2/48,24C29918132494830,Terno 24C29918-13-BC-2,Talla: 48,260.78,0.00
+__import__.product_template_24c29918_13_bc_2,24C29918-13-BC-2/50,24C29918132495032,Terno 24C29918-13-BC-2,Talla: 50,260.78,0.00
+__import__.product_template_24c29918_13_bc_2,24C29918-13-BC-2/52,24C29918132495234,Terno 24C29918-13-BC-2,Talla: 52,260.78,0.00
+__import__.product_template_24c29918_13_bc_2,24C29918-13-BC-2/54,24C29918132495436,Terno 24C29918-13-BC-2,Talla: 54,260.78,0.00
+__import__.product_template_24c29918_13_bc_2,24C29918-13-BC-2/56,24C29918132495638,Terno 24C29918-13-BC-2,Talla: 56,260.78,0.00
+__import__.product_template_24c29918_13_bc_2,24C29918-13-BC-2/58,24C29918132495840,Terno 24C29918-13-BC-2,Talla: 58,260.78,0.00
+__import__.product_template_24c29918_15_bc_2,24C29918-15-BC-2/46,24C29118152494628,Terno 24C29918-15-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c29918_15_bc_2,24C29918-15-BC-2/48,24C29118152494830,Terno 24C29918-15-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c29918_15_bc_2,24C29918-15-BC-2/50,24C29118152495032,Terno 24C29918-15-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c29918_15_bc_2,24C29918-15-BC-2/52,24C29118152495234,Terno 24C29918-15-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c29918_15_bc_2,24C29918-15-BC-2/54,24C29118152495436,Terno 24C29918-15-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c29918_15_bc_2,24C29918-15-BC-2/56,24C29118152495638,Terno 24C29918-15-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c29918_15_bc_2,24C29918-15-BC-2/58,24C29118152495840,Terno 24C29918-15-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24c29918_16_bc_2,24C29918-16-BC-2/46,24C29118162494628,Terno 24C29918-16-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c29918_16_bc_2,24C29918-16-BC-2/48,24C29118162494830,Terno 24C29918-16-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c29918_16_bc_2,24C29918-16-BC-2/50,24C29118162495032,Terno 24C29918-16-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c29918_16_bc_2,24C29918-16-BC-2/52,24C29118162495234,Terno 24C29918-16-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c29918_16_bc_2,24C29918-16-BC-2/54,24C29118162495436,Terno 24C29918-16-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c29918_16_bc_2,24C29918-16-BC-2/56,24C29118162495638,Terno 24C29918-16-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c29918_16_bc_2,24C29918-16-BC-2/58,24C29118162495840,Terno 24C29918-16-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24c29918_19_bc_2,24C29918-19-BC-2/46,24C29918192494628,Terno 24C29918-19-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c29918_19_bc_2,24C29918-19-BC-2/48,24C29918192494830,Terno 24C29918-19-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c29918_19_bc_2,24C29918-19-BC-2/50,24C29918192495032,Terno 24C29918-19-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c29918_19_bc_2,24C29918-19-BC-2/52,24C29918192495234,Terno 24C29918-19-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c29918_19_bc_2,24C29918-19-BC-2/54,24C29918192495436,Terno 24C29918-19-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c29918_19_bc_2,24C29918-19-BC-2/56,24C29918192495638,Terno 24C29918-19-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c25168_219_bc_2,24C25168-219-BC-2/48,24C25168219094830,Terno 24C25168-219-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c25168_219_bc_2,24C25168-219-BC-2/50,24C25168219095032,Terno 24C25168-219-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c25168_219_bc_2,24C25168-219-BC-2/52,24C25168219095234,Terno 24C25168-219-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c25168_219_bc_2,24C25168-219-BC-2/54,24C25168219095436,Terno 24C25168-219-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c25168_219_bc_2,24C25168-219-BC-2/56,24C25168219095638,Terno 24C25168-219-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c29918_10_bc_2,24C29918-10-BC-2/46,24C29918102494628,Terno 24C29918-10-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c29918_10_bc_2,24C29918-10-BC-2/48,24C29918102494830,Terno 24C29918-10-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c29918_10_bc_2,24C29918-10-BC-2/50,24C29918102495032,Terno 24C29918-10-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c29918_10_bc_2,24C29918-10-BC-2/52,24C29918102495234,Terno 24C29918-10-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c29918_19_bc_2,24C29918-19-BC-2/58,24C29918192495840,Terno 24C29918-19-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24c29918_20_bc_2,24C29918-20-BC-2/46,24C29918202494628,Terno 24C29918-20-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_24c29918_20_bc_2,24C29918-20-BC-2/48,24C29918202494830,Terno 24C29918-20-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_24c29918_20_bc_2,24C29918-20-BC-2/50,24C29918202495032,Terno 24C29918-20-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_24c29918_20_bc_2,24C29918-20-BC-2/52,24C29918202495234,Terno 24C29918-20-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_24c29918_20_bc_2,24C29918-20-BC-2/54,24C29918202495436,Terno 24C29918-20-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_24c29918_20_bc_2,24C29918-20-BC-2/56,24C29918202495638,Terno 24C29918-20-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_24c29918_20_bc_2,24C29918-20-BC-2/58,24C29918202495840,Terno 24C29918-20-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_24es296_4_bc_2,24ES296-4-BC-2/52,24ES296424095234,Terno 24ES296-4-BC-2,Talla: 52,260.78,0.00
+__import__.product_template_24es296_4_bc_2,24ES296-4-BC-2/50,24ES296424095032,Terno 24ES296-4-BC-2,Talla: 50,260.78,0.00
+__import__.product_template_24es296_4_bc_2,24ES296-4-BC-2/48,24ES296424094830,Terno 24ES296-4-BC-2,Talla: 48,260.78,0.00
+__import__.product_template_24es296_4_bc_2,24ES296-4-BC-2/46,24ES296424094628,Terno 24ES296-4-BC-2,Talla: 46,260.78,0.00
+__import__.product_template_zp_loafer_h_brw,ZP-LOAFER-H-BRW/9.5,ZPLOAFERHBRW/O9.5,Zapato ZP-LOAFER-H-BRW,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_loafer_h_brw,ZP-LOAFER-H-BRW/9,ZPLOAFERHBRW/O9,Zapato ZP-LOAFER-H-BRW,Talla: 9,152.09,0.00
+__import__.product_template_zp_loafer_h_brw,ZP-LOAFER-H-BRW/8.5,ZPLOAFERHBRW/O8.5,Zapato ZP-LOAFER-H-BRW,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_loafer_h_brw,ZP-LOAFER-H-BRW/8,ZPLOAFERHBRW/O8,Zapato ZP-LOAFER-H-BRW,Talla: 8,152.09,0.00
+__import__.product_template_zp_loafer_h_brw,ZP-LOAFER-H-BRW/7.5,ZPLOAFERHBRW/O7.5,Zapato ZP-LOAFER-H-BRW,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_loafer_h_brw,ZP-LOAFER-H-BRW/7,ZPLOAFERHBRW/O7,Zapato ZP-LOAFER-H-BRW,Talla: 7,152.09,0.00
+__import__.product_template_cam_m_l_firenze_azul,CAM-M/L-FIRENZE-AZUL/L,CAM-M/L-FIRENZE-AZUL/L,CAMISA M/L FIRENZE AZUL,Talla: L,65.13,0.00
+__import__.product_template_cam_m_l_firenze_azul,CAM-M/L-FIRENZE-AZUL/M,CAM-M/L-FIRENZE-AZUL/M,CAMISA M/L FIRENZE AZUL,Talla: M,65.13,0.00
+__import__.product_template_cam_m_l_firenze_black,CAM-M/L-FIRENZE-BLACK/L,CAM-M/L-FIRENZE-BLACK/L,CAMISA M/L FIRENZE BLACK,Talla: L,65.13,0.00
+__import__.product_template_cam_m_l_firenze_black,CAM-M/L-FIRENZE-BLACK/M,CAM-M/L-FIRENZE-BLACK/M,CAMISA M/L FIRENZE BLACK,Talla: M,65.13,0.00
+__import__.product_template_cam_m_l_firenze_black,CAM-M/L-FIRENZE-BLACK/S,CAM-M/L-FIRENZE-BLACK/S,CAMISA M/L FIRENZE BLACK,Talla: S,65.13,0.00
+__import__.product_template_cha_milano_beige,CHA-MILANO BEIGE-M,CHA-MILANO BEIGE-M,CHALECO MILANO BEIGE,Talla: M,58.17,0.00
+__import__.product_template_cha_milano_beige,CHA-MILANO BEIGE-L,CHA-MILANO BEIGE-L,CHALECO MILANO BEIGE,Talla: L,58.17,0.00
+__import__.product_template_cha_milano_blanco,CHA-MILANO BLANCO-M,CHA-MILANO BLANCO-M,CHALECO MILANO BLANCO,Talla: M,52.09,0.00
+__import__.product_template_cha_milano_blanco,CHA-MILANO BLANCO-S,CHA-MILANO BLANCO-S,CHALECO MILANO BLANCO,Talla: S,52.09,0.00
+__import__.product_template_cha_milano_azul,CHA-MILANO AZUL-M,CHA-MILANO AZUL-M,CHALECO MILANO AZUL,Talla: M,52.09,0.00
+__import__.product_template_cha_milano_azul,CHA-MILANO AZUL-S,CHA-MILANO AZUL-S,CHALECO MILANO AZUL,Talla: S,52.09,0.00
+__import__.product_template_cam_roma_beige,CAM. ROMA BEIGE-S,CAM. ROMA BEIGE-S,CAMISA M/C DAMA ROMA BEIGE,Talla: S,47.74,0.00
+__import__.product_template_cam_roma_beige,CAM. ROMA BEIGE-M,CAM. ROMA BEIGE-M,CAMISA M/C DAMA ROMA BEIGE,Talla: M,47.74,0.00
+__import__.product_template_cam_roma_blanco,CAM. ROMA BLANCO-S,CAM. ROMA BLANCO-S,CAMISA M/C DAMA ROMA BLANCO,Talla: S,44.26,0.00
+__import__.product_template_cam_roma_blanco,CAM. ROMA BLANCO-M,CAM. ROMA BLANCO-M,CAMISA M/C DAMA ROMA BLANCO,Talla: M,44.26,0.00
+__import__.product_template_cam_roma_azul,CAM. ROMA AZUL-L,CAM. ROMA AZUL-L,CAMISA M/C DAMA ROMA AZUL,Talla: L,44.26,0.00
+__import__.product_template_cam_roma_azul,CAM. ROMA AZUL-M,CAM. ROMA AZUL-M,CAMISA M/C DAMA ROMA AZUL,Talla: M,44.26,0.00
+__import__.product_template_cam_roma_azul,CAM. ROMA AZUL-S,CAM. ROMA AZUL-S,CAMISA M/C DAMA ROMA AZUL,Talla: S,44.26,0.00
+__import__.product_template_cam_roma_black,CAM. ROMA BLACK-M,CAM. ROMA BLACK-M,CAMISA M/C DAMA ROMA NEGRO,Talla: M,44.26,0.00
+__import__.product_template_cam_roma_black,CAM. ROMA BLACK-L,CAM. ROMA BLACK-L,CAMISA M/C DAMA ROMA NEGRO,Talla: L,44.26,0.00
+__import__.product_template_pant_milano_beige,PANT-MILANO BEIGE-L,PANT-MILANO BEIGE-L,PANTALON ELEGANTE MILANO BEIGE,Talla: L,71.22,0.00
+__import__.product_template_pant_milano_beige,PANT-MILANO BEIGE-M,PANT-MILANO BEIGE-M,PANTALON ELEGANTE MILANO BEIGE,Talla: M,71.22,0.00
+__import__.product_template_pant_milano_beige,PANT-MILANO BEIGE-S,PANT-MILANO BEIGE-S,PANTALON ELEGANTE MILANO BEIGE,Talla: S,71.22,0.00
+__import__.product_template_pant_milano_black,PANT-MILANO BLACK-L,PANT-MILANO BLACK-L,PANTALON ELEGANTE MILANO NEGRO,Talla: L,67.74,0.00
+__import__.product_template_pant_milano_black,PANT-MILANO BLACK-M,PANT-MILANO BLACK-M,PANTALON ELEGANTE MILANO NEGRO,Talla: M,67.74,0.00
+__import__.product_template_pant_milano_black,PANT-MILANO BLACK-S,PANT-MILANO BLACK-S,PANTALON ELEGANTE MILANO NEGRO,Talla: S,67.74,0.00
+__import__.product_template_pant_milano_blanco,PANT-MILANO BLANCO-L,PANT-MILANO BLANCO-L,PANTALON ELEGANTE MILANO BLANCO,Talla: L,67.74,0.00
+__import__.product_template_pant_milano_blanco,PANT-MILANO BLANCO-M,PANT-MILANO BLANCO-M,PANTALON ELEGANTE MILANO BLANCO,Talla: M,67.74,0.00
+__import__.product_template_pant_milano_blanco,PANT-MILANO BLANCO-S,PANT-MILANO BLANCO-S,PANTALON ELEGANTE MILANO BLANCO,Talla: S,67.74,0.00
+__import__.product_template_pant_capri_beige,PANT-CAPRI BEIGE-XS,PANT-CAPRI BEIGE-XS,PANTALON CON ELASTICO CAPRI BEIGE,Talla: XS,71.22,0.00
+__import__.product_template_pant_capri_beige,PANT-CAPRI BEIGE-S,PANT-CAPRI BEIGE-S,PANTALON CON ELASTICO CAPRI BEIGE,Talla: S,71.22,0.00
+__import__.product_template_pant_capri_beige,PANT-CAPRI BEIGE-M,PANT-CAPRI BEIGE-M,PANTALON CON ELASTICO CAPRI BEIGE,Talla: M,71.22,0.00
+__import__.product_template_pant_capri_blanco,PANT-CAPRI BLANCO-S,PANT-CAPRI BLANCO-OS,PANTALON CON ELASTICO CAPRI BLANCO,Talla: S,65.13,0.00
+__import__.product_template_pant_capri_blanco,PANT-CAPRI BLANCO-M,PANT-CAPRI BLANCO-OM,PANTALON CON ELASTICO CAPRI BLANCO,Talla: M,65.13,0.00
+__import__.product_template_pant_capri_blanco,PANT-CAPRI BLANCO-L,PANT-CAPRI BLANCO-OL,PANTALON CON ELASTICO CAPRI BLANCO,Talla: L,65.13,0.00
+__import__.product_template_pant_capri_black,PANT-CAPRI BLACK-L,PANT-CAPRI BLACK-OL,PANTALON CON ELASTICO CAPRI NEGRO,Talla: L,65.13,0.00
+__import__.product_template_pant_capri_black,PANT-CAPRI BLACK-M,PANT-CAPRI BLACK-OM,PANTALON CON ELASTICO CAPRI NEGRO,Talla: M,65.13,0.00
+__import__.product_template_pant_capri_black,PANT-CAPRI BLACK-S,PANT-CAPRI BLACK-OS,PANTALON CON ELASTICO CAPRI NEGRO,Talla: S,65.13,0.00
+__import__.product_template_pant_capri_blue,PANT-CAPRI BLUE-L,PANT-CAPRI BLUE-OL,PANTALON CON ELASTICO CAPRI AZUL,Talla: L,65.13,0.00
+__import__.product_template_pant_capri_blue,PANT-CAPRI BLUE-M,PANT-CAPRI BLUE-OM,PANTALON CON ELASTICO CAPRI AZUL,Talla: M,65.13,0.00
+__import__.product_template_pant_capri_blue,PANT-CAPRI BLUE-S,PANT-CAPRI BLUE-OS,PANTALON CON ELASTICO CAPRI AZUL,Talla: S,65.13,0.00
+__import__.product_template_pant_prisila,PANT-PRISILA-S,PANT-PRISILA-S,PANTALON PRISILA,Talla: S,33.83,0.00
+__import__.product_template_8500dc,8500DC-16-S1,8500DC202491601,H. CAMISA D/P WHITE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8500dc,8500DC-16-S2,8500DC202491602,H. CAMISA D/P WHITE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8500dc,8500DC-17-S1,8500DC202491701,H. CAMISA D/P WHITE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8500dc,8500DC-17-S2,8500DC202491702,H. CAMISA D/P WHITE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17601bg,17601BG-17.5-S1,17601BG202491751,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 17.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601bg,17601BG-17.5-S2,17601BG202491752,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601bg,17601BG-18-S1,17601BG202491801,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 18, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601bg,17601BG-18-S2,17601BG202491802,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 18, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601bg,17601BG-18.5-S1,17601BG202491851,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 18.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601bg,17601BG-18.5-S2,17601BG202491852,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 18.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601bg,17601BG-19-S1,17601BG202491901,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 19, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601bg,17601BG-19-S2,17601BG202491902,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 19, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601bg,17601BG-19.5-S1,17601BG202491951,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 19.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601bg,17601BG-19.5-S2,17601BG202491952,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 19.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601bg,17601BG-20-S1,17601BG202492001,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 20, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601bg,17601BG-20-S2,17601BG202492002,H. CAMISA P/S BIG SIZE WHITE BRUNO CASSINI 32-33,"Talla: 20, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_8504dc,8504DC-15.5-S1,8504DC202491551,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8504dc,8504DC-15-S2,8504DC202491502,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8504dc,8504DC-15-S1,8504DC202491501,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8504dc,8504DC-14.5-S1,8504DC202491451,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8500,8500-17-S1,8500202491701,Camisa 8500,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8504dc,8504DC-17.5-S2,8504DC202491752,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8504dc,8504DC-16-S1,8504DC202491601,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8502,8502-14.5-S1,8502202491451,Camisa 8502,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a156_1dc,A156-1DC-14.5-S1,A1561DC202491451,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a156_1dc,A156-1DC-15-S1,A1561DC202491501,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 15, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a156_1dc,A156-1DC-15-S2,A1561DC202491502,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 15, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a156_1dc,A156-1DC-15.5-S2,A1561DC202491552,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a156_1dc,A156-1DC-15.5-S1,A1561DC202491551,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_8504dc,8504DC-16-S2,8504DC202491602,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8502,8502-16.5-S1,8502202491651,Camisa 8502,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8500,8500-16.5-S2,8500202491652,Camisa 8500,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8500,8500-16.5-S1,8500202491651,Camisa 8500,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8500,8500-16-S2,8500202491602,Camisa 8500,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8500,8500-16-S1,8500202491601,Camisa 8500,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8500,8500-15.5-S2,8500202491552,Camisa 8500,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8500,8500-17.5-S2,8500202491752,Camisa 8500,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8500,8500-15.5-S1,8500202491551,Camisa 8500,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a118_82,A118-82-17.5-S2,A11882202491752,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_8504dc,8504DC-17-S1,8504DC202491701,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_8504dc,8504DC-16.5-S2,8504DC202491652,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8504dc,8504DC-15.5-S2,8504DC202491552,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8502,8502-15.5-S1,8502202491551,Camisa 8502,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8502,8502-17-S2,8502202491702,Camisa 8502,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8502,8502-15-S2,8502202491502,Camisa 8502,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8502,8502-17-S1,8502202491701,Camisa 8502,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8502,8502-15-S1,8502202491501,Camisa 8502,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8502,8502-16.5-S2,8502202491652,Camisa 8502,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8502,8502-16-S2,8502202491602,Camisa 8502,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8502,8502-16-S1,8502202491601,Camisa 8502,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8502,8502-15.5-S2,8502202491552,Camisa 8502,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8502,8502-17.5-S2,8502202491752,Camisa 8502,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_17601_sk,17601-SK-14.5-S1,17601SK202491451,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-15-S1,17601SK202491501,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-15-S2,17601SK202491502,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-15.5-S1,17601SK202491551,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-15.5-S2,17601SK202491552,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-16-S1,17601SK202491601,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-16-S2,17601SK202491602,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-16.5-S1,17601SK202491651,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-16.5-S2,17601SK202491652,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-17-S1,17601SK202491701,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-17-S2,17601SK202491702,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601_sk,17601-SK-17.5-S2,17601SK202491752,H. CAMISA P/SMOKING WHITE BRUNO CASSINI 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601dc,17601DC-14.5-S1,17601DC202491451,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 14.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17601dc,17601DC-15-S1,17601DC202491501,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 15, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17601dc,17601DC-15-S2,17601DC202491502,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 15, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17601dc,17601DC-15.5-S1,17601DC202491551,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 15.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17601dc,17601DC-15.5-S2,17601DC202491552,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 15.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17601dc,17601DC-16-S1,17601DC202491601,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 16, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17601dc,17601DC-16-S2,17601DC202491602,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 16, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17601dc,17601DC-16.5-S1,17601DC202491651,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 16.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17601dc,17601DC-16.5-S2,17601DC202491652,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 16.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17601dc,17601DC-17-S1,17601DC202491701,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 17, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_17601dc,17601DC-17-S2,17601DC202491702,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 17, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_17601dc,17601DC-17.5-S2,17601DC202491752,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (17601dc),"Talla: 17.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_8504dc,8504DC-16.5-S1,8504DC202491651,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_a156_1dc,A156-1DC-16.5-S1,A1561DC202491651,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a156_1dc,A156-1DC-16.5-S2,A1561DC202491652,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a156_1dc,A156-1DC-17-S1,A1561DC202491701,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a156_1dc,A156-1DC-17-S2,A1561DC202491702,H. CAMISA D/P WHITE BRUNO CASSINI 32-33 (a156_1dc),"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_8504dc,8504DC-17-S2,8504DC202491702,H. CAMISA D/P BLUE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_200,200-14.5-S1,200202491451,Camisa 200,"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_200,200-15.5-S1,200202491551,Camisa 200,"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_200,200-15.5-S2,200202491552,Camisa 200,"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_200,200-16-S1,200202491601,Camisa 200,"Talla: 16, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_200,200-16-S2,200202491602,Camisa 200,"Talla: 16, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_200,200-16.5-S1,200202491651,Camisa 200,"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_200,200-16.5-S2,200202491652,Camisa 200,"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_200,200-17-S1,200202491701,Camisa 200,"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_200,200-17-S2,200202491702,Camisa 200,"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_200,200-17.5-S2,200202491752,Camisa 200,"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_8500,8500-17-S2,8500202491702,Camisa 8500,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_str3,STR3-16-S2,STR3202491602,H. CAMISA P/S LINEN LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a118_82,A118-82-17-S2,A11882202491702,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a118_82,A118-82-14.5-S1,A11882202491451,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a118_82,A118-82-17-S1,A11882202491701,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a118_82,A118-82-16.5-S2,A11882202491652,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a118_82,A118-82-16.5-S1,A11882202491651,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a118_82,A118-82-15.5-S2,A11882202491552,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a118_82,A118-82-15.5-S1,A11882202491551,H. CAMISA P/S BLACK BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_5207,5207-15-S1,5207202491501,Camisa 5207,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5207,5207-14.5-S1,5207202491451,Camisa 5207,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5207,5207-15-S2,5207202491502,Camisa 5207,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_str3,STR3-14.5-S1,STR3202491451,H. CAMISA P/S LINEN LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_5207,5207-15.5-S2,5207202491552,Camisa 5207,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a108_24,A108-24-17.5-S2,A10824202491752,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a158_10,A158-10-15.5-S1,A15810202491551,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a158_10,A158-10-15.5-S2,A15810202491552,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a158_10,A158-10-16-S1,A15810202491601,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a158_10,A158-10-16-S2,A15810202491602,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a158_10,A158-10-16.5-S1,A15810202491651,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a158_10,A158-10-16.5-S2,A15810202491652,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a158_10,A158-10-17-S1,A15810202491701,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a158_10,A158-10-17-S2,A15810202491702,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a158_10,A158-10-17.5-S2,A15810202491752,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a108_24,A108-24-16.5-S1,A10824202491651,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_str3,STR3-16.5-S2,STR3202491652,H. CAMISA P/S LINEN LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a108_24,A108-24-16-S2,A10824202491602,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_24,A108-24-16.5-S2,A10824202491652,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_str3,STR3-15.5-S2,STR3202491552,H. CAMISA P/S LINEN LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_str3,STR3-15.5-S1,STR3202491551,H. CAMISA P/S LINEN LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a108_24,A108-24-17-S2,A10824202491702,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_5252,5252-16.5-S2,5252202491652,Camisa 5252,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5252,5252-16.5-S1,5252202491651,Camisa 5252,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5207,5207-16.5-S1,5207202491651,Camisa 5207,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5207,5207-16.5-S2,5207202491652,Camisa 5207,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5252,5252-14.5-S1,5252202491451,Camisa 5252,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a108_24,A108-24-14.5-S1,A10824202491451,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_24,A108-24-15-S1,A10824202491501,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_24,A108-24-15-S2,A10824202491502,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_24,A108-24-15.5-S1,A10824202491551,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_24,A108-24-15.5-S2,A10824202491552,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_24,A108-24-16-S1,A10824202491601,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_24,A108-24-17-S1,A10824202491701,H. CAMISA P/S CORAL BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_str3,STR3-16-S1,STR3202491601,H. CAMISA P/S LINEN LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_5207,5207-15.5-S1,5207202491551,Camisa 5207,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_str3,STR3-16.5-S1,STR3202491651,H. CAMISA P/S LINEN LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a126_3,A126-3-17-S2,A1263202491702,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a126_3,A126-3-17-S1,A1263202491701,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_3,A126-3-16.5-S1,A1263202491651,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_3,A126-3-16.5-S2,A1263202491652,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_5305,5305-14.5-S1,5305202491451,Camisa 5305,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5305,5305-16.5-S1,5305202491651,Camisa 5305,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_5305,5305-15.5-S2,5305202491552,Camisa 5305,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5305,5305-16.5-S2,5305202491652,Camisa 5305,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_5305,5305-15.5-S1,5305202491551,Camisa 5305,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a126_3,A126-3-15.5-S2,A1263202491552,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a126_10,A126-10-15-S1,A12610202491501,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a126_10,A126-10-16.5-S1,A12610202491651,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a126_10,A126-10-17-S1,A12610202491701,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a126_10,A126-10-16-S2,A12610202491602,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a126_10,A126-10-17-S2,A12610202491702,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a126_10,A126-10-16.5-S2,A12610202491652,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16318,16318-15.5-S1,16318202491551,Camisa 16318,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16318,16318-15.5-S2,16318202491552,Camisa 16318,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16318,16318-16.5-S1,16318202491651,Camisa 16318,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16318,16318-16.5-S2,16318202491652,Camisa 16318,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a126_4,A126-4-17-S2,A1264202491702,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a158_4,A158-4-14.5-S1,A1584202491451,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_4),"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_4,A108-4-15.5-S2,A1084202491552,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_4,A108-4-15.5-S1,A1084202491551,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_4,A108-4-16-S2,A1084202491602,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 16, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_4,A108-4-14.5-S1,A1084202491451,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_10,A126-10-15-S2,A12610202491502,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a126_10,A126-10-16-S1,A12610202491601,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a126_10,A126-10-15.5-S1,A12610202491551,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a126_10,A126-10-15.5-S2,A12610202491552,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a126_10,A126-10-17.5-S2,A12610202491752,H. CAMISA P/S PURPLE BRUNO CASSINI 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a126_4,A126-4-14.5-S1,A1264202491451,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_4,A126-4-15.5-S1,A1264202491551,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_4,A126-4-15.5-S2,A1264202491552,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a126_4,A126-4-16-S1,A1264202491601,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_4,A126-4-16-S2,A1264202491602,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a126_4,A126-4-16.5-S1,A1264202491651,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_4,A126-4-16.5-S2,A1264202491652,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a126_4,A126-4-17-S1,A1264202491701,H. CAMISA P/S BLUE BRUNO CASSINI 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a158_10,A158-10-15-S1,A15810202491501,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a158_10,A158-10-15-S2,A15810202491502,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a158_10,A158-10-14.5-S1,A15810202491451,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a158_10),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a108_4,A108-4-17-S2,A1084202491702,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_4,A108-4-16.5-S1,A1084202491651,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_4,A108-4-17-S1,A1084202491701,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_4,A108-4-16.5-S2,A1084202491652,H. CAMISA P/S BLUE BRUNO CASSINI 34-35 (a108_4),"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a156_1,A156-1-14.5-S1,A1561202491451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.34,0.00
+__import__.product_template_a156_1,A156-1-16.5-S2,A1561202491652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.34,0.00
+__import__.product_template_a156_1,A156-1-17-S1,A1561202491701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 17, Manga de Camisa: S1 - 32/33",47.34,0.00
+__import__.product_template_a156_1,A156-1-15-S2,A1561202491502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 15, Manga de Camisa: S2 - 34/35",47.34,0.00
+__import__.product_template_a156_1,A156-1-16.5-S1,A1561202491651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.34,0.00
+__import__.product_template_a156_1,A156-1-15.5-S2,A1561202491552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.34,0.00
+__import__.product_template_30201,30201-17-S2,30201202491702,Camisa 30201,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_30201,30201-17.5-S2,30201202491752,Camisa 30201,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a151_1,A151-1-17-S2,A1511202491702,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a156_1,A156-1-17.5-S2,A1561202491752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.34,0.00
+__import__.product_template_16701,16701-14.5-S1,16701202491451,Camisa 16701,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16701,16701-15-S1,16701202491501,Camisa 16701,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16701,16701-15-S2,16701202491502,Camisa 16701,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16701,16701-15.5-S1,16701202491551,Camisa 16701,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16701,16701-15.5-S2,16701202491552,Camisa 16701,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16701,16701-16-S1,16701202491601,Camisa 16701,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16701,16701-16-S2,16701202491602,Camisa 16701,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16701,16701-16.5-S1,16701202491651,Camisa 16701,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16701,16701-16.5-S2,16701202491652,Camisa 16701,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_30201,30201-15.5-S1,30201202491551,Camisa 30201,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_30201,30201-15.5-S2,30201202491552,Camisa 30201,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_30201,30201-16-S1,30201202491601,Camisa 30201,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_30201,30201-16-S2,30201202491602,Camisa 30201,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_30201,30201-16.5-S1,30201202491651,Camisa 30201,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_30201,30201-16.5-S2,30201202491652,Camisa 30201,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_30201,30201-17-S1,30201202491701,Camisa 30201,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a156_1,A156-1-15.5-S1,A1561202491551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.34,0.00
+__import__.product_template_a151_1,A151-1-17.5-S2,A1511202491752,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a156_1,A156-1-17-S2,A1561202491702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 17, Manga de Camisa: S2 - 34/35",47.34,0.00
+__import__.product_template_a156_1,A156-1-15-S1,A1561202491501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a156_1),"Talla: 15, Manga de Camisa: S1 - 32/33",47.34,0.00
+__import__.product_template_16701,16701-17-S1,16701202491701,Camisa 16701,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16701,16701-17-S2,16701202491702,Camisa 16701,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16701,16701-17.5-S2,16701202491752,Camisa 16701,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a108_7,A108-7-15-S1,A1087202491501,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_7,A108-7-15-S2,A1087202491502,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a126_3,A126-3-15-S1,A1263202491501,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_7,A108-7-17.5-S2,A1087202491752,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_7,A108-7-17-S2,A1087202491702,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a158_3,A158-3-17-S2,A1583202491702,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35 (a158_3),"Talla: 17, Manga de Camisa: S2 - 34/35",47.34,0.00
+__import__.product_template_a158_3,A158-3-17-S1,A1583202491701,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35 (a158_3),"Talla: 17, Manga de Camisa: S1 - 32/33",47.34,0.00
+__import__.product_template_a108_3,A108-3-14.5-S1,A1083202491451,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a108_3),"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_3,A108-3-15-S1,A1083202491501,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a108_3),"Talla: 15, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_3,A108-3-15-S2,A1083202491502,H. CAMISA P/S BLUE BRUNO CASSINI 32-33 (a108_3),"Talla: 15, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_6901,6901-16.5-S2,6901202491652,Camisa 6901,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_6901,6901-14.5-S1,6901202491451,Camisa 6901,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_6901,6901-16.5-S1,6901202491651,Camisa 6901,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a126_3,A126-3-15.5-S1,A1263202491551,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a126_3,A126-3-15-S2,A1263202491502,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_7,A108-7-15.5-S1,A1087202491551,H. CAMISA P/S LIGHT BLUE BRUNO CASSINI 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a151_1,A151-1-16.5-S1,A1511202491651,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a163_1,A163-1-14.5-S1,A1631202491451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a163_1,A163-1-15-S1,A1631202491501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 15, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a163_1,A163-1-15-S2,A1631202491502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 15, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_1,A108-1-14.5-S1,A1081202491451,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_1,A108-1-15-S1,A1081202491501,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 15, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_1,A108-1-15-S2,A1081202491502,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 15, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_16301,16301-15.5-S1,16301202491551,Camisa 16301,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16301,16301-15.5-S2,16301202491552,Camisa 16301,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16301,16301-16-S1,16301202491601,Camisa 16301,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16301,16301-16-S2,16301202491602,Camisa 16301,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16301,16301-16.5-S1,16301202491651,Camisa 16301,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16301,16301-16.5-S2,16301202491652,Camisa 16301,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16301,16301-17-S1,16301202491701,Camisa 16301,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16301,16301-17-S2,16301202491702,Camisa 16301,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_16301,16301-17.5-S2,16301202491752,Camisa 16301,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a163_1,A163-1-16-S1,A1631202491601,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 16, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_17601,17601-14.5-S1,17601202491451,Camisa 17601,"Talla: 14.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601,17601-15-S1,17601202491501,Camisa 17601,"Talla: 15, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_a163_1,A163-1-16-S2,A1631202491602,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 16, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a163_1,A163-1-16.5-S1,A1631202491651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a151_1,A151-1-17-S1,A1511202491701,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a163_1,A163-1-15.5-S2,A1631202491552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_1,A108-1-16.5-S2,A1081202491652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a163_1,A163-1-15.5-S1,A1631202491551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_1,A108-1-16.5-S1,A1081202491651,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_1,A108-1-17.5-S2,A1081202491752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_1,A108-1-16-S2,A1081202491602,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 16, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_1,A108-1-17-S2,A1081202491702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_1,A108-1-16-S1,A1081202491601,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 16, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_1,A108-1-17-S1,A1081202491701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a108_1,A108-1-15.5-S2,A1081202491552,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a108_1,A108-1-15.5-S1,A1081202491551,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a108_1),"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a151_1,A151-1-16.5-S2,A1511202491652,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a163_1,A163-1-16.5-S2,A1631202491652,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a163_1,A163-1-17-S2,A1631202491702,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a163_1,A163-1-17-S1,A1631202491701,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_a163_1,A163-1-17.5-S2,A1631202491752,H. CAMISA P/S WHITE BRUNO CASSINI 32-33 (a163_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a151_1,A151-1-15.5-S2,A1511202491552,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 15.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a151_1,A151-1-15.5-S1,A1511202491551,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 15.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_17601,17601-16.5-S1,17601202491651,Camisa 17601,"Talla: 16.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601,17601-16.5-S2,17601202491652,Camisa 17601,"Talla: 16.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601,17601-17-S1,17601202491701,Camisa 17601,"Talla: 17, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17601,17601-17-S2,17601202491702,Camisa 17601,"Talla: 17, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17601,17601-17.5-S2,17601202491752,Camisa 17601,"Talla: 17.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_a115_1,A115-1-17.5-S2,A1151202491752,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a115_1),"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_a151_1,A151-1-14.5-S1,A1511202491451,H. CAMISA P/S WHITE BRUNO CASSINI 34-35 (a151_1),"Talla: 14.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_opkb0300_413,OPKB0300-413/XL,799016397692,H. POLO P/H M/C DARK SAPPHIRE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_lbpc_b03_101ss_nv,LBPC-B03-101SS-NV/XL,743682045449,H. CAMISA P/H M/C NAVY LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_ockbs010_969,OCKBS010-969/S,799016631741,H. POLO P/H M/C AZURE BLUE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockbs010_969,OCKBS010-969/M,799016631734,H. POLO P/H M/C AZURE BLUE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockbs010_969,OCKBS010-969/L,799016631727,H. POLO P/H M/C AZURE BLUE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ocks0197_780,OCKS0197-780/L,799016516499,H. POLO P/H M/C CREAM GOLD PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ocks0197_780,OCKS0197-780/XL,799016516505,H. POLO P/H M/C CREAM GOLD PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_opwb0500_413,OPWB0500-413/XL,009246505225,H. CAMISA P/H M/C 100% LINO DARK SAPPHIRE PENGUIN,Talla: XL,95.57,0.00
+__import__.product_template_lbpc_b04_101s_bl,LBPC-B04-101S-BL/M,743682046545,H. CAMISA P/H M/L BLACK LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b03_101s_wh,LBPC-B03-101S-WH/L,7448339962959,H. CAMISA P/H M/C WHITE LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_b03_101ss_nv,LBPC-B03-101SS-NV/M,743682045425,H. CAMISA P/H M/C NAVY LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b03_101s_wh,LBPC-B03-101S-WH/S,7448356265248,H. CAMISA P/H M/C WHITE LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b03_101ss_nv,LBPC-B03-101SS-NV/L,743682045432,H. CAMISA P/H M/C NAVY LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_b03_101s_wh,LBPC-B03-101S-WH/XL,7448332161199,H. CAMISA P/H M/C WHITE LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b04_101s_bl,LBPC-B04-101S-BL/S,743682046538,H. CAMISA P/H M/L BLACK LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b04_101s_bl,LBPC-B04-101S-BL/XL,743682046569,H. CAMISA P/H M/L BLACK LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b04_101s_bl,LBPC-B04-101S-BL/L,743682046552,H. CAMISA P/H M/L BLACK LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_b03_101s_wh,LBPC-B03-101S-WH/M,7448336688654,H. CAMISA P/H M/C WHITE LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_opkb0300_413,OPKB0300-413/S,799016397661,H. POLO P/H M/C DARK SAPPHIRE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_opkb0300_413,OPKB0300-413/M,799016397678,H. POLO P/H M/C DARK SAPPHIRE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_lbpc_b04_101s_wh,LBPC-B04-101S-WH/L,7448334276204,H. CAMISA P/H M/L WHITE LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_b04_101s_wh,LBPC-B04-101S-WH/M,7448332249286,H. CAMISA P/H M/L WHITE LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b04_101s_wh,LBPC-B04-101S-WH/XL,7448343011094,H. CAMISA P/H M/L WHITE LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b04_102s_ja,LBPC-B04-102S-JA/L,743682047511,H. CAMISA P/H M/L JADE LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_b04_101s_wh,LBPC-B04-101S-WH/S,7448355624657,H. CAMISA P/H M/L WHITE LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_ockbs010_330,OCKBS010-330/M,799016631192,H. POLO P/H M/C SILT GREEN PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockbs010_330,OCKBS010-330/XL,799016631215,H. POLO P/H M/C SILT GREEN PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_opwb0400_118,OPWB0400-118/L,009246504976,H. CAMISA P/H M/L 100% LINO BRIGHT WHITE PENGUIN,Talla: L,117.30,0.00
+__import__.product_template_opwb0400_413,OPWB0400-413/M,009246505027,H. CAMISA P/H M/L 100% LINO DARK SAPPHIRE PENGUIN,Talla: M,117.30,0.00
+__import__.product_template_opwb0400_413,OPWB0400-413/L,009246505034,H. CAMISA P/H M/L 100% LINO DARK SAPPHIRE PENGUIN,Talla: L,117.30,0.00
+__import__.product_template_lbpc_b04_101s_sl,LBPC-B04-101S-SL/M,743682046668,H. CAMISA P/H M/L SALMON LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_opwb0500_413,OPWB0500-413/M,009246505201,H. CAMISA P/H M/C 100% LINO DARK SAPPHIRE PENGUIN,Talla: M,95.57,0.00
+__import__.product_template_lbpc_c31_206s_te,LBPC-C31-206S-TE/L,0743682084493,H. POLO P/HOMBRE TERRACOTA LONG BEACH,Talla: L,34.70,0.00
+__import__.product_template_opwb0400_413,OPWB0400-413/S,009246505010,H. CAMISA P/H M/L 100% LINO DARK SAPPHIRE PENGUIN,Talla: S,117.30,0.00
+__import__.product_template_opwb0400_413,OPWB0400-413/XL,009246505041,H. CAMISA P/H M/L 100% LINO DARK SAPPHIRE PENGUIN,Talla: XL,117.30,0.00
+__import__.product_template_ockbs010_969,OCKBS010-969/XL,799016631826,H. POLO P/H M/C AZURE BLUE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_ocks0197_780,OCKS0197-780/M,799016516482,H. POLO P/H M/C CREAM GOLD PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockbs010_330,OCKBS010-330/L,799016631185,H. POLO P/H M/C SILT GREEN PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockbs010_330,OCKBS010-330/S,799016631208,H. POLO P/H M/C SILT GREEN PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockb0800_010,OCKB0800-010/XL,799016518147,H. POLO P/H M/C TRUE BLACK PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_ockb0800_010,OCKB0800-010/L,799016516130,H. POLO P/H M/C TRUE BLACK PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_lbpc_c31_223r_sl,LBPC-C31-223R-SL/M,0743682085520,H. POLO P/HOMBRE SALMON LONG BEACH,Talla: M,34.70,0.00
+__import__.product_template_lbpc_b04_101s_sl,LBPC-B04-101S-SL/L,743682046675,H. CAMISA P/H M/L SALMON LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_b04_101s_sl,LBPC-B04-101S-SL/XL,743682046682,H. CAMISA P/H M/L SALMON LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b04_101s_sl,LBPC-B04-101S-SL/S,743682046651,H. CAMISA P/H M/L SALMON LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_opwb0500_413,OPWB0500-413/L,009246505218,H. CAMISA P/H M/C 100% LINO DARK SAPPHIRE PENGUIN,Talla: L,95.57,0.00
+__import__.product_template_opwb0500_413,OPWB0500-413/S,009246505195,H. CAMISA P/H M/C 100% LINO DARK SAPPHIRE PENGUIN,Talla: S,95.57,0.00
+__import__.product_template_lbpc_b04_102s_sk,LBPC-B04-102S-SK/XL,7448333746746,H. CAMISA P/H M/L SKY LONG BEACH,Talla: XL,50.35,0.00
+__import__.product_template_lbpc_b04_102s_sk,LBPC-B04-102S-SK/L,7448339977960,H. CAMISA P/H M/L SKY LONG BEACH,Talla: L,50.35,0.00
+__import__.product_template_lbpc_b04_102s_sk,LBPC-B04-102S-SK/M,7448357132167,H. CAMISA P/H M/L SKY LONG BEACH,Talla: M,50.35,0.00
+__import__.product_template_lbpc_b04_102s_sk,LBPC-B04-102S-SK/S,7448339014061,H. CAMISA P/H M/L SKY LONG BEACH,Talla: S,50.35,0.00
+__import__.product_template_lbpc_b04_102s_nv,LBPC-B04-102S-NV/XL,743682047405,H. CAMISA P/H M/L NAVY LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b04_102s_nv,LBPC-B04-102S-NV/S,743682047375,H. CAMISA P/H M/L NAVY LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b04_102s_ja,LBPC-B04-102S-JA/XL,743682047528,H. CAMISA P/H M/L JADE LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b04_102s_nv,LBPC-B04-102S-NV/L,743682047399,H. CAMISA P/H M/L NAVY LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_lbpc_b04_102s_nv,LBPC-B04-102S-NV/M,743682047382,H. CAMISA P/H M/L NAVY LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b04_102s_ja,LBPC-B04-102S-JA/S,743682047498,H. CAMISA P/H M/L JADE LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b04_102s_ja,LBPC-B04-102S-JA/M,743682047504,H. CAMISA P/H M/L JADE LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b03_101ss_nv,LBPC-B03-101SS-NV/S,743682045418,H. CAMISA P/H M/C NAVY LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_c31_206s_te,LBPC-C31-206S-TE/M,0743682084486,H. POLO P/HOMBRE TERRACOTA LONG BEACH,Talla: M,34.70,0.00
+__import__.product_template_lbpc_c31_206s_te,LBPC-C31-206S-TE/S,0743682084479,H. POLO P/HOMBRE TERRACOTA LONG BEACH,Talla: S,34.70,0.00
+__import__.product_template_lbpc_c31_206s_te,LBPC-C31-206S-TE/XL,0743682084509,H. POLO P/HOMBRE TERRACOTA LONG BEACH,Talla: XL,34.70,0.00
+__import__.product_template_opwb0400_118,OPWB0400-118/S,009246504952,H. CAMISA P/H M/L 100% LINO BRIGHT WHITE PENGUIN,Talla: S,117.30,0.00
+__import__.product_template_opwb0400_118,OPWB0400-118/M,009246504969,H. CAMISA P/H M/L 100% LINO BRIGHT WHITE PENGUIN,Talla: M,117.30,0.00
+__import__.product_template_opkb0300_413,OPKB0300-413/L,799016397685,H. POLO P/H M/C DARK SAPPHIRE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_opwb0400_118,OPWB0400-118/XL,009246504983,H. CAMISA P/H M/L 100% LINO BRIGHT WHITE PENGUIN,Talla: XL,117.30,0.00
+__import__.product_template_lbpc_c31_223r_sl,LBPC-C31-223R-SL/S,0743682085513,H. POLO P/HOMBRE SALMON LONG BEACH,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b03_101s_bl,LBPC-B03-101S-BL/XL,7448346574510,H. CAMISA P/H M/C BLACK LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b03_101s_bl,LBPC-B03-101S-BL/S,7448336265213,H. CAMISA P/H M/C BLACK LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b03_101s_bl,LBPC-B03-101S-BL/M,7448346588524,H. CAMISA P/H M/C BLACK LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b03_101s_bl,LBPC-B03-101S-BL/L,7448335519553,H. CAMISA P/H M/C BLACK LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_opbb0099_413_op,OPBB0099-413.OP/30,691046761361,Terno OPBB0099-413.OP,Talla: 30,82.52,0.00
+__import__.product_template_opbb0099_413_op,OPBB0099-413.OP/31,691046761378,Terno OPBB0099-413.OP,Talla: 31,82.52,0.00
+__import__.product_template_opbb0099_413_op,OPBB0099-413.OP/32,691046761385,Terno OPBB0099-413.OP,Talla: 32,82.52,0.00
+__import__.product_template_opbb0099_413_op,OPBB0099-413.OP/33,691046761392,Terno OPBB0099-413.OP,Talla: 33,82.52,0.00
+__import__.product_template_opbb0099_413_op,OPBB0099-413.OP/34,691046761408,Terno OPBB0099-413.OP,Talla: 34,82.52,0.00
+__import__.product_template_lbpc_c31_223r_bl,LBPC-C31-223R-BL/S,0743682085551,H. POLO P/HOMBRE BLACK LONG BEACH,Talla: S,34.70,0.00
+__import__.product_template_lbpc_c31_223r_bl,LBPC-C31-223R-BL/XL,0743682085582,H. POLO P/HOMBRE BLACK LONG BEACH,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_c31_223r_bl,LBPC-C31-223R-BL/M,0743682085568,H. POLO P/HOMBRE BLACK LONG BEACH,Talla: M,34.70,0.00
+__import__.product_template_lbpc_c31_223r_bl,LBPC-C31-223R-BL/L,0743682085575,H. POLO P/HOMBRE BLACK LONG BEACH,Talla: L,34.70,0.00
+__import__.product_template_opbb0099_413_op,OPBB0099-413.OP/36,691046761415,Terno OPBB0099-413.OP,Talla: 36,82.52,0.00
+__import__.product_template_ockb0800_449,OCKB0800-449/XL,799016631093,H. POLO P/H M/C COOL BLUE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_ockb0800_449,OCKB0800-449/S,799016631086,H. POLO P/H M/C COOL BLUE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockb0800_449,OCKB0800-449/M,799016631079,H. POLO P/H M/C COOL BLUE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockb0800_449,OCKB0800-449/L,799016631062,H. POLO P/H M/C COOL BLUE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockb0800_118,OCKB0800-118/XL,799016516208,H. POLO P/H M/C PINK BRIGHT WHITE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_opbb0099_413_op,OPBB0099-413.OP/38,691046761422,Terno OPBB0099-413.OP,Talla: 38,82.52,0.00
+__import__.product_template_opbb2000_281,OPBB2000-281/30,799016398460,Terno OPBB2000-281,Talla: 30,82.52,0.00
+__import__.product_template_ockbs010_830,OCKBS010-830/L,009246567018,H. T-SHIRT P/H MOCK ORANGE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockbs010_830,OCKBS010-830/M,009246567025,H. T-SHIRT P/H MOCK ORANGE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockbs010_830,OCKBS010-830/S,009246567032,H. T-SHIRT P/H MOCK ORANGE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockb0010_673,OCKB0010-673/S,799016543396,H. POLO P/H M/C PARFAIT PINK PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockb0800_118,OCKB0800-118/S,799016516178,H. POLO P/H M/C PINK BRIGHT WHITE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockb0800_118,OCKB0800-118/M,799016516185,H. POLO P/H M/C PINK BRIGHT WHITE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_opkb0300_010,OPKB0300-010/S,799016397487,H. POLO P/H M/C TRUE BLACK PENGUIN (opkb0300_010),Talla: S,65.13,0.00
+__import__.product_template_opkb0300_402,OPKB0300-402/S,799016397609,H. POLO P/H M/C BALLAD BLUE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_opkb0300_010,OPKB0300-010/M,799016397494,H. POLO P/H M/C TRUE BLACK PENGUIN (opkb0300_010),Talla: M,65.13,0.00
+__import__.product_template_opkb0300_402,OPKB0300-402/M,799016397616,H. POLO P/H M/C BALLAD BLUE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_opkb0300_402,OPKB0300-402/L,799016397623,H. POLO P/H M/C BALLAD BLUE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ocbs3100_059,OCBS3100-059/34,799016533908,Terno OCBS3100-059,Talla: 34,82.52,0.00
+__import__.product_template_opbs1099_352,OPBS1099-352/31,799016229795,Terno OPBS1099-352,Talla: 31,82.52,0.00
+__import__.product_template_ockbs010_679,OCKBS010-679/XL,009246464690,H. POLO P/H M/C RASPBERRY SORBEOT PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_ockbs010_679,OCKBS010-679/S,009246464669,H. POLO P/H M/C RASPBERRY SORBEOT PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockbs010_679,OCKBS010-679/M,009246464676,H. POLO P/H M/C RASPBERRY SORBEOT PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockbs010_679,OCKBS010-679/L,009246464683,H. POLO P/H M/C RASPBERRY SORBEOT PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_opkb0300_010,OPKB0300-010/XL,799016397517,H. POLO P/H M/C TRUE BLACK PENGUIN (opkb0300_010),Talla: XL,65.13,0.00
+__import__.product_template_opkb0300_010,OPKB0300-010/L,799016397500,H. POLO P/H M/C TRUE BLACK PENGUIN (opkb0300_010),Talla: L,65.13,0.00
+__import__.product_template_opkb0300_402,OPKB0300-402/XL,799016397630,H. POLO P/H M/C BALLAD BLUE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_opbb2000_281,OPBB2000-281/36,799016398514,Terno OPBB2000-281,Talla: 36,82.52,0.00
+__import__.product_template_opbb2000_281,OPBB2000-281/34,799016398507,Terno OPBB2000-281,Talla: 34,82.52,0.00
+__import__.product_template_opbb2000_281,OPBB2000-281/33,799016398491,Terno OPBB2000-281,Talla: 33,82.52,0.00
+__import__.product_template_opbb2000_281,OPBB2000-281/32,799016398484,Terno OPBB2000-281,Talla: 32,82.52,0.00
+__import__.product_template_opbb2000_281,OPBB2000-281/31,799016398477,Terno OPBB2000-281,Talla: 31,82.52,0.00
+__import__.product_template_ocbs3100_059,OCBS3100-059/33,401052251950,Terno OCBS3100-059,Talla: 33,82.52,0.00
+__import__.product_template_ocbs3100_059,OCBS3100-059/36,799016533915,Terno OCBS3100-059,Talla: 36,82.52,0.00
+__import__.product_template_ockb0010_673,OCKB0010-673/M,799016543402,H. POLO P/H M/C PARFAIT PINK PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ocbs3100_059,OCBS3100-059/38,799016533922,Terno OCBS3100-059,Talla: 38,82.52,0.00
+__import__.product_template_opbs1099_352,OPBS1099-352/36,799016229757,Terno OPBS1099-352,Talla: 36,82.52,0.00
+__import__.product_template_opbs1099_352,OPBS1099-352/34,799016229740,Terno OPBS1099-352,Talla: 34,82.52,0.00
+__import__.product_template_opbs1099_352,OPBS1099-352/38,799016229764,Terno OPBS1099-352,Talla: 38,82.52,0.00
+__import__.product_template_opbs1099_352,OPBS1099-352/33,799016229801,Terno OPBS1099-352,Talla: 33,82.52,0.00
+__import__.product_template_opbs1099_352,OPBS1099-352/32,799016229733,Terno OPBS1099-352,Talla: 32,82.52,0.00
+__import__.product_template_ocbs3100_059,OCBS3100-059/32,401052251868,Terno OCBS3100-059,Talla: 32,82.52,0.00
+__import__.product_template_ocbs3100_059,OCBS3100-059/31,009246469046,Terno OCBS3100-059,Talla: 31,82.52,0.00
+__import__.product_template_ocbs3100_059,OCBS3100-059/30,009246469039,Terno OCBS3100-059,Talla: 30,82.52,0.00
+__import__.product_template_opbs1099_352,OPBS1099-352/30,799016229726,Terno OPBS1099-352,Talla: 30,82.52,0.00
+__import__.product_template_opbb2000_281,OPBB2000-281/38,799016398521,Terno OPBB2000-281,Talla: 38,82.52,0.00
+__import__.product_template_ockbs010_974,OCKBS010-974/XL,009246464744,H. POLO P/H M/C STAR SAPPHIRE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_ockbs010_974,OCKBS010-974/S,009246464713,H. POLO P/H M/C STAR SAPPHIRE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_opksb300_691,OPKSB300-691/XL,799016558048,H. POLO P/H M/C PINK DOGWOOD PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_opksb300_691,OPKSB300-691/S,799016558031,H. POLO P/H M/C PINK DOGWOOD PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_opksb300_691,OPKSB300-691/M,799016558024,H. POLO P/H M/C PINK DOGWOOD PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_opksb300_691,OPKSB300-691/L,799016558017,H. POLO P/H M/C PINK DOGWOOD PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_opksb300_485,OPKSB300-485/XL,009246568664,H. POLO P/H M/C SARGASSO SEA PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_opksb300_485,OPKSB300-485/S,009246568657,H. POLO P/H M/C SARGASSO SEA PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_opksb300_485,OPKSB300-485/M,009246568640,H. POLO P/H M/C SARGASSO SEA PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_opksb300_485,OPKSB300-485/L,009246568633,H. POLO P/H M/C SARGASSO SEA PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockb0010_673,OCKB0010-673/XL,799016543426,H. POLO P/H M/C PARFAIT PINK PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_opbb0099_250_op,OPBB0099-250.OP/32,691046761293,Terno OPBB0099-250.OP,Talla: 32,82.52,0.00
+__import__.product_template_opbb0099_250_op,OPBB0099-250.OP/31,691046761286,Terno OPBB0099-250.OP,Talla: 31,82.52,0.00
+__import__.product_template_opbb0099_250_op,OPBB0099-250.OP/30,691046761279,Terno OPBB0099-250.OP,Talla: 30,82.52,0.00
+__import__.product_template_ockb0800_118,OCKB0800-118/L,799016516192,H. POLO P/H M/C PINK BRIGHT WHITE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockbs010_830,OCKBS010-830/XL,009246567049,H. T-SHIRT P/H MOCK ORANGE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_ockbs010_974,OCKBS010-974/L,009246464737,H. POLO P/H M/C STAR SAPPHIRE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockbs010_974,OCKBS010-974/M,009246464720,H. POLO P/H M/C STAR SAPPHIRE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockb0010_673,OCKB0010-673/L,799016543419,H. POLO P/H M/C PARFAIT PINK PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_lbpc_b04_101s_nv,LBPC-B04-101S-NV/XL,7448345760785,H. CAMISA P/HOMBRE M/L NAVY LONG BEACH,Talla: XL,47.74,0.00
+__import__.product_template_lbpc_b04_101s_nv,LBPC-B04-101S-NV/S,7448335226291,H. CAMISA P/HOMBRE M/L NAVY LONG BEACH,Talla: S,47.74,0.00
+__import__.product_template_lbpc_b04_101s_nv,LBPC-B04-101S-NV/M,7448336158126,H. CAMISA P/HOMBRE M/L NAVY LONG BEACH,Talla: M,47.74,0.00
+__import__.product_template_lbpc_b04_101s_nv,LBPC-B04-101S-NV/L,7448332385311,H. CAMISA P/HOMBRE M/L NAVY LONG BEACH,Talla: L,47.74,0.00
+__import__.product_template_opwb0500_118,OPWB0500-118/XL,009246505164,H. CAMISA P/H M/C 100% LINO BRIGHT PENGUIN,Talla: XL,95.57,0.00
+__import__.product_template_opwb0500_118,OPWB0500-118/S,009246505133,H. CAMISA P/H M/C 100% LINO BRIGHT PENGUIN,Talla: S,95.57,0.00
+__import__.product_template_opwb0500_118,OPWB0500-118/M,009246505140,H. CAMISA P/H M/C 100% LINO BRIGHT PENGUIN,Talla: M,95.57,0.00
+__import__.product_template_opwb0500_118,OPWB0500-118/L,009246505157,H. CAMISA P/H M/C 100% LINO BRIGHT PENGUIN,Talla: L,95.57,0.00
+__import__.product_template_ockbs010_993,OCKBS010-993/S,799016543914,H. T-SHIRT P/H MOSAIC BLUE PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockbs010_993,OCKBS010-993/XL,799016543945,H. T-SHIRT P/H MOSAIC BLUE PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_ockb0801_005,OCKB0801-005/S,799016578541,H. POLO P/H M/C DK. CHARCOAL PENGUIN,Talla: S,65.13,0.00
+__import__.product_template_ockb0801_005,OCKB0801-005/M,799016578527,H. POLO P/H M/C DK. CHARCOAL PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockb0801_005,OCKB0801-005/L,799016578510,H. POLO P/H M/C DK. CHARCOAL PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockbs010_993,OCKBS010-993/M,799016543921,H. T-SHIRT P/H MOSAIC BLUE PENGUIN,Talla: M,65.13,0.00
+__import__.product_template_ockbs010_993,OCKBS010-993/L,799016543938,H. T-SHIRT P/H MOSAIC BLUE PENGUIN,Talla: L,65.13,0.00
+__import__.product_template_ockb0801_005,OCKB0801-005/XL,799016578558,H. POLO P/H M/C DK. CHARCOAL PENGUIN,Talla: XL,65.13,0.00
+__import__.product_template_pb,PB-15,PB-15,M. BRAZALETES P/DAMA VARIOS MODELOS,Talla: 15,16.51,0.00
+__import__.product_template_lv_cv_t11_031_nv,LV-CV-T11-031-NV-48,LV-CV-T11-031-NV-48,LEVA P/CABALLERO CARVEN NAVY,Talla: 48,156.43,0.00
+__import__.product_template_lv_cv_t11_031_nv,LV-CV-T11-031-NV-46,LV-CV-T11-031-NV-46,LEVA P/CABALLERO CARVEN NAVY,Talla: 46,156.43,0.00
+__import__.product_template_lv_cv_t11_031_nv,LV-CV-T11-031-NV-44,LV-CV-T11-031-NV-44,LEVA P/CABALLERO CARVEN NAVY,Talla: 44,156.43,0.00
+__import__.product_template_lv_cv_t11_031_nv,LV-CV-T11-031-NV-42,LV-CV-T11-031-NV-42,LEVA P/CABALLERO CARVEN NAVY,Talla: 42,156.43,0.00
+__import__.product_template_lv_cv_t11_031_nv,LV-CV-T11-031-NV-40,LV-CV-T11-031-NV-40,LEVA P/CABALLERO CARVEN NAVY,Talla: 40,156.43,0.00
+__import__.product_template_lv_cv_t11_031_nv,LV-CV-T11-031-NV-38,LV-CV-T11-031-NV-38,LEVA P/CABALLERO CARVEN NAVY,Talla: 38,156.43,0.00
+__import__.product_template_lv_cv_t11_031_nv,LV-CV-T11-031-NV-36,LV-CV-T11-031-NV-36,LEVA P/CABALLERO CARVEN NAVY,Talla: 36,156.43,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-42,PT-CV-T11-031-NV-42,H. PANTALON P/CABALLERO CARVEN,Talla: 42,47.74,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-40,PT-CV-T11-031-NV-40,H. PANTALON P/CABALLERO CARVEN,Talla: 40,47.74,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-38,PT-CV-T11-031-NV-38,H. PANTALON P/CABALLERO CARVEN,Talla: 38,47.74,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-36,PT-CV-T11-031-NV-36,H. PANTALON P/CABALLERO CARVEN,Talla: 36,47.74,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-34,PT-CV-T11-031-NV-34,H. PANTALON P/CABALLERO CARVEN,Talla: 34,47.74,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-32,PT-CV-T11-031-NV-32,H. PANTALON P/CABALLERO CARVEN,Talla: 32,47.74,0.00
+__import__.product_template_pt_cv_t11_031_nv,PT-CV-T11-031-NV-30,PT-CV-T11-031-NV-30,H. PANTALON P/CABALLERO CARVEN,Talla: 30,47.74,0.00
+__import__.product_template_top_fanny_ro,TOP-FANNY-RO/L,TOP-FANNY-RO/OL,TOP P/DAMA MOPA ROJO,Talla: L,57.30,0.00
+__import__.product_template_blusa_hanna_ne,BLUSA-HANNA-NE/XL,BLUSA-HANNA-NE/OXL,BLUSA P/DAMA MOPPA NEGRA,Talla: XL,66.00,0.00
+__import__.product_template_blusa_hanna_ne,BLUSA-HANNA-NE/L,BLUSA-HANNA-NE/OL,BLUSA P/DAMA MOPPA NEGRA,Talla: L,66.00,0.00
+__import__.product_template_blusa_hanna_ne,BLUSA-HANNA-NE/M,BLUSA-HANNA-NE/OM,BLUSA P/DAMA MOPPA NEGRA,Talla: M,66.00,0.00
+__import__.product_template_blusa_hanna_ne,BLUSA-HANNA-NE/S,BLUSA-HANNA-NE/OS,BLUSA P/DAMA MOPPA NEGRA,Talla: S,66.00,0.00
+__import__.product_template_blusa_hanna_ro,BLUSA-HANNA-RO/S,BLUSA-HANNA-RO/OS,BLUSA P/DAMA MOPPA ROJA,Talla: S,66.00,0.00
+__import__.product_template_blusa_hanna_ro,BLUSA-HANNA-RO/M,BLUSA-HANNA-RO/OM,BLUSA P/DAMA MOPPA ROJA,Talla: M,66.00,0.00
+__import__.product_template_blusa_hanna_ro,BLUSA-HANNA-RO/L,BLUSA-HANNA-RO/OL,BLUSA P/DAMA MOPPA ROJA,Talla: L,66.00,0.00
+__import__.product_template_blusa_hanna_ro,BLUSA-HANNA-RO/XL,BLUSA-HANNA-RO/OXL,BLUSA P/DAMA MOPPA ROJA,Talla: XL,66.00,0.00
+__import__.product_template_blus_brigida,BLUS-BRIGIDA/S,BLUS-BRIGIDA/OS,BLUSA P/DAMA MOPA BLANCA,Talla: S,75.56,0.00
+__import__.product_template_blus_brigida,BLUS-BRIGIDA/M,BLUS-BRIGIDA/OM,BLUSA P/DAMA MOPA BLANCA,Talla: M,75.56,0.00
+__import__.product_template_blus_brigida,BLUS-BRIGIDA/L,BLUS-BRIGIDA/OL,BLUSA P/DAMA MOPA BLANCA,Talla: L,75.56,0.00
+__import__.product_template_top_fanny_ve,TOP-FANNY-VE/XL,TOP-FANNY-VE/OXL,TOP P/DAMA MOPA VERDE,Talla: XL,57.30,0.00
+__import__.product_template_top_fanny_ve,TOP-FANNY-VE/L,TOP-FANNY-VE/OL,TOP P/DAMA MOPA VERDE,Talla: L,57.30,0.00
+__import__.product_template_top_fanny_ve,TOP-FANNY-VE/M,TOP-FANNY-VE/OM,TOP P/DAMA MOPA VERDE,Talla: M,57.30,0.00
+__import__.product_template_top_fanny_ro,TOP-FANNY-RO/M,TOP-FANNY-RO/OM,TOP P/DAMA MOPA ROJO,Talla: M,57.30,0.00
+__import__.product_template_top_fanny_ro,TOP-FANNY-RO/XL,TOP-FANNY-RO/OXL,TOP P/DAMA MOPA ROJO,Talla: XL,57.30,0.00
+__import__.product_template_top_vilma_f,TOP-VILMA-F/L,TOP-VILMA-F/OL,TOP MOPA ROJO-BLANCO-FUCSIA,Talla: L,52.96,0.00
+__import__.product_template_top_vilma_f,TOP-VILMA-F/M,TOP-VILMA-F/OM,TOP MOPA ROJO-BLANCO-FUCSIA,Talla: M,52.96,0.00
+__import__.product_template_top_vilma_f,TOP-VILMA-F/S,TOP-VILMA-F/OS,TOP MOPA ROJO-BLANCO-FUCSIA,Talla: S,52.96,0.00
+__import__.product_template_top_vilma_b,TOP-VILMA-B/L,TOP-VILMA-B/OL,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_b),Talla: L,52.96,0.00
+__import__.product_template_top_vilma_b,TOP-VILMA-B/M,TOP-VILMA-B/OM,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_b),Talla: M,52.96,0.00
+__import__.product_template_top_vilma_b,TOP-VILMA-B/S,TOP-VILMA-B/OS,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_b),Talla: S,52.96,0.00
+__import__.product_template_top_vilma_ro,TOP-VILMA-RO/XXL,TOP-VILMA-RO/OXXL,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_ro),Talla: XXL,52.96,0.00
+__import__.product_template_top_vilma_ro,TOP-VILMA-RO/XL,TOP-VILMA-RO/OXL,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_ro),Talla: XL,52.96,0.00
+__import__.product_template_top_vilma_ro,TOP-VILMA-RO/L,TOP-VILMA-RO/OL,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_ro),Talla: L,52.96,0.00
+__import__.product_template_top_vilma_ro,TOP-VILMA-RO/M,TOP-VILMA-RO/OM,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_ro),Talla: M,52.96,0.00
+__import__.product_template_top_vilma_ro,TOP-VILMA-RO/S,TOP-VILMA-RO/OS,TOP MOPA ROJO-BLANCO-FUCSIA (top_vilma_ro),Talla: S,52.96,0.00
+__import__.product_template_vest_laura_b,VEST-LAURA-B/M,VEST-LAURA-B/OM,VESTIDO DAMA BLANCO - VERDE,Talla: M,142.52,0.00
+__import__.product_template_vest_laura_b,VEST-LAURA-B/S,VEST-LAURA-B/OS,VESTIDO DAMA BLANCO - VERDE,Talla: S,142.52,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-18-S2,ERN-SABAT-10-18-S2,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 18, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-17.5-S1,ERNS102317501,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 17.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_zp_1004_picasso_ne,ZP-1004-PICASSO-NE/8.5,ZP1004PICANE/O8.5,Zapato ZP-1004-PICASSO-NE,Talla: 8.5,130.35,0.00
+__import__.product_template_zp_1004_picasso_ne,ZP-1004-PICASSO-NE/8,ZP1004PICANE/O8,Zapato ZP-1004-PICASSO-NE,Talla: 8,130.35,0.00
+__import__.product_template_zp_1004_picasso_ne,ZP-1004-PICASSO-NE/7.5,ZP1004PICANE/O7.5,Zapato ZP-1004-PICASSO-NE,Talla: 7.5,130.35,0.00
+__import__.product_template_zp_1004_picasso_ne,ZP-1004-PICASSO-NE/6,ZP1004PICANE/O6,Zapato ZP-1004-PICASSO-NE,Talla: 6,130.35,0.00
+__import__.product_template_zp_1004_picasso_ne,ZP-1004-PICASSO-NE/5.5,ZP1004PICANE/O5.5,Zapato ZP-1004-PICASSO-NE,Talla: 5.5,130.35,0.00
+__import__.product_template_zp_1002_ambar_vn,ZP-1002-AMBAR-VN/8.5,ZP1002AMBARVN/O8.5,Zapato ZP-1002-AMBAR-VN,Talla: 8.5,130.35,0.00
+__import__.product_template_zp_1002_ambar_vn,ZP-1002-AMBAR-VN/8,ZP1002AMBARVN/O8,Zapato ZP-1002-AMBAR-VN,Talla: 8,130.35,0.00
+__import__.product_template_zp_1002_ambar_vn,ZP-1002-AMBAR-VN/7.5,ZP1002AMBARVN/O7.5,Zapato ZP-1002-AMBAR-VN,Talla: 7.5,130.35,0.00
+__import__.product_template_zp_1002_ambar_vn,ZP-1002-AMBAR-VN/6,ZP1002AMBARVN/O6,Zapato ZP-1002-AMBAR-VN,Talla: 6,130.35,0.00
+__import__.product_template_zp_1002_ambar_vn,ZP-1002-AMBAR-VN/5.5,ZP1002AMBARVN/O5.5,Zapato ZP-1002-AMBAR-VN,Talla: 5.5,130.35,0.00
+__import__.product_template_pt_23e312010_8,PT-23E312010-8/34,23E3120108202434,Pantalon PT-23E312010-8,Talla: 34,47.74,0.00
+__import__.product_template_pt_23e312010_8,PT-23E312010-8/36,23E3120108202436,Pantalon PT-23E312010-8,Talla: 36,47.74,0.00
+__import__.product_template_pt_23e312010_8,PT-23E312010-8/38,23E3120108202438,Pantalon PT-23E312010-8,Talla: 38,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/38,23C2938686202438,Pantalon PT-23C29386-86,Talla: 38,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/36,23C2938686202436,Pantalon PT-23C29386-86,Talla: 36,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/34,23C2938686202434,Pantalon PT-23C29386-86,Talla: 34,47.74,0.00
+__import__.product_template_pt_23e312010_8,PT-23E312010-8/33,23E3120108202433,Pantalon PT-23E312010-8,Talla: 33,47.74,0.00
+__import__.product_template_pt_23e312010_8,PT-23E312010-8/32,23E3120108202432,Pantalon PT-23E312010-8,Talla: 32,47.74,0.00
+__import__.product_template_pt_23e312010_8,PT-23E312010-8/40,23E3120108202440,Pantalon PT-23E312010-8,Talla: 40,47.74,0.00
+__import__.product_template_pt_23e312010_8,PT-23E312010-8/30,23E3120108202430,Pantalon PT-23E312010-8,Talla: 30,47.74,0.00
+__import__.product_template_pt_23c29386_88,PT-23C29386-88/40,23C2938688202440,Pantalon PT-23C29386-88,Talla: 40,47.74,0.00
+__import__.product_template_pt_23c29386_88,PT-23C29386-88/33,23C2938688202433,Pantalon PT-23C29386-88,Talla: 33,47.74,0.00
+__import__.product_template_pt_23c29386_88,PT-23C29386-88/32,23C2938688202432,Pantalon PT-23C29386-88,Talla: 32,47.74,0.00
+__import__.product_template_pt_23c29386_88,PT-23C29386-88/38,23C2938688202438,Pantalon PT-23C29386-88,Talla: 38,47.74,0.00
+__import__.product_template_pt_23c29386_88,PT-23C29386-88/36,23C2938688202436,Pantalon PT-23C29386-88,Talla: 36,47.74,0.00
+__import__.product_template_pt_23c29386_88,PT-23C29386-88/30,23C2938688202430,Pantalon PT-23C29386-88,Talla: 30,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/40,23C2938686202440,Pantalon PT-23C29386-86,Talla: 40,47.74,0.00
+__import__.product_template_pt_23c29386_88,PT-23C29386-88/34,23C2938688202434,Pantalon PT-23C29386-88,Talla: 34,47.74,0.00
+__import__.product_template_pt_23a29607_32,PT-23A29607-32/40,23A2960732202440,Pantalon PT-23A29607-32,Talla: 40,47.74,0.00
+__import__.product_template_pt_23a29607_32,PT-23A29607-32/38,23A2960732202438,Pantalon PT-23A29607-32,Talla: 38,47.74,0.00
+__import__.product_template_pt_23a29607_32,PT-23A29607-32/36,23A2960732202436,Pantalon PT-23A29607-32,Talla: 36,47.74,0.00
+__import__.product_template_pt_23a29607_32,PT-23A29607-32/34,23A2960732202434,Pantalon PT-23A29607-32,Talla: 34,47.74,0.00
+__import__.product_template_pt_23a29607_32,PT-23A29607-32/33,23A2960732202433,Pantalon PT-23A29607-32,Talla: 33,47.74,0.00
+__import__.product_template_pt_23a29607_32,PT-23A29607-32/32,23A2960732202432,Pantalon PT-23A29607-32,Talla: 32,47.74,0.00
+__import__.product_template_pt_23a29607_32,PT-23A29607-32/30,23A2960732202430,Pantalon PT-23A29607-32,Talla: 30,47.74,0.00
+__import__.product_template_pt_23a1516_6,PT-23A1516-6/40,23A15166202440,Pantalon PT-23A1516-6,Talla: 40,47.74,0.00
+__import__.product_template_pt_23a1516_6,PT-23A1516-6/38,23A15166202438,Pantalon PT-23A1516-6,Talla: 38,47.74,0.00
+__import__.product_template_pt_23a1516_6,PT-23A1516-6/36,23A15166202436,Pantalon PT-23A1516-6,Talla: 36,47.74,0.00
+__import__.product_template_pt_23a1516_6,PT-23A1516-6/34,23A15166202434,Pantalon PT-23A1516-6,Talla: 34,47.74,0.00
+__import__.product_template_pt_23a1516_6,PT-23A1516-6/33,23A15166202433,Pantalon PT-23A1516-6,Talla: 33,47.74,0.00
+__import__.product_template_pt_23a1516_6,PT-23A1516-6/32,23A15166202432,Pantalon PT-23A1516-6,Talla: 32,47.74,0.00
+__import__.product_template_pt_23a1516_6,PT-23A1516-6/30,23A15166202430,Pantalon PT-23A1516-6,Talla: 30,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/32,23C2938686202432,Pantalon PT-23C29386-86,Talla: 32,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/30,23C2938686202430,Pantalon PT-23C29386-86,Talla: 30,47.74,0.00
+__import__.product_template_pt_23c29386_86,PT-23C29386-86/33,23C2938686202433,Pantalon PT-23C29386-86,Talla: 33,47.74,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/60,23A1516620246042,Terno 23A1516-6BC-2,Talla: 60,304.26,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/62,23A1516620246244,Terno 23A1516-6BC-2,Talla: 62,304.26,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/64,23A1516620246446,Terno 23A1516-6BC-2,Talla: 64,304.26,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/66,23A1516620246648,Terno 23A1516-6BC-2,Talla: 66,304.26,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/68,23A1516620246850,Terno 23A1516-6BC-2,Talla: 68,304.26,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/70,23A1516620247052,Terno 23A1516-6BC-2,Talla: 70,304.26,0.00
+__import__.product_template_23c29386_86bc_2,23C29386-86BC-2/62,23C293868620246244,Terno 23C29386-86BC-2,Talla: 62,304.26,0.00
+__import__.product_template_23c29386_86bc_2,23C29386-86BC-2/64,23C293868620246446,Terno 23C29386-86BC-2,Talla: 64,304.26,0.00
+__import__.product_template_23c29386_86bc_2,23C29386-86BC-2/66,23C293868620246648,Terno 23C29386-86BC-2,Talla: 66,304.26,0.00
+__import__.product_template_23c29386_86bc_2,23C29386-86BC-2/68,23C293868620246850,Terno 23C29386-86BC-2,Talla: 68,304.26,0.00
+__import__.product_template_23c29386_86bc_2,23C29386-86BC-2/70,23C293868620247052,Terno 23C29386-86BC-2,Talla: 70,304.26,0.00
+__import__.product_template_23a29607_32bc_2,23A29607-32BC-2/46,23A2960732244628,Terno 23A29607-32BC-2,Talla: 46,260.78,0.00
+__import__.product_template_23a29607_32bc_2,23A29607-32BC-2/48,23A2960732244830,Terno 23A29607-32BC-2,Talla: 48,260.78,0.00
+__import__.product_template_23a29607_32bc_2,23A29607-32BC-2/50,23A2960732245032,Terno 23A29607-32BC-2,Talla: 50,260.78,0.00
+__import__.product_template_23a29607_32bc_2,23A29607-32BC-2/52,23A2960732245234,Terno 23A29607-32BC-2,Talla: 52,260.78,0.00
+__import__.product_template_23a29607_32bc_2,23A29607-32BC-2/54,23A2960732245436,Terno 23A29607-32BC-2,Talla: 54,260.78,0.00
+__import__.product_template_23a29607_32bc_2,23A29607-32BC-2/56,23A2960732245638,Terno 23A29607-32BC-2,Talla: 56,260.78,0.00
+__import__.product_template_23a29607_32bc_2,23A29607-32BC-2/58,23A2960732245840,Terno 23A29607-32BC-2,Talla: 58,260.78,0.00
+__import__.product_template_23b11210_100bc_2,23B11210-100BC-2/46,23B11210100244628,Terno 23B11210-100BC-2,Talla: 46,260.78,0.00
+__import__.product_template_23b11210_100bc_2,23B11210-100BC-2/48,23B11210100244830,Terno 23B11210-100BC-2,Talla: 48,260.78,0.00
+__import__.product_template_23b11210_100bc_2,23B11210-100BC-2/50,23B11210100245032,Terno 23B11210-100BC-2,Talla: 50,260.78,0.00
+__import__.product_template_23b11210_100bc_2,23B11210-100BC-2/52,23B11210100245234,Terno 23B11210-100BC-2,Talla: 52,260.78,0.00
+__import__.product_template_23b11210_100bc_2,23B11210-100BC-2/54,23B11210100245436,Terno 23B11210-100BC-2,Talla: 54,260.78,0.00
+__import__.product_template_23b11210_100bc_2,23B11210-100BC-2/56,23B11210100245638,Terno 23B11210-100BC-2,Talla: 56,260.78,0.00
+__import__.product_template_23b11210_100bc_2,23B11210-100BC-2/58,23B11210100245840,Terno 23B11210-100BC-2,Talla: 58,260.78,0.00
+__import__.product_template_23c29118_16bc_2,23C29118-16BC-2/46,23C2911816244628,Terno 23C29118-16BC-2,Talla: 46,260.78,0.00
+__import__.product_template_23c29118_16bc_2,23C29118-16BC-2/48,23C2911816244830,Terno 23C29118-16BC-2,Talla: 48,260.78,0.00
+__import__.product_template_23c29118_16bc_2,23C29118-16BC-2/50,23C2911816245032,Terno 23C29118-16BC-2,Talla: 50,260.78,0.00
+__import__.product_template_23c29118_16bc_2,23C29118-16BC-2/52,23C2911816245234,Terno 23C29118-16BC-2,Talla: 52,260.78,0.00
+__import__.product_template_23c29118_16bc_2,23C29118-16BC-2/54,23C2911816245436,Terno 23C29118-16BC-2,Talla: 54,260.78,0.00
+__import__.product_template_23c29118_16bc_2,23C29118-16BC-2/56,23C2911816245638,Terno 23C29118-16BC-2,Talla: 56,260.78,0.00
+__import__.product_template_23c29118_16bc_2,23C29118-16BC-2/58,23C2911816245840,Terno 23C29118-16BC-2,Talla: 58,260.78,0.00
+__import__.product_template_23e2780_n_bc_2,23E2780-N-BC-2/46,23E2780N20244628,Terno 23E2780-N-BC-2,Talla: 46,260.78,0.00
+__import__.product_template_23e2780_n_bc_2,23E2780-N-BC-2/48,23E2780N20244830,Terno 23E2780-N-BC-2,Talla: 48,260.78,0.00
+__import__.product_template_23e2780_n_bc_2,23E2780-N-BC-2/50,23E2780N20245032,Terno 23E2780-N-BC-2,Talla: 50,260.78,0.00
+__import__.product_template_23e2780_n_bc_2,23E2780-N-BC-2/52,23E2780N20245234,Terno 23E2780-N-BC-2,Talla: 52,260.78,0.00
+__import__.product_template_23e2780_n_bc_2,23E2780-N-BC-2/54,23E2780N20245436,Terno 23E2780-N-BC-2,Talla: 54,260.78,0.00
+__import__.product_template_23e2780_n_bc_2,23E2780-N-BC-2/56,23E2780N20245638,Terno 23E2780-N-BC-2,Talla: 56,260.78,0.00
+__import__.product_template_23e2780_n_bc_2,23E2780-N-BC-2/58,23E2780N20245840,Terno 23E2780-N-BC-2,Talla: 58,260.78,0.00
+__import__.product_template_23e312010_8bc_2,23E312010-8BC-2/46,23E3120108244628,Terno 23E312010-8BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23e312010_8bc_2,23E312010-8BC-2/48,23E3120108244830,Terno 23E312010-8BC-2,Talla: 48,243.39,0.00
+__import__.product_template_23e3705_25bc_2,23E3705-25BC-2/46,23E37052520244628,Terno 23E3705-25BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23e3705_25bc_2,23E3705-25BC-2/48,23E37052520244830,Terno 23E3705-25BC-2,Talla: 48,243.39,0.00
+__import__.product_template_23e3705_25bc_2,23E3705-25BC-2/50,23E37052520245032,Terno 23E3705-25BC-2,Talla: 50,243.39,0.00
+__import__.product_template_23e3705_25bc_2,23E3705-25BC-2/52,23E37052520245234,Terno 23E3705-25BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23e3705_25bc_2,23E3705-25BC-2/54,23E37052520245436,Terno 23E3705-25BC-2,Talla: 54,243.39,0.00
+__import__.product_template_23e3705_25bc_2,23E3705-25BC-2/56,23E37052520245638,Terno 23E3705-25BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23e3705_25bc_2,23E3705-25BC-2/58,23E37052520245840,Terno 23E3705-25BC-2,Talla: 58,243.39,0.00
+__import__.product_template_23e5296_4bc_2,23E5296-4BC-2/46,23E5296420244628,Terno 23E5296-4BC-2,Talla: 46,260.78,0.00
+__import__.product_template_23e5296_4bc_2,23E5296-4BC-2/48,23E5296420244830,Terno 23E5296-4BC-2,Talla: 48,260.78,0.00
+__import__.product_template_23e5296_4bc_2,23E5296-4BC-2/50,23E5296420245032,Terno 23E5296-4BC-2,Talla: 50,260.78,0.00
+__import__.product_template_23e5296_4bc_2,23E5296-4BC-2/52,23E5296420245234,Terno 23E5296-4BC-2,Talla: 52,260.78,0.00
+__import__.product_template_23e5296_4bc_2,23E5296-4BC-2/54,23E5296420245436,Terno 23E5296-4BC-2,Talla: 54,260.78,0.00
+__import__.product_template_23e5296_4bc_2,23E5296-4BC-2/56,23E5296420245638,Terno 23E5296-4BC-2,Talla: 56,260.78,0.00
+__import__.product_template_23e5296_4bc_2,23E5296-4BC-2/58,23E5296420245840,Terno 23E5296-4BC-2,Talla: 58,260.78,0.00
+__import__.product_template_23e312010_8bc_2,23E312010-8BC-2/50,23E3120108245032,Terno 23E312010-8BC-2,Talla: 50,243.39,0.00
+__import__.product_template_23e312010_8bc_2,23E312010-8BC-2/52,23E3120108245234,Terno 23E312010-8BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23e312010_8bc_2,23E312010-8BC-2/54,23E3120108245436,Terno 23E312010-8BC-2,Talla: 54,243.39,0.00
+__import__.product_template_23e312010_8bc_2,23E312010-8BC-2/56,23E3120108245638,Terno 23E312010-8BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23e312010_8bc_2,23E312010-8BC-2/58,23E3120108245840,Terno 23E312010-8BC-2,Talla: 58,243.39,0.00
+__import__.product_template_pt_ni_o,PT-NIÑO/20,PT-NIÑO/O20,Pantalon PT-NIÑO,Talla: 20,57.99,0.00
+__import__.product_template_016_zoley_top,016-ZOLEY-TOP/L,016ZOTP/OL,TOP DAMA ZOLEY FUCSIA Y BLANCO,Talla: L,43.39,0.00
+__import__.product_template_016_zoley_top,016-ZOLEY-TOP/M,016ZOTP/OM,TOP DAMA ZOLEY FUCSIA Y BLANCO,Talla: M,43.39,0.00
+__import__.product_template_007_zoley_top,007-ZOLEY-TOP/L,007ZOTP/L,TOP LINO ZOLEY ARENA,Talla: L,43.39,0.00
+__import__.product_template_007_zoley_pant,007-ZOLEY-PANT/L,007ZPAN/L,PANTALON LINO ZOLEY ARENA,Talla: L,51.22,0.00
+__import__.product_template_003_zoley_sh,003-ZOLEY-SH/XL,003ZOS/OXL,SHORT ZOLEY LINO VERDE,Talla: XL,46.87,0.00
+__import__.product_template_003_zoley_sh,003-ZOLEY-SH/L,003ZOSH/OL,SHORT ZOLEY LINO VERDE,Talla: L,46.87,0.00
+__import__.product_template_007_zoley_top,007-ZOLEY-TOP/M,007ZOTP/M,TOP LINO ZOLEY ARENA,Talla: M,43.39,0.00
+__import__.product_template_007_zoley_pant,007-ZOLEY-PANT/M,007ZPAN/M,PANTALON LINO ZOLEY ARENA,Talla: M,51.22,0.00
+__import__.product_template_003_zoley_sh,003-ZOLEY-SH/M,003ZOSH/OM,SHORT ZOLEY LINO VERDE,Talla: M,46.87,0.00
+__import__.product_template_pt_008_black_1,PT-008-BLACK-1/40,PT-008-BLACK-1/O40,Pantalon PT-008-BLACK-1,Talla: 40,39.04,0.00
+__import__.product_template_pt_17001_7,PT-17001-7/38,PT-17001-7/O38,Pantalon PT-17001-7,Talla: 38,47.74,0.00
+__import__.product_template_ern_sabat_1259,ERN-SABAT-1259-16.5-S2,ERNST1259/16.5-S2,H. CAMISA P/S BRUNO CASSINI WHITE 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-14.5-S2,ERNS125914502,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 14.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_zp_gam_cr_s_f_cassini,ZP-GAM-CR-S/F-CASSINI/7,ZPGAMCRSFCAS/OO7,Zapato ZP-GAM-CR-S/F-CASSINI,Talla: 7,152.09,0.00
+__import__.product_template_zp_gam_cr_s_f_cassini,ZP-GAM-CR-S/F-CASSINI/7.5,ZPGAMCRSFCAS/OO7.5,Zapato ZP-GAM-CR-S/F-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_gam_cr_s_f_cassini,ZP-GAM-CR-S/F-CASSINI/8,ZPGAMCRSFCAS/OO8,Zapato ZP-GAM-CR-S/F-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_gam_cr_s_f_cassini,ZP-GAM-CR-S/F-CASSINI/8.5,ZPGAMCRSFCAS/OO8.5,Zapato ZP-GAM-CR-S/F-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_gam_cr_s_f_cassini,ZP-GAM-CR-S/F-CASSINI/9,ZPGAMCRSFCAS/OO9,Zapato ZP-GAM-CR-S/F-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_gam_cr_s_f_cassini,ZP-GAM-CR-S/F-CASSINI/9.5,ZPGAMCRSFCAS/OO9.5,Zapato ZP-GAM-CR-S/F-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_gam_cr_s_f_cassini,ZP-GAM-CR-S/F-CASSINI/10,ZPGAMCRSFCAS/OO10,Zapato ZP-GAM-CR-S/F-CASSINI,Talla: 10,152.09,0.00
+__import__.product_template_ern_llana_1260dc,ERN-LLANA-1260DC-14.5-S2,ERNLL1260DC-14.5-S2,H. CAMISA P/CABALLERO D/P WHITE BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_llana_1260dc,ERN-LLANA-1260DC-14.5-S1,ERNLL1260DC-14.5-S1,H. CAMISA P/CABALLERO D/P WHITE BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_llana_1260dc,ERN-LLANA-1260DC-17-S2,ERNLL1260DC-17-S2,H. CAMISA P/CABALLERO D/P WHITE BRUNO CASSINI,"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_llana_1260dc,ERN-LLANA-1260DC-17-S1,ERNLL1260DC-17-S1,H. CAMISA P/CABALLERO D/P WHITE BRUNO CASSINI,"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_llana_1260,ERN-LLANA-1260-17-S1,ERNLL126017-S1,H. CAMISA P/CABALLERO P/S WHITE BRUNO CASSINI,"Talla: 17, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_ern_llana_1260,ERN-LLANA-1260-17-S2,ERNLL126017-S2,H. CAMISA P/CABALLERO P/S WHITE BRUNO CASSINI,"Talla: 17, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_ern_llana_1260,ERN-LLANA-1260-17.5-S1,ERNLL126017.5-S1,H. CAMISA P/CABALLERO P/S WHITE BRUNO CASSINI,"Talla: 17.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_ern_llana_1260,ERN-LLANA-1260-17.5-S2,ERNLL126017.5-S2,H. CAMISA P/CABALLERO P/S WHITE BRUNO CASSINI,"Talla: 17.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_zp_gam_cof_s_f_cassini,ZP-GAM-COF-S/F-CASSINI/8.5,ZPGAMCOFSFCAS/OO8.5,Zapato ZP-GAM-COF-S/F-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_cuwsp014_467,CUWSP014-467/L,7448342959953,H. CAMISA CUBAVERA M/C P/CABALLERO MEDITERRANEA B,Talla: L,73.83,0.00
+__import__.product_template_tl_y23_101b_a,TL-Y23-101B.A/34,7453040766789,Terno TL-Y23-101B.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_10_500b,TL-10-500B/46,TL-10-500B/O46,Terno TL-10-500B,Talla: 46,165.13,0.00
+__import__.product_template_tl_d23_1102a_a,TL-D23-1102A.A/40,7453040873685,Terno TL-D23-1102A.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_d23_1101d_a,TL-D23-1101D.A/32,TL-D23-1101D.A/O32,Terno TL-D23-1101D.A,Talla: 32,47.74,0.00
+__import__.product_template_tl_10_500b,TL-10-500B/38,TL-10-500B/O38,Terno TL-10-500B,Talla: 38,165.13,0.00
+__import__.product_template_tl_10_500b,TL-10-500B/40,TL-10-500B/O40,Terno TL-10-500B,Talla: 40,165.13,0.00
+__import__.product_template_tl_d23_1102b_a,TL-D23-1102B.A/34,745304087375,Terno TL-D23-1102B.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1102b_a,TL-D23-1102B.A/30,7453040873739,Terno TL-D23-1102B.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_10_500b,TL-10-500B/42,TL-10-500B/O42,Terno TL-10-500B,Talla: 42,165.13,0.00
+__import__.product_template_tl_10_500b,TL-10-500B/36,TL-10-500B/O36,Terno TL-10-500B,Talla: 36,165.13,0.00
+__import__.product_template_tl_d23_1102b_a,TL-D23-1102B.A/36,745304087376,Terno TL-D23-1102B.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1102a_a,TL-D23-1102A.A/32,TL-D23-1102A.A/O32,Terno TL-D23-1102A.A,Talla: 32,47.74,0.00
+__import__.product_template_tl_y23_101b_a,TL-Y23-101B.A/30,TL-Y23-101B.A/O30,Terno TL-Y23-101B.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_d23_1102a_a,TL-D23-1102A.A/38,7453040873678,Terno TL-D23-1102A.A,Talla: 38,47.74,0.00
+__import__.product_template_tl_d23_1102d_a,TL-D23-1102D.A/30,TL-D23-1102D.A/O30,Terno TL-D23-1102D.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_d23_1102c_a,TL-D23-1102C.A/38,7453040873876,Terno TL-D23-1102C.A,Talla: 38,47.74,0.00
+__import__.product_template_tl_y23_104a_b,TL-Y23-104A.B/34,205005476960,Terno TL-Y23-104A.B,Talla: 34,47.74,0.00
+__import__.product_template_tl_10_500b,TL-10-500B/44,TL-10-500B/O44,Terno TL-10-500B,Talla: 44,165.13,0.00
+__import__.product_template_tl_y23_101b_a,TL-Y23-101B.A/38,745304076680,Terno TL-Y23-101B.A,Talla: 38,47.74,0.00
+__import__.product_template_tl_d23_1101d_a,TL-D23-1101D.A/40,745304087358,Terno TL-D23-1101D.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_d23_1101d_a,TL-D23-1101D.A/34,7453040873555,Terno TL-D23-1101D.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1102b_a,TL-D23-1102B.A/38,745304087377,Terno TL-D23-1102B.A,Talla: 38,47.74,0.00
+__import__.product_template_tl_d23_1102b_a,TL-D23-1102B.A/40,7453040873784,Terno TL-D23-1102B.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_d23_1102c_a,TL-D23-1102C.A/36,7453040873869,Terno TL-D23-1102C.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1102c_a,TL-D23-1102C.A/30,7453040873838,Terno TL-D23-1102C.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_d23_1102c_a,TL-D23-1102C.A/32,7453040873845,Terno TL-D23-1102C.A,Talla: 32,47.74,0.00
+__import__.product_template_tl_d23_1102d_a,TL-D23-1102D.A/40,7453040873982,Terno TL-D23-1102D.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_d23_1102d_a,TL-D23-1102D.A/38,7453040873975,Terno TL-D23-1102D.A,Talla: 38,47.74,0.00
+__import__.product_template_tl_d23_1102d_a,TL-D23-1102D.A/36,7453040873968,Terno TL-D23-1102D.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1102d_a,TL-D23-1102D.A/34,7453040873951,Terno TL-D23-1102D.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1102d_a,TL-D23-1102D.A/32,7453040873944,Terno TL-D23-1102D.A,Talla: 32,47.74,0.00
+__import__.product_template_tl_d23_1102a_a,TL-D23-1102A.A/34,7453040873654,Terno TL-D23-1102A.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1101d_a,TL-D23-1101D.A/36,7453040873562,Terno TL-D23-1101D.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1101d_a,TL-D23-1101D.A/30,TL-D23-1101D.A/30,Terno TL-D23-1101D.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_y23_101b_a,TL-Y23-101B.A/32,TL-Y23-101B.A/O32,Terno TL-Y23-101B.A,Talla: 32,47.74,0.00
+__import__.product_template_tl_y23_104a_b,TL-Y23-104A.B/40,205005476976,Terno TL-Y23-104A.B,Talla: 40,47.74,0.00
+__import__.product_template_tl_y23_101b_a,TL-Y23-101B.A/36,745304076679,Terno TL-Y23-101B.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_y23_101b_a,TL-Y23-101B.A/40,7453040766819,Terno TL-Y23-101B.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_y23_104a_b,TL-Y23-104A.B/38,20500547697,Terno TL-Y23-104A.B,Talla: 38,47.74,0.00
+__import__.product_template_tl_d23_1102c_a,TL-D23-1102C.A/34,7453040873852,Terno TL-D23-1102C.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1102a_a,TL-D23-1102A.A/30,7453040873630,Terno TL-D23-1102A.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_d23_1101d_a,TL-D23-1101D.A/38,745304087357,Terno TL-D23-1101D.A,Talla: 38,47.74,0.00
+__import__.product_template_tl_d23_1102b_a,TL-D23-1102B.A/32,7453040873746,Terno TL-D23-1102B.A,Talla: 32,47.74,0.00
+__import__.product_template_tl_d23_1102c_a,TL-D23-1102C.A/40,7453040873883,Terno TL-D23-1102C.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_y23_104a_b,TL-Y23-104A.B/36,2050054769628,Terno TL-Y23-104A.B,Talla: 36,47.74,0.00
+__import__.product_template_tl_y23_104a_b,TL-Y23-104A.B/30,2050054769567,Terno TL-Y23-104A.B,Talla: 30,47.74,0.00
+__import__.product_template_tl_y23_104a_b,TL-Y23-104A.B/32,2050054769581,Terno TL-Y23-104A.B,Talla: 32,47.74,0.00
+__import__.product_template_tl_d23_1102a_a,TL-D23-1102A.A/36,7453040873661,Terno TL-D23-1102A.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1101c_a,TL-D23-1101C.A/40,7453040873487,Terno TL-D23-1101C.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_d23_1101c_a,TL-D23-1101C.A/36,745304087346,Terno TL-D23-1101C.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1101c_a,TL-D23-1101C.A/34,745304087345,Terno TL-D23-1101C.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1101c_a,TL-D23-1101C.A/38,745304087347,Terno TL-D23-1101C.A,Talla: 38,47.74,0.00
+__import__.product_template_lbpc_b30_101s_wh,LBPC-B30-101S-WH/M,0743682060121,H. T-SHIRT LONG BEACH M/C WHITE,Talla: M,21.65,0.00
+__import__.product_template_fa_33_1035br,FA-33-1035BR/46,0743682083014,Terno FA-33-1035BR,Talla: 46,243.39,0.00
+__import__.product_template_fa_33_999r_nv,FA-33-999R-NV/38,0743682008352,Terno FA-33-999R-NV,Talla: 38,243.39,0.00
+__import__.product_template_fa_33_999r_nv,FA-33-999R-NV/44,0743682008383,Terno FA-33-999R-NV,Talla: 44,243.39,0.00
+__import__.product_template_fa_33_999r_nv,FA-33-999R-NV/46,0743682008390,Terno FA-33-999R-NV,Talla: 46,243.39,0.00
+__import__.product_template_fa_33_1035br,FA-33-1035BR/40,0743682082987,Terno FA-33-1035BR,Talla: 40,243.39,0.00
+__import__.product_template_tl_d23_1101b_a,TL-D23-1101B.A/34,7453040873357,Terno TL-D23-1101B.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1101b_a,TL-D23-1101B.A/32,7453040873340,Terno TL-D23-1101B.A,Talla: 32,47.74,0.00
+__import__.product_template_fa_33_1035br,FA-33-1035BR/44,0743682083007,Terno FA-33-1035BR,Talla: 44,243.39,0.00
+__import__.product_template_tl_d23_1101b_a,TL-D23-1101B.A/30,745304087333,Terno TL-D23-1101B.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_d23_1101a_a,TL-D23-1101A.A/40,7453040873289,Terno TL-D23-1101A.A,Talla: 40,47.74,0.00
+__import__.product_template_fa_33_999r_nv,FA-33-999R-NV/40,0743682008369,Terno FA-33-999R-NV,Talla: 40,243.39,0.00
+__import__.product_template_fa_33_1035br,FA-33-1035BR/38,0743682082970,Terno FA-33-1035BR,Talla: 38,243.39,0.00
+__import__.product_template_tl_d23_1101c_a,TL-D23-1101C.A/32,TL-D23-1101C.A/O32,Terno TL-D23-1101C.A,Talla: 32,47.74,0.00
+__import__.product_template_fa_33_1000f_sl,FA-33-1000F-SL/40,0743682008864,Terno FA-33-1000F-SL,Talla: 40,243.39,0.00
+__import__.product_template_tl_d23_1101a_a,TL-D23-1101A.A/30,7453040873234,Terno TL-D23-1101A.A,Talla: 30,47.74,0.00
+__import__.product_template_fa_33_1000f_sl,FA-33-1000F-SL/38,0743682008857,Terno FA-33-1000F-SL,Talla: 38,243.39,0.00
+__import__.product_template_fa_33_1000f_nv,FA-33-1000F-NV/46,0743682008949,Terno FA-33-1000F-NV,Talla: 46,243.39,0.00
+__import__.product_template_fa_33_1001f_burg,FA-33-1001F-BURG/44,0743682008789,Terno FA-33-1001F-BURG,Talla: 44,243.39,0.00
+__import__.product_template_lbpc_b30_101s_wh,LBPC-B30-101S-WH/L,0743682060138,H. T-SHIRT LONG BEACH M/C WHITE,Talla: L,21.65,0.00
+__import__.product_template_fa_33_1035br,FA-33-1035BR/42,0743682082994,Terno FA-33-1035BR,Talla: 42,243.39,0.00
+__import__.product_template_fa_33_1000f_nv,FA-33-1000F-NV/42,0743682008925,Terno FA-33-1000F-NV,Talla: 42,243.39,0.00
+__import__.product_template_fa_33_1000f_nv,FA-33-1000F-NV/40,0743682008918,Terno FA-33-1000F-NV,Talla: 40,243.39,0.00
+__import__.product_template_fa_33_1001f_burg,FA-33-1001F-BURG/38,0743682008758,Terno FA-33-1001F-BURG,Talla: 38,243.39,0.00
+__import__.product_template_fa_33_1001f_burg,FA-33-1001F-BURG/46,0743682008796,Terno FA-33-1001F-BURG,Talla: 46,243.39,0.00
+__import__.product_template_fa_33_1035br,FA-33-1035BR/36,0743682082963,Terno FA-33-1035BR,Talla: 36,243.39,0.00
+__import__.product_template_lbpc_a31_254r_dknv,LBPC-A31-254R-DKNV/XL,0743682012472,H. POLO LONG BEACH M/C P/CABALLERO DARK NAVY,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_a31_254r_nge,LBPC-A31-254R-NGE/XL,0743682012519,H. POLO LONG BEACH M/C P/CABALLERO NILO GREEN,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_a31_254r_nge,LBPC-A31-254R-NGE/S,0743682012489,H. POLO LONG BEACH M/C P/CABALLERO NILO GREEN,Talla: S,34.70,0.00
+__import__.product_template_lbpc_a31_254r_nge,LBPC-A31-254R-NGE/M,0743682012496,H. POLO LONG BEACH M/C P/CABALLERO NILO GREEN,Talla: M,34.70,0.00
+__import__.product_template_lbpc_a31_254r_nge,LBPC-A31-254R-NGE/L,0743682012502,H. POLO LONG BEACH M/C P/CABALLERO NILO GREEN,Talla: L,34.70,0.00
+__import__.product_template_lbpc_b30_101s_wh,LBPC-B30-101S-WH/XL,0743682060145,H. T-SHIRT LONG BEACH M/C WHITE,Talla: XL,21.65,0.00
+__import__.product_template_tl_d23_1101b_a,TL-D23-1101B.A/36,7453040873364,Terno TL-D23-1101B.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1101a_a,TL-D23-1101A.A/36,7453040873265,Terno TL-D23-1101A.A,Talla: 36,47.74,0.00
+__import__.product_template_tl_d23_1101a_a,TL-D23-1101A.A/34,7453040873258,Terno TL-D23-1101A.A,Talla: 34,47.74,0.00
+__import__.product_template_tl_d23_1101a_a,TL-D23-1101A.A/32,7453040873241,Terno TL-D23-1101A.A,Talla: 32,47.74,0.00
+__import__.product_template_lbpc_b31_101s_ge,LBPC-B31-101S-GE/M,0743682033798,H. POLO LONG BEACH M/C P/CABALLERO KELLY GREEN,Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_ge,LBPC-B31-101S-GE/XL,0743682033811,H. POLO LONG BEACH M/C P/CABALLERO KELLY GREEN,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_ge,LBPC-B31-101S-GE/S,0743682033781,H. POLO LONG BEACH M/C P/CABALLERO KELLY GREEN,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_ge,LBPC-B31-101S-GE/L,0743682033804,H. POLO LONG BEACH M/C P/CABALLERO KELLY GREEN,Talla: L,34.70,0.00
+__import__.product_template_tl_d23_1101a_a,TL-D23-1101A.A/38,7453040873272,Terno TL-D23-1101A.A,Talla: 38,47.74,0.00
+__import__.product_template_tl_d23_1101c_a,TL-D23-1101C.A/30,TL-D23-1101C.A/O30,Terno TL-D23-1101C.A,Talla: 30,47.74,0.00
+__import__.product_template_tl_d23_1101b_a,TL-D23-1101B.A/40,7453040873388,Terno TL-D23-1101B.A,Talla: 40,47.74,0.00
+__import__.product_template_tl_d23_1101b_a,TL-D23-1101B.A/38,7453040873371,Terno TL-D23-1101B.A,Talla: 38,47.74,0.00
+__import__.product_template_fa_33_1000f_sl,FA-33-1000F-SL/42,0743682008871,Terno FA-33-1000F-SL,Talla: 42,243.39,0.00
+__import__.product_template_fa_33_1001f_burg,FA-33-1001F-BURG/42,0743682008772,Terno FA-33-1001F-BURG,Talla: 42,243.39,0.00
+__import__.product_template_lbpc_a31_243s_bl,LBPC-A31-243S-BL/L,743682034726,H. POLO LONG BEACH M/C P/CABALLERO BLACK,Talla: L,34.70,0.00
+__import__.product_template_lbpc_a31_243s_hch,LBPC-A31-243S-HCH/M,743682034917,H. POLO LONG BEACH M/C P/CABALLERO CHARCOAL,Talla: M,34.70,0.00
+__import__.product_template_lbpc_a31_243s_hch,LBPC-A31-243S-HCH/L,743682034924,H. POLO LONG BEACH M/C P/CABALLERO CHARCOAL,Talla: L,34.70,0.00
+__import__.product_template_lbpc_a31_243s_chrr,LBPC-A31-243S-CHRR/XL,743682034856,H. POLO LONG BEACH M/C P/CABALLERO CHERRY,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_a31_243s_chrr,LBPC-A31-243S-CHRR/S,743682034825,H. POLO LONG BEACH M/C P/CABALLERO CHERRY,Talla: S,34.70,0.00
+__import__.product_template_lbpc_a31_243s_chrr,LBPC-A31-243S-CHRR/M,743682034832,H. POLO LONG BEACH M/C P/CABALLERO CHERRY,Talla: M,34.70,0.00
+__import__.product_template_lbpc_a31_243s_chrr,LBPC-A31-243S-CHRR/L,743682034849,H. POLO LONG BEACH M/C P/CABALLERO CHERRY,Talla: L,34.70,0.00
+__import__.product_template_lbpc_a31_243s_bl,LBPC-A31-243S-BL/XL,743682034733,H. POLO LONG BEACH M/C P/CABALLERO BLACK,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_in,LBPC-B31-101S-IN/S,743682033866,H. POLO LONG BEACH M/C P/CABALLERO INDIGO,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_in,LBPC-B31-101S-IN/M,743682033873,H. POLO LONG BEACH M/C P/CABALLERO INDIGO,Talla: M,34.70,0.00
+__import__.product_template_lbpc_a31_243s_wh,LBPC-A31-243S-WH/XL,743682034771,H. POLO LONG BEACH M/C P/CABALLERO WHITE,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_a31_243s_wh,LBPC-A31-243S-WH/S,743682034740,H. POLO LONG BEACH M/C P/CABALLERO WHITE,Talla: S,34.70,0.00
+__import__.product_template_lbpc_a31_243s_wh,LBPC-A31-243S-WH/M,743682034757,H. POLO LONG BEACH M/C P/CABALLERO WHITE,Talla: M,34.70,0.00
+__import__.product_template_lbpc_a31_243s_wh,LBPC-A31-243S-WH/L,743682034764,H. POLO LONG BEACH M/C P/CABALLERO WHITE,Talla: L,34.70,0.00
+__import__.product_template_lbpc_a31_243s_nv,LBPC-A31-243S-NV/XL,743682034818,H. POLO LONG BEACH M/C P/CABALLERO NAVY,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_a31_243s_nv,LBPC-A31-243S-NV/S,743682034788,H. POLO LONG BEACH M/C P/CABALLERO NAVY,Talla: S,34.70,0.00
+__import__.product_template_lbpc_a31_243s_nv,LBPC-A31-243S-NV/M,743682034795,H. POLO LONG BEACH M/C P/CABALLERO NAVY,Talla: M,34.70,0.00
+__import__.product_template_lbpc_a31_243s_nv,LBPC-A31-243S-NV/L,743682034801,H. POLO LONG BEACH M/C P/CABALLERO NAVY,Talla: L,34.70,0.00
+__import__.product_template_lbpc_a31_243s_lk,LBPC-A31-243S-LK/XL,743682034894,H. POLO LONG BEACH M/C P/CABALLERO LAKE,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_a31_243s_lk,LBPC-A31-243S-LK/S,743682034863,H. POLO LONG BEACH M/C P/CABALLERO LAKE,Talla: S,34.70,0.00
+__import__.product_template_lbpc_a31_243s_lk,LBPC-A31-243S-LK/M,743682034870,H. POLO LONG BEACH M/C P/CABALLERO LAKE,Talla: M,34.70,0.00
+__import__.product_template_lbpc_a31_243s_lk,LBPC-A31-243S-LK/L,743682034887,H. POLO LONG BEACH M/C P/CABALLERO LAKE,Talla: L,34.70,0.00
+__import__.product_template_lbpc_a31_243s_hch,LBPC-A31-243S-HCH/XL,743682034931,H. POLO LONG BEACH M/C P/CABALLERO CHARCOAL,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_a31_243s_hch,LBPC-A31-243S-HCH/S,743682034900,H. POLO LONG BEACH M/C P/CABALLERO CHARCOAL,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_in,LBPC-B31-101S-IN/L,743682033880,H. POLO LONG BEACH M/C P/CABALLERO INDIGO,Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_bl,LBPC-B31-101S-BL/M,743682033590,H. POLO LONG BEACH M/C P/CABALLERO BLACK (lbpc_b31_101s_bl),Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_bl,LBPC-B31-101S-BL/XL,743682033613,H. POLO LONG BEACH M/C P/CABALLERO BLACK (lbpc_b31_101s_bl),Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_chrr,LBPC-B31-101S-CHRR/L,743682033729,H. POLO LONG BEACH M/C P/CABALLERO CHERRY (lbpc_b31_101s_chrr),Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_chrr,LBPC-B31-101S-CHRR/M,743682033712,H. POLO LONG BEACH M/C P/CABALLERO CHERRY (lbpc_b31_101s_chrr),Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_chrr,LBPC-B31-101S-CHRR/XL,743682033736,H. POLO LONG BEACH M/C P/CABALLERO CHERRY (lbpc_b31_101s_chrr),Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_chrr,LBPC-B31-101S-CHRR/S,743682033705,H. POLO LONG BEACH M/C P/CABALLERO CHERRY (lbpc_b31_101s_chrr),Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_bl,LBPC-B31-101S-BL/S,743682033583,H. POLO LONG BEACH M/C P/CABALLERO BLACK (lbpc_b31_101s_bl),Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_bl,LBPC-B31-101S-BL/L,743682033606,H. POLO LONG BEACH M/C P/CABALLERO BLACK (lbpc_b31_101s_bl),Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_nv,LBPC-B31-101S-NV/M,0743682033675,H. POLO LONG BEACH M/C P/CABALLERO NAVY (lbpc_b31_101s_nv),Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_nv,LBPC-B31-101S-NV/L,0743682033682,H. POLO LONG BEACH M/C P/CABALLERO NAVY (lbpc_b31_101s_nv),Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_rs,LBPC-B31-101S-RS/XL,743682034092,H. POLO LONG BEACH M/C P/CABALLERO ROSE,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_rs,LBPC-B31-101S-RS/S,743682034061,H. POLO LONG BEACH M/C P/CABALLERO ROSE,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_rs,LBPC-B31-101S-RS/M,743682034078,H. POLO LONG BEACH M/C P/CABALLERO ROSE,Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_rs,LBPC-B31-101S-RS/L,743682034085,H. POLO LONG BEACH M/C P/CABALLERO ROSE,Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_nv,LBPC-B31-101S-NV/XL,0743682033699,H. POLO LONG BEACH M/C P/CABALLERO NAVY (lbpc_b31_101s_nv),Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_in,LBPC-B31-101S-IN/XL,743682033897,H. POLO LONG BEACH M/C P/CABALLERO INDIGO,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_lk,LBPC-B31-101S-LK/XL,743682033972,H. POLO LONG BEACH M/C P/CABALLERO LAKE (lbpc_b31_101s_lk),Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_lk,LBPC-B31-101S-LK/S,743682033941,H. POLO LONG BEACH M/C P/CABALLERO LAKE (lbpc_b31_101s_lk),Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_lk,LBPC-B31-101S-LK/M,743682033958,H. POLO LONG BEACH M/C P/CABALLERO LAKE (lbpc_b31_101s_lk),Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_lk,LBPC-B31-101S-LK/L,743682033965,H. POLO LONG BEACH M/C P/CABALLERO LAKE (lbpc_b31_101s_lk),Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_iv,LBPC-B31-101S-IV/XL,743682034054,H. POLO LONG BEACH M/C P/CABALLERO IVORY,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_iv,LBPC-B31-101S-IV/S,743682034023,H. POLO LONG BEACH M/C P/CABALLERO IVORY,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_iv,LBPC-B31-101S-IV/M,743682034030,H. POLO LONG BEACH M/C P/CABALLERO IVORY,Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_iv,LBPC-B31-101S-IV/L,743682034047,H. POLO LONG BEACH M/C P/CABALLERO IVORY,Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_mu,LBPC-B31-101S-MU/XL,743682033774,H. POLO LONG BEACH M/C P/CABALLERO MUSTARD,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_mu,LBPC-B31-101S-MU/S,743682033743,H. POLO LONG BEACH M/C P/CABALLERO MUSTARD,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_mu,LBPC-B31-101S-MU/M,743682033750,H. POLO LONG BEACH M/C P/CABALLERO MUSTARD,Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_mu,LBPC-B31-101S-MU/L,743682033767,H. POLO LONG BEACH M/C P/CABALLERO MUSTARD,Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_ltge,LBPC-B31-101S-LTGE/XL,743682034139,H. POLO LONG BEACH M/C P/CABALLERO PISTACCIO,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_ltge,LBPC-B31-101S-LTGE/S,743682034108,H. POLO LONG BEACH M/C P/CABALLERO PISTACCIO,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_ltge,LBPC-B31-101S-LTGE/M,743682034115,H. POLO LONG BEACH M/C P/CABALLERO PISTACCIO,Talla: M,34.70,0.00
+__import__.product_template_lbpc_b31_101s_ltge,LBPC-B31-101S-LTGE/L,743682034122,H. POLO LONG BEACH M/C P/CABALLERO PISTACCIO,Talla: L,34.70,0.00
+__import__.product_template_lbpc_b31_101s_wi,LBPC-B31-101S-WI/XL,0743682033859,H. POLO LONG BEACH M/C P/CABALLERO WINE,Talla: XL,34.70,0.00
+__import__.product_template_lbpc_b31_101s_wi,LBPC-B31-101S-WI/S,0743682033828,H. POLO LONG BEACH M/C P/CABALLERO WINE,Talla: S,34.70,0.00
+__import__.product_template_lbpc_b31_101s_wi,LBPC-B31-101S-WI/M,0743682033835,H. POLO LONG BEACH M/C P/CABALLERO WINE,Talla: M,34.70,0.00
+__import__.product_template_cuwfd027_112,CUWFD027-112/S,713610501507,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRILLIANT WHITE,Talla: S,82.52,0.00
+__import__.product_template_cuwfd027_112,CUWFD027-112/M,713610501514,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRILLIANT WHITE,Talla: M,82.52,0.00
+__import__.product_template_c9hw0034_100d,C9HW0034-100D/S,795570519693,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRIGHT WHITE,Talla: S,104.26,0.00
+__import__.product_template_c9hw0034_100d,C9HW0034-100D/L,795570519662,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRIGHT WHITE,Talla: L,104.26,0.00
+__import__.product_template_cuwme029_112,CUWME029-112/S,713610668569,H. CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: S,82.52,0.00
+__import__.product_template_cuwfd027_112,CUWFD027-112/L,713610501521,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRILLIANT WHITE,Talla: L,82.52,0.00
+__import__.product_template_cuwsp002_112,CUWSP002-112/XL,7448332823899,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE,Talla: XL,73.83,0.00
+__import__.product_template_cuwsp005_408,CUWSP005-408/L,7448341756782,H. CAMISA CUBAVERA M/C P/CABALLERO DRESS BLUES,Talla: L,73.83,0.00
+__import__.product_template_cuwsp005_408,CUWSP005-408/M,7448332152128,H. CAMISA CUBAVERA M/C P/CABALLERO DRESS BLUES,Talla: M,73.83,0.00
+__import__.product_template_cuwsp005_408,CUWSP005-408/S,7448340839875,H. CAMISA CUBAVERA M/C P/CABALLERO DRESS BLUES,Talla: S,73.83,0.00
+__import__.product_template_cuwsp005_408,CUWSP005-408/XL,7448335926948,H. CAMISA CUBAVERA M/C P/CABALLERO DRESS BLUES,Talla: XL,73.83,0.00
+__import__.product_template_cuwsp002_112,CUWSP002-112/M,7448342471493,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE,Talla: M,73.83,0.00
+__import__.product_template_cuwsp002_112,CUWSP002-112/S,7448336284283,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE,Talla: S,73.83,0.00
+__import__.product_template_cuwsp011_022,CUWSP011-022/M,7448333667621,H. CAMISA CUBAVERA M/C P/CABALLERO JET BLACK,Talla: M,73.83,0.00
+__import__.product_template_cuwsp011_022,CUWSP011-022/L,7448342477419,H. CAMISA CUBAVERA M/C P/CABALLERO JET BLACK,Talla: L,73.83,0.00
+__import__.product_template_cuwsp011_022,CUWSP011-022/S,7448337179175,H. CAMISA CUBAVERA M/C P/CABALLERO JET BLACK,Talla: S,73.83,0.00
+__import__.product_template_cuwme010_439,CUWME010-439/L,713610667203,H. CAMISA CUBAVERA M/C LINO P/CABALLERO AQUA ESQUE,Talla: L,82.52,0.00
+__import__.product_template_cuwme006_439,CUWME006-439/XL,713610667920,H. CAMISA P/H M/C AQUA ESQUE CUBAVERA,Talla: XL,82.52,0.00
+__import__.product_template_cuwme029_112,CUWME029-112/L,713610668583,H. CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: L,82.52,0.00
+__import__.product_template_cuwsp002_112,CUWSP002-112/L,7448332469424,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE,Talla: L,73.83,0.00
+__import__.product_template_c9hw0034_100d,C9HW0034-100D/M,795570519648,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRIGHT WHITE,Talla: M,104.26,0.00
+__import__.product_template_cuwme029_112,CUWME029-112/M,713610668576,H. CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: M,82.52,0.00
+__import__.product_template_cuwme029_112,CUWME029-112/XL,713610668590,H. CAMISA P/H M/C BRILLIANT WHITE CUBAVERA,Talla: XL,82.52,0.00
+__import__.product_template_cuwme010_439,CUWME010-439/M,713610667197,H. CAMISA CUBAVERA M/C LINO P/CABALLERO AQUA ESQUE,Talla: M,82.52,0.00
+__import__.product_template_cuwme010_439,CUWME010-439/XL,713610667210,H. CAMISA CUBAVERA M/C LINO P/CABALLERO AQUA ESQUE,Talla: XL,82.52,0.00
+__import__.product_template_cuwme010_439,CUWME010-439/S,713610667180,H. CAMISA CUBAVERA M/C LINO P/CABALLERO AQUA ESQUE,Talla: S,82.52,0.00
+__import__.product_template_cuwme006_439,CUWME006-439/M,713610667906,H. CAMISA P/H M/C AQUA ESQUE CUBAVERA,Talla: M,82.52,0.00
+__import__.product_template_cuwme006_439,CUWME006-439/S,713610667890,H. CAMISA P/H M/C AQUA ESQUE CUBAVERA,Talla: S,82.52,0.00
+__import__.product_template_cuwme006_439,CUWME006-439/L,713610667913,H. CAMISA P/H M/C AQUA ESQUE CUBAVERA,Talla: L,82.52,0.00
+__import__.product_template_cuwfd027_112,CUWFD027-112/XL,713610501538,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRILLIANT WHITE,Talla: XL,82.52,0.00
+__import__.product_template_cv_l20_002bl_f,CV-L20-002BL-F/40,7448336589517,Terno CV-L20-002BL-F,Talla: 40,47.74,0.00
+__import__.product_template_cv_l20_002bl_f,CV-L20-002BL-F/36,7448339025036,Terno CV-L20-002BL-F,Talla: 36,47.74,0.00
+__import__.product_template_cv_l20_002bl_f,CV-L20-002BL-F/32,7448342485421,Terno CV-L20-002BL-F,Talla: 32,47.74,0.00
+__import__.product_template_cv_l20_002bl_f,CV-L20-002BL-F/30,7448337432461,Terno CV-L20-002BL-F,Talla: 30,47.74,0.00
+__import__.product_template_cuwsp015_122,CUWSP015-122/M,7448332321364,H. CAMISA CUBAVERA M/C P/CABALLERO NATURAL LINEN,Talla: M,73.83,0.00
+__import__.product_template_cuwsp015_122,CUWSP015-122/L,7448334762783,H. CAMISA CUBAVERA M/C P/CABALLERO NATURAL LINEN,Talla: L,73.83,0.00
+__import__.product_template_cuwsp014_467,CUWSP014-467/XL,7448346941947,H. CAMISA CUBAVERA M/C P/CABALLERO MEDITERRANEA B,Talla: XL,73.83,0.00
+__import__.product_template_cuwsp014_467,CUWSP014-467/S,7448340616636,H. CAMISA CUBAVERA M/C P/CABALLERO MEDITERRANEA B,Talla: S,73.83,0.00
+__import__.product_template_cuwsp014_467,CUWSP014-467/M,7448356452440,H. CAMISA CUBAVERA M/C P/CABALLERO MEDITERRANEA B,Talla: M,73.83,0.00
+__import__.product_template_cuwsp011_022,CUWSP011-022/XL,7448349826821,H. CAMISA CUBAVERA M/C P/CABALLERO JET BLACK,Talla: XL,73.83,0.00
+__import__.product_template_cuwsd081_963,CUWSD081-963/XL,401065431493,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BLUE CORAL,Talla: XL,82.52,0.00
+__import__.product_template_cuwsd081_963,CUWSD081-963/S,401065431479,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BLUE CORAL,Talla: S,82.52,0.00
+__import__.product_template_cuwsd081_963,CUWSD081-963/M,401065431417,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BLUE CORAL,Talla: M,82.52,0.00
+__import__.product_template_cuwsd081_963,CUWSD081-963/L,401065431387,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BLUE CORAL,Talla: L,82.52,0.00
+__import__.product_template_cuwsp015_122,CUWSP015-122/XL,7448332183108,H. CAMISA CUBAVERA M/C P/CABALLERO NATURAL LINEN,Talla: XL,73.83,0.00
+__import__.product_template_cuwsp015_122,CUWSP015-122/S,7448341177174,H. CAMISA CUBAVERA M/C P/CABALLERO NATURAL LINEN,Talla: S,73.83,0.00
+__import__.product_template_c9hw0034_100d,C9HW0034-100D/XL,795570519679,H. CAMISA CUBAVERA M/L LINO P/CABALLERO BRIGHT WHITE,Talla: XL,104.26,0.00
+__import__.product_template_cuwfc021_112,CUWFC021-112/L,713610532273,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE (cuwfc021_112),Talla: L,82.52,0.00
+__import__.product_template_cuwfc021_112,CUWFC021-112/M,713610532266,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE (cuwfc021_112),Talla: M,82.52,0.00
+__import__.product_template_cuwfc021_112,CUWFC021-112/XL,713610532280,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE (cuwfc021_112),Talla: XL,82.52,0.00
+__import__.product_template_cuwfc021_112,CUWFC021-112/S,713610532259,H. CAMISA CUBAVERA M/C P/CABALLERO BRILLIANT WHITE (cuwfc021_112),Talla: S,82.52,0.00
+__import__.product_template_lbpc_b30_101s_nv,LBPC-B30-101S-NV/M,743682060169,H. T-SHIRT LONG BEACH M/C P/CABALLERO NAVY,Talla: M,21.65,0.00
+__import__.product_template_lbpc_b30_101s_nv,LBPC-B30-101S-NV/L,743682060176,H. T-SHIRT LONG BEACH M/C P/CABALLERO NAVY,Talla: L,21.65,0.00
+__import__.product_template_lbpc_b30_101s_nv,LBPC-B30-101S-NV/S,743682060152,H. T-SHIRT LONG BEACH M/C P/CABALLERO NAVY,Talla: S,21.65,0.00
+__import__.product_template_c9hw0034_022,C9HW0034-022/S,795570792621,H. GUAYABERA CUBAVERA LINO P/CABALLERO JET BLACK,Talla: S,108.60,0.00
+__import__.product_template_c9hw0034_022,C9HW0034-022/M,795570792645,H. GUAYABERA CUBAVERA LINO P/CABALLERO JET BLACK,Talla: M,108.60,0.00
+__import__.product_template_c9hw0034_022,C9HW0034-022/XL,795570792669,H. GUAYABERA CUBAVERA LINO P/CABALLERO JET BLACK,Talla: XL,108.60,0.00
+__import__.product_template_c9hw0034_022,C9HW0034-022/L,795570792652,H. GUAYABERA CUBAVERA LINO P/CABALLERO JET BLACK,Talla: L,108.60,0.00
+__import__.product_template_cv_l20_001gr_c,CV-L20-001GR-C/34,7448330141193,Terno CV-L20-001GR-C,Talla: 34,47.74,0.00
+__import__.product_template_cv_l20_001gr_c,CV-L20-001GR-C/36,7448351877804,Terno CV-L20-001GR-C,Talla: 36,47.74,0.00
+__import__.product_template_cv_l20_001gr_c,CV-L20-001GR-C/40,7448357788777,Terno CV-L20-001GR-C,Talla: 40,47.74,0.00
+__import__.product_template_cv_l20_001gr_c,CV-L20-001GR-C/38,7448342518556,Terno CV-L20-001GR-C,Talla: 38,47.74,0.00
+__import__.product_template_cv_l20_001gr_c,CV-L20-001GR-C/33,7448337942953,Terno CV-L20-001GR-C,Talla: 33,47.74,0.00
+__import__.product_template_cv_l20_001gr_c,CV-L20-001GR-C/32,7448334668658,Terno CV-L20-001GR-C,Talla: 32,47.74,0.00
+__import__.product_template_cv_t11_031_gr,CV-T11-031-GR/48,7448337230234,Terno CV-T11-031-GR,Talla: 48,165.13,0.00
+__import__.product_template_cv_t11_031_gr,CV-T11-031-GR/46,7448338168123,Terno CV-T11-031-GR,Talla: 46,165.13,0.00
+__import__.product_template_cv_t11_031_gr,CV-T11-031-GR/44,7448332856811,Terno CV-T11-031-GR,Talla: 44,165.13,0.00
+__import__.product_template_cv_t11_031_gr,CV-T11-031-GR/42,7448348392327,Terno CV-T11-031-GR,Talla: 42,165.13,0.00
+__import__.product_template_cv_t11_031_gr,CV-T11-031-GR/40,7448333316383,Terno CV-T11-031-GR,Talla: 40,165.13,0.00
+__import__.product_template_cv_t11_031_gr,CV-T11-031-GR/38,7448345752735,Terno CV-T11-031-GR,Talla: 38,165.13,0.00
+__import__.product_template_cv_t11_031_gr,CV-T11-031-GR/36,7448343560547,Terno CV-T11-031-GR,Talla: 36,165.13,0.00
+__import__.product_template_cv_l20_002ch_c,CV-L20-002CH-C/40,7448332356397,Terno CV-L20-002CH-C,Talla: 40,47.74,0.00
+__import__.product_template_cv_l20_002ch_c,CV-L20-002CH-C/38,7448333920948,Terno CV-L20-002CH-C,Talla: 38,47.74,0.00
+__import__.product_template_cv_l20_002ch_c,CV-L20-002CH-C/36,7448343413430,Terno CV-L20-002CH-C,Talla: 36,47.74,0.00
+__import__.product_template_cv_l20_002ch_c,CV-L20-002CH-C/34,7448346940964,Terno CV-L20-002CH-C,Talla: 34,47.74,0.00
+__import__.product_template_cv_l20_002ch_c,CV-L20-002CH-C/33,7448332625684,Terno CV-L20-002CH-C,Talla: 33,47.74,0.00
+__import__.product_template_cv_l20_002ch_c,CV-L20-002CH-C/30,7448330430433,Terno CV-L20-002CH-C,Talla: 30,47.74,0.00
+__import__.product_template_cv_l20_002ch_c,CV-L20-002CH-C/32,7448347065086,Terno CV-L20-002CH-C,Talla: 32,47.74,0.00
+__import__.product_template_cv_l20_002nv_c,CV-L20-002NV-C/40,7448341680629,Terno CV-L20-002NV-C,Talla: 40,47.74,0.00
+__import__.product_template_cv_l20_002nv_c,CV-L20-002NV-C/38,7448351182120,Terno CV-L20-002NV-C,Talla: 38,47.74,0.00
+__import__.product_template_cv_l20_002nv_c,CV-L20-002NV-C/36,7448332032031,Terno CV-L20-002NV-C,Talla: 36,47.74,0.00
+__import__.product_template_cv_l20_002nv_c,CV-L20-002NV-C/34,7448348874816,Terno CV-L20-002NV-C,Talla: 34,47.74,0.00
+__import__.product_template_cv_l20_002nv_c,CV-L20-002NV-C/33,7448330260290,Terno CV-L20-002NV-C,Talla: 33,47.74,0.00
+__import__.product_template_cv_l20_002nv_c,CV-L20-002NV-C/32,7448336733729,Terno CV-L20-002NV-C,Talla: 32,47.74,0.00
+__import__.product_template_cv_l20_002nv_c,CV-L20-002NV-C/30,7448352068041,Terno CV-L20-002NV-C,Talla: 30,47.74,0.00
+__import__.product_template_cv_l20_002ltgr_c,CV-L20-002LTGR-C/40,7448339085016,Terno CV-L20-002LTGR-C,Talla: 40,47.74,0.00
+__import__.product_template_cv_l20_002ltgr_c,CV-L20-002LTGR-C/38,7448340749747,Terno CV-L20-002LTGR-C,Talla: 38,47.74,0.00
+__import__.product_template_cv_l20_002ltgr_c,CV-L20-002LTGR-C/36,7448334190142,Terno CV-L20-002LTGR-C,Talla: 36,47.74,0.00
+__import__.product_template_cv_l20_002ltgr_c,CV-L20-002LTGR-C/34,7448330724778,Terno CV-L20-002LTGR-C,Talla: 34,47.74,0.00
+__import__.product_template_cv_l20_002ltgr_c,CV-L20-002LTGR-C/33,7448333576572,Terno CV-L20-002LTGR-C,Talla: 33,47.74,0.00
+__import__.product_template_cv_l20_002ltgr_c,CV-L20-002LTGR-C/32,7448352818851,Terno CV-L20-002LTGR-C,Talla: 32,47.74,0.00
+__import__.product_template_cv_l20_002ltgr_c,CV-L20-002LTGR-C/30,7448335713760,Terno CV-L20-002LTGR-C,Talla: 30,47.74,0.00
+__import__.product_template_cv_l20_002bu_c,CV-L20-002BU-C/40,7448334379387,Terno CV-L20-002BU-C,Talla: 40,47.74,0.00
+__import__.product_template_cv_l20_002bu_c,CV-L20-002BU-C/38,7448344554514,Terno CV-L20-002BU-C,Talla: 38,47.74,0.00
+__import__.product_template_cv_l20_002bu_c,CV-L20-002BU-C/36,7448332589559,Terno CV-L20-002BU-C,Talla: 36,47.74,0.00
+__import__.product_template_cv_l20_002bu_c,CV-L20-002BU-C/34,7448344568528,Terno CV-L20-002BU-C,Talla: 34,47.74,0.00
+__import__.product_template_cv_l20_002bu_c,CV-L20-002BU-C/33,7448334245217,Terno CV-L20-002BU-C,Talla: 33,47.74,0.00
+__import__.product_template_cv_l20_002bu_c,CV-L20-002BU-C/32,7448335892878,Terno CV-L20-002BU-C,Talla: 32,47.74,0.00
+__import__.product_template_cv_l20_002bu_c,CV-L20-002BU-C/30,7448339493477,Terno CV-L20-002BU-C,Talla: 30,47.74,0.00
+__import__.product_template_cv_l20_002bl_f,CV-L20-002BL-F/38,7448334783788,Terno CV-L20-002BL-F,Talla: 38,47.74,0.00
+__import__.product_template_cv_l20_002bl_f,CV-L20-002BL-F/34,7448331759786,Terno CV-L20-002BL-F,Talla: 34,47.74,0.00
+__import__.product_template_cv_l20_002bl_f,CV-L20-002BL-F/33,7448333162140,Terno CV-L20-002BL-F,Talla: 33,47.74,0.00
+__import__.product_template_cv_l20_001gr_c,CV-L20-001GR-C/30,7448354245242,Terno CV-L20-001GR-C,Talla: 30,47.74,0.00
+__import__.product_template_pt_10036a_18_498,PT-10036A-18-498/28,PT-10036A-18-498/O28,Pantalon PT-10036A-18-498,Talla: 28,47.74,0.00
+__import__.product_template_zp_loafer_h,ZP-LOAFER-H/6.5,ZP-LOAFER-H/O6.5,Zapato ZP-LOAFER-H,Talla: 6.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/30,ZP-CASSINI-PS-PT-BLK/30,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 30,152.09,0.00
+__import__.product_template_j5530_black,J5530-BLACK/L,J5530-BLACK/OL,TWEED JACKET-100% POLYESTER-BLACK,Talla: L,84.26,0.00
+__import__.product_template_j5530_black,J5530-BLACK/M,J5530-BLACK/OM,TWEED JACKET-100% POLYESTER-BLACK,Talla: M,84.26,0.00
+__import__.product_template_j5530_black,J5530-BLACK/S,J5530-BLACK/OS,TWEED JACKET-100% POLYESTER-BLACK,Talla: S,84.26,0.00
+__import__.product_template_j5519_white,J5519-WHITE/L,J5519-WHITE/OL,TWO BUTTON JACKET -100% POLYESTER BLACK-WHITE,Talla: L,57.30,0.00
+__import__.product_template_j5519_white,J5519-WHITE/M,J5519-WHITE/OM,TWO BUTTON JACKET -100% POLYESTER BLACK-WHITE,Talla: M,57.30,0.00
+__import__.product_template_j5519_white,J5519-WHITE/S,J5519-WHITE/OS,TWO BUTTON JACKET -100% POLYESTER BLACK-WHITE,Talla: S,57.30,0.00
+__import__.product_template_j5519_black,J5519-BLACK/L,J5519-BLACK/OL,TWO BUTTON JACKET -100% POLYESTER BLACK-WHITE (j5519_black),Talla: L,57.30,0.00
+__import__.product_template_j5519_black,J5519-BLACK/M,J5519-BLACK/OM,TWO BUTTON JACKET -100% POLYESTER BLACK-WHITE (j5519_black),Talla: M,57.30,0.00
+__import__.product_template_j5519_black,J5519-BLACK/S,J5519-BLACK/OS,TWO BUTTON JACKET -100% POLYESTER BLACK-WHITE (j5519_black),Talla: S,57.30,0.00
+__import__.product_template_j5508_black,J5508-BLACK/L,J5508-BLACK/OL,TWEED JACKET-100% POLYESTER-BLACK (j5508_black),Talla: L,91.22,0.00
+__import__.product_template_j5508_black,J5508-BLACK/M,J5508-BLACK/OM,TWEED JACKET-100% POLYESTER-BLACK (j5508_black),Talla: M,91.22,0.00
+__import__.product_template_j5508_black,J5508-BLACK/S,J5508-BLACK/OS,TWEED JACKET-100% POLYESTER-BLACK (j5508_black),Talla: S,91.22,0.00
+__import__.product_template_set_mili_nara_bl,SET-MILI-NARA-BL/M,SET-MILI-NARA-BL/OM,M. SET P/DAMA ARENA MILI NARA,Talla: M,123.39,0.00
+__import__.product_template_set_europa_ne,SET-EUROPA-NE/S,SET-EUROPA-NE/OS,M. SET P/DAMA NEGRO EUROPA,Talla: S,122.52,0.00
+__import__.product_template_set_europa_ne,SET-EUROPA-NE/L,SET-EUROPA-NE/OL,M. SET P/DAMA NEGRO EUROPA,Talla: L,122.52,0.00
+__import__.product_template_ve_izar_nara,VE-IZAR-NARA/S,VE-IZAR-NARA/OS,M. VESTIDO MAGENTA IZAR,Talla: S,114.70,0.00
+__import__.product_template_bl_amanecer,BL-AMANECER/L,REF-AMANECER/OL,M. BLUSA ROSA AMANECER,Talla: L,73.83,0.00
+__import__.product_template_ve_destello,VE-DESTELLO/S,VE-DESTELLO/OS,M. VESTIDO AZUL DESTELLO,Talla: S,135.57,0.00
+__import__.product_template_set_lucero_n,SET-LUCERO-N/S,SET-LUCERO-N/OS,M. SET P/DAMA PISTACHIO LUCERO,Talla: S,138.17,0.00
+__import__.product_template_set_aries_rs,SET-ARIES-RS/M,SET-ARIES-RS/OM,M. SET P/DAMA ROSA ARIES,Talla: M,135.57,0.00
+__import__.product_template_set_aries_rs,SET-ARIES-RS/L,SET-ARIES-RS/OL,M. SET P/DAMA ROSA ARIES,Talla: L,135.57,0.00
+__import__.product_template_bl_amanecer,BL-AMANECER/M,BL-AMANECER/OM,M. BLUSA ROSA AMANECER,Talla: M,73.83,0.00
+__import__.product_template_ve_izar_nara,VE-IZAR-NARA/M,VE-IZAR-NARA/OM,M. VESTIDO MAGENTA IZAR,Talla: M,114.70,0.00
+__import__.product_template_top_galilei_na,TOP-GALILEI-NA/L,TOP-GALILEI-NA/OL,M. TOP NEGRO GALILEI,Talla: L,69.48,0.00
+__import__.product_template_top_galilei_na,TOP-GALILEI-NA/M,TOP-GALILEI-NA/OM,M. TOP NEGRO GALILEI,Talla: M,69.48,0.00
+__import__.product_template_top_galilei_na,TOP-GALILEI-NA/S,TOP-GALILEI-NA/OS,M. TOP NEGRO GALILEI,Talla: S,69.48,0.00
+__import__.product_template_zp_gam_az_s_f_cassini,ZP-GAM-AZ-S/F-CASSINI/9,ZPGAMAZSFCAS/O9,Zapato ZP-GAM-AZ-S/F-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_cassini_gaziano_blk,ZP-CASSINI-GAZIANO-BLK/9,ZP-CASSINI-GAZ-BL/O9,Zapato ZP-CASSINI-GAZIANO-BLK,Talla: 9,152.09,0.00
+__import__.product_template_zp_cassini_gaziano_blk,ZP-CASSINI-GAZIANO-BLK/8.5,ZP-CASSINI-GAZIANO-BLK/O8.5,Zapato ZP-CASSINI-GAZIANO-BLK,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_cassini_gaziano_blk,ZP-CASSINI-GAZIANO-BLK/8,ZP-CASSINI-GAZIANO-BLK/O8,Zapato ZP-CASSINI-GAZIANO-BLK,Talla: 8,152.09,0.00
+__import__.product_template_zp_cassini_gaziano_blk,ZP-CASSINI-GAZIANO-BLK/7,ZPCASGAZIANOBLK/O7,Zapato ZP-CASSINI-GAZIANO-BLK,Talla: 7,152.09,0.00
+__import__.product_template_cv_u11_037_nv,CV-U11-037-NV/42,CV-U11-037-NV/42,Terno CV-U11-037-NV,Talla: 42,165.13,0.00
+__import__.product_template_cv_u11_016_bu,CV-U11-016-BU/36,CV-U11-016-BU/O36,Terno CV-U11-016-BU,Talla: 36,165.13,0.00
+__import__.product_template_cv_t11_031_nv,CV-T11-031-NV/36,7448335330332,Terno CV-T11-031-NV,Talla: 36,165.13,0.00
+__import__.product_template_cv_t11_031_nv,CV-T11-031-NV/38,7448353888877,Terno CV-T11-031-NV,Talla: 38,165.13,0.00
+__import__.product_template_cv_t11_031_nv,CV-T11-031-NV/40,7448330442405,Terno CV-T11-031-NV,Talla: 40,165.13,0.00
+__import__.product_template_cv_t11_031_nv,CV-T11-031-NV/42,7448337724788,Terno CV-T11-031-NV,Talla: 42,165.13,0.00
+__import__.product_template_cv_t11_031_nv,CV-T11-031-NV/44,7448333453453,Terno CV-T11-031-NV,Talla: 44,165.13,0.00
+__import__.product_template_cv_t11_031_nv,CV-T11-031-NV/46,7448340567532,Terno CV-T11-031-NV,Talla: 46,165.13,0.00
+__import__.product_template_cv_t11_031_nv,CV-T11-031-NV/48,7448336882816,Terno CV-T11-031-NV,Talla: 48,165.13,0.00
+__import__.product_template_pt_9c29386_80,PT-9C29386-80/28,PT-9C29386-80/O28,Pantalon PT-9C29386-80,Talla: 28,47.74,0.00
+__import__.product_template_zp_rz_coffe_tl,ZP-RZ-COFFE-TL/9.5,ZP-RZ-COFFE-TL/O9.5,Zapato ZP-RZ-COFFE-TL,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_rz_coffe_tl,ZP-RZ-COFFE-TL/8.5,ZP-RZ-COFFE-TL/O8.5,Zapato ZP-RZ-COFFE-TL,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_rz_coffe_tl,ZP-RZ-COFFE-TL/8,ZP-RZ-COFFE-TL/O8,Zapato ZP-RZ-COFFE-TL,Talla: 8,152.09,0.00
+__import__.product_template_zp_rz_coffe_tl,ZP-RZ-COFFE-TL/7.5,ZP-RZ-COFFE-TL/O7.5,Zapato ZP-RZ-COFFE-TL,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_rz_coffe_tl,ZP-RZ-COFFE-TL/7,ZP-RZ-COFFE-TL/O7,Zapato ZP-RZ-COFFE-TL,Talla: 7,152.09,0.00
+__import__.product_template_zp_loafer_h,ZP-LOAFER-H/7,ZP-LOAFER-H/7,Zapato ZP-LOAFER-H,Talla: 7,152.09,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-18-S1,ERN-SABAT-10-18-S1,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 18, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_pt_22c0905_4c,PT-22C0905-4C/28,PT-22C0905-4C/O28,Pantalon PT-22C0905-4C,Talla: 28,56.43,0.00
+__import__.product_template_pt_9c29386_80,PT-9C29386-80/38,PT-9C29386-80/O38,Pantalon PT-9C29386-80,Talla: 38,47.74,0.00
+__import__.product_template_ern_sabat_1259_wm,ERN-SABAT-1259-WM/S,ES1259W/S,BLUSA DE DAMA P/S BRUNO CASSINI WHITE T.S,Talla: S,42.52,0.00
+__import__.product_template_2279dw,2279DW/S,2279DW/S,VESTIDO CQ BY CQ T.S,Talla: S,160.78,0.00
+__import__.product_template_pt_23e312010_4,PT-23E312010-4/28,PT-23E312010-4/O28,Pantalon PT-23E312010-4,Talla: 28,47.74,0.00
+__import__.product_template_ve_heidy_consig,VE-HEIDY-CONSIG/L,VE-HEIDY-CONSIG/OL,VESTIDO AZUL REY,Talla: L,117.30,0.00
+__import__.product_template_set_carlota_consig,SET-CARLOTA-CONSIG/S,SET-CARLOTA-CONSIG/OS,CONJUNTO ESTAMPADO ROJO,Talla: S,114.69,0.00
+__import__.product_template_set_carlota_consig,SET-CARLOTA-CONSIG/L,SET-CARLOTA-CONSIG/OL,CONJUNTO ESTAMPADO ROJO,Talla: L,114.69,0.00
+__import__.product_template_ve_aurora_consig,VE-AURORA-CONSIG/L,VE-AURORA-CONSIGO/L,VESTIDO FUCSIA,Talla: L,121.65,0.00
+__import__.product_template_ve_aurora_consig,VE-AURORA-CONSIG/M,VE-AURORA-CONSIG/OM,VESTIDO FUCSIA,Talla: M,121.65,0.00
+__import__.product_template_ve_antonia_consig,VE-ANTONIA-CONSIG/L,VE-ANTONIA-CONSIG/OL,VESTIDO ESTAMPADO FUCSIA,Talla: L,124.26,0.00
+__import__.product_template_ern_sabat_1259,ERN-SABAT-1259-16.5-S1,ERNST12591651,H. CAMISA P/S BRUNO CASSINI WHITE 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_zp_rz_coffe_tl,ZP-RZ-COFFE-TL/9,ZP-RZ-COFFE-TL/O9,Zapato ZP-RZ-COFFE-TL,Talla: 9,152.09,0.00
+__import__.product_template_z_3125_pl,Z-3125-PL-36,Z-3125-PL-36,M. ZAPATO P/DAMA PLATA DFV,Talla: 36,114.70,0.00
+__import__.product_template_z_3130_pl,Z-3130-PL-38,Z-3130-PL-38,M. ZAPATO P/DAMA PLATA DFV (z_3130_pl),Talla: 38,114.70,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-20-S2,ERNSABAT1259DC2002,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 20, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-20-S1,ERNSABAT1259DC2001,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 20, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-19.5-S2,ERNSABAT1259DC1952,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 19.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-19.5-S1,ERNSABAT1259DC1951,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 19.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-18.5-S2,ERNSABAT1259DC1852,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 18.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-18.5-S1,ERNSABAT1259DC1851,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 18.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_short_cairo,SHORT-CAIRO /M,SHORT-CAIRO /OM,SHORT LINO P/DAMA BEIGE / LADRILLO /NEGRO /VERDE ESTAMP,Talla: M,47.74,0.00
+__import__.product_template_lv_23e312010_3,LV-23E312010-3/52,LV-23E312010-3/O52,Leva LV-23E312010-3,Talla: 52,173.83,0.00
+__import__.product_template_lv_18078_382,LV-18078-382/56,LV-18078-382/O56,Leva LV-18078-382,Talla: 56,165.13,0.00
+__import__.product_template_pt_22c0905_4c,PT-22C0905-4C/38,PT-22C0905-4C/O38,Pantalon PT-22C0905-4C,Talla: 38,47.74,0.00
+__import__.product_template_tcw30840_az,TCW30840-AZ/42,TCW30840-AZ/O42,Terno TCW30840-AZ,Talla: 42,217.30,0.00
+__import__.product_template_tcw30840_az,TCW30840-AZ/40,TCW30840-AZ/O40,Terno TCW30840-AZ,Talla: 40,217.30,0.00
+__import__.product_template_tcw30840_az,TCW30840-AZ/38,TCW30840-AZ/O38,Terno TCW30840-AZ,Talla: 38,217.30,0.00
+__import__.product_template_tcw30840_az,TCW30840-AZ/36,TCW30840-AZ/O36,Terno TCW30840-AZ,Talla: 36,217.30,0.00
+__import__.product_template_pt_tl_10_400b_azn,PT-TL-10-400B-AZN/38,PTTL10400BAZN/O38,Pantalon PT-TL-10-400B-AZN,Talla: 38,65.13,0.00
+__import__.product_template_lv_23e312010_3,LV-23E312010-3/56,LV-23E312010-3/O56,Leva LV-23E312010-3,Talla: 56,69.48,0.00
+__import__.product_template_pt_17001_7,PT-17001-7/30,PT-17001-7/O30,Pantalon PT-17001-7,Talla: 30,47.74,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/9.5,ZP-50224-CAS-VN/O9.5,Zapato ZP-50224-CASSINI-VN,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/9,ZP-50224-CAS-VN/O9,Zapato ZP-50224-CASSINI-VN,Talla: 9,152.09,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/7.5,ZP-50224-CAS-VN/O7.5,Zapato ZP-50224-CASSINI-VN,Talla: 7.5,152.09,0.00
+__import__.product_template_ern_sabat_1259,ERN-SABAT-1259-19-S2,ERNSTBG12591902,H. CAMISA P/S BRUNO CASSINI WHITE 34-35,"Talla: 19, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_1259,ERN-SABAT-1259-19-S1,ERNSTBG12591901,H. CAMISA P/S BRUNO CASSINI WHITE 34-35,"Talla: 19, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/7,ZP-50224-CAS-VN/O7,Zapato ZP-50224-CASSINI-VN,Talla: 7,152.09,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/8.5,ZP-50224-CAS-VN/O8.5,Zapato ZP-50224-CASSINI-VN,Talla: 8.5,152.09,0.00
+__import__.product_template_cr,CR-12,CR-12,M. COLLARES P/DAMA VARIOS MODELOS,Talla: 12,14.61,0.00
+__import__.product_template_pt_17001_7,PT-17001-7/32,PT-17001-7/O32,Pantalon PT-17001-7,Talla: 32,47.74,0.00
+__import__.product_template_pant_palma_mo,PANT-PALMA MO/L,PANT-PALMA MO/OL,PANTALON DE DAMA PALMA VERDE/KAKY,Talla: L,75.56,0.00
+__import__.product_template_pant_palma_mo,PANT-PALMA MO/M,PANT-PALMA MO/OM,PANTALON DE DAMA PALMA VERDE/KAKY,Talla: M,75.56,0.00
+__import__.product_template_pant_palma_mo,PANT-PALMA MO/S,PANT-PALMA MO/OS,PANTALON DE DAMA PALMA VERDE/KAKY,Talla: S,75.56,0.00
+__import__.product_template_pt_23e312010_4,PT-23E312010-4/30,PT-23E312010-4/O30,Pantalon PT-23E312010-4,Talla: 30,47.74,0.00
+__import__.product_template_pt_3803_50,PT-3803/50/46,PT-3803/O50/O46,Pantalon PT-3803/50,Talla: 46,47.74,0.00
+__import__.product_template_lv_gb_g11_002,LV-GB-G11-002/40,LV-GB-G11-002/O40,Leva LV-GB-G11-002,Talla: 40,69.48,0.00
+__import__.product_template_bl_capri_mopa,BL-CAPRI MOPA/S,BL-CAPRI MOPA/OS,M. BLUSA P/DAMA VERDE / NEGRO / BLANCO,Talla: S,59.91,0.00
+__import__.product_template_ve_abril_li,VE-ABRIL LI/M,VE-ABRIL LI/OM,M. VESTIDO P/DAMA LINO BLANCO/VERDE,Talla: M,117.30,0.00
+__import__.product_template_ve_lourde,VE-LOURDE/M,VE-LOURDE/OM,M. VESTIDO P/DAMA BLANCO / NEGRO,Talla: M,132.09,0.00
+__import__.product_template_ve_lirata,VE-LIRATA/L,VE-LIRATA/OL,M. VESTIDO P/DAMA MAMEY,Talla: L,108.61,0.00
+__import__.product_template_ve_lirata,VE-LIRATA/S,VE-LIRATA/OS,M. VESTIDO P/DAMA MAMEY,Talla: S,108.61,0.00
+__import__.product_template_ve_lirata,VE-LIRATA/M,VE-LIRATA/OM,M. VESTIDO P/DAMA MAMEY,Talla: M,108.61,0.00
+__import__.product_template_ve_abril_li,VE-ABRIL LI/S,VE-ABRIL LI/OS,M. VESTIDO P/DAMA LINO BLANCO/VERDE,Talla: S,117.30,0.00
+__import__.product_template_ve_abril_li,VE-ABRIL LI/L,VE-ABRIL LI/OL,M. VESTIDO P/DAMA LINO BLANCO/VERDE,Talla: L,117.30,0.00
+__import__.product_template_ve_nathali,VE-NATHALI/S,VE-NATHALI/OS,M. VESTIDO P/DAMA ROSA ESTAMPADO,Talla: S,110.35,0.00
+__import__.product_template_ve_nathali,VE-NATHALI/M,VE-NATHALI/OM,M. VESTIDO P/DAMA ROSA ESTAMPADO,Talla: M,110.35,0.00
+__import__.product_template_bl_capri_mopa,BL-CAPRI MOPA/M,BL-CAPRI MOPA/OM,M. BLUSA P/DAMA VERDE / NEGRO / BLANCO,Talla: M,59.91,0.00
+__import__.product_template_ent_greta_m,ENT-GRETA M/S,ENT-GRETA M/OS,M. ENTERIZO P/DAMA ROJO / NEGRO,Talla: S,106.00,0.00
+__import__.product_template_ent_greta_m,ENT-GRETA M/L,ENT-GRETA M/OL,M. ENTERIZO P/DAMA ROJO / NEGRO,Talla: L,106.00,0.00
+__import__.product_template_ent_harper,ENT-HARPER/L,ENT-HARPER/OL,M. ENTERIZO CELESTE ESTAMP / LILA ESTAMAP,Talla: L,110.35,0.00
+__import__.product_template_ent_greta_m,ENT-GRETA M/M,ENT-GRETA M/OM,M. ENTERIZO P/DAMA ROJO / NEGRO,Talla: M,106.00,0.00
+__import__.product_template_ent_harper,ENT-HARPER/M,ENT-HARPER/OM,M. ENTERIZO CELESTE ESTAMP / LILA ESTAMAP,Talla: M,110.35,0.00
+__import__.product_template_ent_harper,ENT-HARPER/S,ENT-HARPER/OS,M. ENTERIZO CELESTE ESTAMP / LILA ESTAMAP,Talla: S,110.35,0.00
+__import__.product_template_bl_mali,BL-MALI/S,BL-MALI/OS,M. BLUSA P/DAMA FUCSIA / NEGRO,Talla: S,68.61,0.00
+__import__.product_template_bl_mali,BL-MALI/M,BL-MALI/OM,M. BLUSA P/DAMA FUCSIA / NEGRO,Talla: M,68.61,0.00
+__import__.product_template_bl_calif,BL- CALIF/S,BL- CALIF/OS,M. BLUSA P/DAMA LADRILLO ESTAM. / CALIFORNIA ROJO BLANCO,Talla: S,86.00,0.00
+__import__.product_template_bl_calif,BL- CALIF/M,BL- CALIF/OM,M. BLUSA P/DAMA LADRILLO ESTAM. / CALIFORNIA ROJO BLANCO,Talla: M,86.00,0.00
+__import__.product_template_bl_calif,BL- CALIF/L,BL- CALIF/OL,M. BLUSA P/DAMA LADRILLO ESTAM. / CALIFORNIA ROJO BLANCO,Talla: L,86.00,0.00
+__import__.product_template_bl_capri_mopa,BL-CAPRI MOPA/L,BL-CAPRI MOPA/OL,M. BLUSA P/DAMA VERDE / NEGRO / BLANCO,Talla: L,59.91,0.00
+__import__.product_template_ve_dafne_m,VE-DAFNE M/L,VE-DAFNE M/OL,M. VESTIDO P/DAMA AZUL / BLANCO,Talla: L,141.65,0.00
+__import__.product_template_ve_dafne_m,VE-DAFNE M/M,VE-DAFNE M/OM,M. VESTIDO P/DAMA AZUL / BLANCO,Talla: M,141.65,0.00
+__import__.product_template_ve_dafne_m,VE-DAFNE M/S,VE-DAFNE M/OS,M. VESTIDO P/DAMA AZUL / BLANCO,Talla: S,141.65,0.00
+__import__.product_template_ve_gena_m,VE-GENA M/L,VE-GENA M/OL,M. VESTIDO P/DAMA ACEITUNA / BLANCO,Talla: L,129.48,0.00
+__import__.product_template_ve_gena_m,VE-GENA M/M,VE-GENA M/OM,M. VESTIDO P/DAMA ACEITUNA / BLANCO,Talla: M,129.48,0.00
+__import__.product_template_ve_gena_m,VE-GENA M/S,VE-GENA M/OS,M. VESTIDO P/DAMA ACEITUNA / BLANCO,Talla: S,129.48,0.00
+__import__.product_template_ve_lena,VE-LENA/L,VE-LENA/OL,M. VESTIDO P/DAMA LILA / BEIGE,Talla: L,119.91,0.00
+__import__.product_template_ve_lena,VE-LENA/M,VE-LENA/OM,M. VESTIDO P/DAMA LILA / BEIGE,Talla: M,119.91,0.00
+__import__.product_template_ve_lena,VE-LENA/S,VE-LENA/OS,M. VESTIDO P/DAMA LILA / BEIGE,Talla: S,119.91,0.00
+__import__.product_template_ve_lourde,VE-LOURDE/S,VE-LOURDE/OS,M. VESTIDO P/DAMA BLANCO / NEGRO,Talla: S,132.09,0.00
+__import__.product_template_ve_lourde,VE-LOURDE/L,VE-LOURDE/OL,M. VESTIDO P/DAMA BLANCO / NEGRO,Talla: L,132.09,0.00
+__import__.product_template_bl_mali,BL-MALI/L,BL-MALI/OL,M. BLUSA P/DAMA FUCSIA / NEGRO,Talla: L,68.61,0.00
+__import__.product_template_top_sandy,TOP-SANDY/S,TOP-SANDY/OS,M. TOP P/DAMA ROSA / AZUL,Talla: S,68.61,0.00
+__import__.product_template_top_sandy,TOP-SANDY/M,TOP-SANDY/OM,M. TOP P/DAMA ROSA / AZUL,Talla: M,68.61,0.00
+__import__.product_template_top_sandy,TOP-SANDY/L,TOP-SANDY/OL,M. TOP P/DAMA ROSA / AZUL,Talla: L,68.61,0.00
+__import__.product_template_ve_nathali,VE-NATHALI/L,VE-NATHALI/OL,M. VESTIDO P/DAMA ROSA ESTAMPADO,Talla: L,110.35,0.00
+__import__.product_template_ve_anahi_n,VE-ANAHI N/S,VE-ANAHI N/OS,M. VESTIDO P/DAMA NARANJA ROSA CORAL / NAVY,Talla: S,139.91,0.00
+__import__.product_template_ve_anahi_n,VE-ANAHI N/M,VE-ANAHI N/OM,M. VESTIDO P/DAMA NARANJA ROSA CORAL / NAVY,Talla: M,139.91,0.00
+__import__.product_template_ve_anahi_n,VE-ANAHI N/L,VE-ANAHI N/OL,M. VESTIDO P/DAMA NARANJA ROSA CORAL / NAVY,Talla: L,139.91,0.00
+__import__.product_template_top_amb,TOP-AMB/S,TOP-AMB/OS,M. TOP AMBAR BLANCO / VERDE / FUCSIA,Talla: S,68.61,0.00
+__import__.product_template_pant_cairo_m,PANT-CAIRO M/S,PANT-CAIRO M/OS,M. PANTALON LINO P/DAMA BEIGE / LADRILLO /NEGRO /VERDE ESTAMP,Talla: S,92.09,0.00
+__import__.product_template_pant_cairo_m,PANT-CAIRO M/M,PANT-CAIRO M/OM,M. PANTALON LINO P/DAMA BEIGE / LADRILLO /NEGRO /VERDE ESTAMP,Talla: M,92.09,0.00
+__import__.product_template_pant_cairo_m,PANT-CAIRO M/L,PANT-CAIRO M/OL,M. PANTALON LINO P/DAMA BEIGE / LADRILLO /NEGRO /VERDE ESTAMP,Talla: L,92.09,0.00
+__import__.product_template_top_amb,TOP-AMB/L,TOP-AMB/OL,M. TOP AMBAR BLANCO / VERDE / FUCSIA,Talla: L,68.61,0.00
+__import__.product_template_top_amb,TOP-AMB/M,TOP-AMB/OM,M. TOP AMBAR BLANCO / VERDE / FUCSIA,Talla: M,68.61,0.00
+__import__.product_template_swt70072_ro,SWT70072-RO/M,SWT70072-RO/OM,M. TOP P/DAMAS ROSA,Talla: M,42.52,0.00
+__import__.product_template_swt70072_ro,SWT70072-RO/L,SWT70072-RO/OL,M. TOP P/DAMAS ROSA,Talla: L,42.52,0.00
+__import__.product_template_swt70072_wh,SWT70072-WH/L,SWT70072-WH/OL,M. TOP P/DAMAS BLANCA,Talla: L,42.52,0.00
+__import__.product_template_swt70072_ro,SWT70072-RO/S,SWT70072-RO/OS,M. TOP P/DAMAS ROSA,Talla: S,42.52,0.00
+__import__.product_template_swt7000a_na,SWT7000A-NA/L,SWT7000A-NA/OL,M. TOP P/DAMAS NARANJA,Talla: L,46.00,0.00
+__import__.product_template_swt70205_gr,SWT70205-GR/L,SWT70205-GR/OL,M. TOP P/DAMAS GRIS,Talla: L,51.22,0.00
+__import__.product_template_swt70205_gr,SWT70205-GR/M,SWT70205-GR/OM,M. TOP P/DAMAS GRIS,Talla: M,51.22,0.00
+__import__.product_template_swt70205_gr,SWT70205-GR/S,SWT70205-GR/OS,M. TOP P/DAMAS GRIS,Talla: S,51.22,0.00
+__import__.product_template_swt7000a_na,SWT7000A-NA/S,SWT7000A-NA/OS,M. TOP P/DAMAS NARANJA,Talla: S,46.00,0.00
+__import__.product_template_swt7000a_na,SWT7000A-NA/M,SWT7000A-NA/OM,M. TOP P/DAMAS NARANJA,Talla: M,46.00,0.00
+__import__.product_template_t8529_wh,T8529-WH/M,T8529-WH/OM,M. BLUSA P/DAMAS BLANCA,Talla: M,60.78,0.00
+__import__.product_template_p8539_ne,P8539-NE/S,P8539-NE/OS,M. PANTALON P/DAMA NEGRO RAYAS,Talla: S,82.52,0.00
+__import__.product_template_swt70255_ro,SWT70255-RO/M,SWT70255-RO/OM,M. TOP P/DAMAS ROSA (swt70255_ro),Talla: M,51.22,0.00
+__import__.product_template_r719_ne,R719-NE/L,R719-NE/OL,M. PANTALON P/DAMAS NEGRO,Talla: L,49.48,0.00
+__import__.product_template_r719_ne,R719-NE/M,R719-NE/OM,M. PANTALON P/DAMAS NEGRO,Talla: M,49.48,0.00
+__import__.product_template_r719_ne,R719-NE/S,R719-NE/OS,M. PANTALON P/DAMAS NEGRO,Talla: S,49.48,0.00
+__import__.product_template_fd2965_p1348_wh,FD2965-P1348-WH/S,FD2965-P1348-WH/OS,M. VESTIDO P/DAMAS BLANCO,Talla: S,58.17,0.00
+__import__.product_template_r719_bg,R719-BG/S,R719-BG/OS,M. PANTALON P/DAMAS BEIGE,Talla: S,49.48,0.00
+__import__.product_template_fd2965_p1348_wh,FD2965-P1348-WH/L,FD2965-P1348-WH/OL,M. VESTIDO P/DAMAS BLANCO,Talla: L,58.17,0.00
+__import__.product_template_fd8763_ro,FD8763-RO/S,FD8763-RO/OS,M. VESTIDO P/DAMAS ESTAMPADO ROSA,Talla: S,55.57,0.00
+__import__.product_template_fd2965_p1348_wh,FD2965-P1348-WH/M,FD2965-P1348-WH/OM,M. VESTIDO P/DAMAS BLANCO,Talla: M,58.17,0.00
+__import__.product_template_fd8763_ro,FD8763-RO/M,FD8763-RO/OM,M. VESTIDO P/DAMAS ESTAMPADO ROSA,Talla: M,55.57,0.00
+__import__.product_template_fd8763_ro,FD8763-RO/L,FD8763-RO/OL,M. VESTIDO P/DAMAS ESTAMPADO ROSA,Talla: L,55.57,0.00
+__import__.product_template_fd11476_p1371_ve,FD11476-P1371-VE/M,FD11476-P1371-VE/OM,M. VESTIDO P/DAMAS VERDE CAFÉ,Talla: M,114.70,0.00
+__import__.product_template_fd11476_p1371_ve,FD11476-P1371-VE/L,FD11476-P1371-VE/OL,M. VESTIDO P/DAMAS VERDE CAFÉ,Talla: L,114.70,0.00
+__import__.product_template_fd11476_p1371_ve,FD11476-P1371-VE/S,FD11476-P1371-VE/OS,M. VESTIDO P/DAMAS VERDE CAFÉ,Talla: S,114.70,0.00
+__import__.product_template_r679_pr,R679-PR/L,R679-PR/OL,M. PANTALON P/DAMAS PALO ROSA,Talla: L,49.48,0.00
+__import__.product_template_p8539_ne,P8539-NE/M,P8539-NE/OM,M. PANTALON P/DAMA NEGRO RAYAS,Talla: M,82.52,0.00
+__import__.product_template_p8539_ne,P8539-NE/L,P8539-NE/OL,M. PANTALON P/DAMA NEGRO RAYAS,Talla: L,82.52,0.00
+__import__.product_template_r679_pr,R679-PR/S,R679-PR/OS,M. PANTALON P/DAMAS PALO ROSA,Talla: S,49.48,0.00
+__import__.product_template_r679_pr,R679-PR/M,R679-PR/OM,M. PANTALON P/DAMAS PALO ROSA,Talla: M,49.48,0.00
+__import__.product_template_swt70255_ro,SWT70255-RO/L,SWT70255-RO/OL,M. TOP P/DAMAS ROSA (swt70255_ro),Talla: L,51.22,0.00
+__import__.product_template_swt70072_wh,SWT70072-WH/M,SWT70072-WH/OM,M. TOP P/DAMAS BLANCA,Talla: M,42.52,0.00
+__import__.product_template_t8529_wh,T8529-WH/S,T8529-WH/OS,M. BLUSA P/DAMAS BLANCA,Talla: S,60.78,0.00
+__import__.product_template_swt70072_wh,SWT70072-WH/S,SWT70072-WH/OS,M. TOP P/DAMAS BLANCA,Talla: S,42.52,0.00
+__import__.product_template_t8529_wh,T8529-WH/L,T8529-WH/OL,M. BLUSA P/DAMAS BLANCA,Talla: L,60.78,0.00
+__import__.product_template_swt70255_ro,SWT70255-RO/S,SWT70255-RO/OS,M. TOP P/DAMAS ROSA (swt70255_ro),Talla: S,51.22,0.00
+__import__.product_template_r719_bg,R719-BG/L,R719-BG/OL,M. PANTALON P/DAMAS BEIGE,Talla: L,49.48,0.00
+__import__.product_template_r719_bg,R719-BG/M,R719-BG/OM,M. PANTALON P/DAMAS BEIGE,Talla: M,49.48,0.00
+__import__.product_template_lv_tl10_658a,LV-TL10-658A/58,LV-TL10-658A/O58,Leva LV-TL10-658A,Talla: 58,69.48,0.00
+__import__.product_template_pt_22c0905_4c,PT-22C0905-4C/34,PT-22C0905-4C/O34,Pantalon PT-22C0905-4C,Talla: 34,47.74,0.00
+__import__.product_template_lv_22c0905_4c,LV-22C0905-4C/52,LV-22C0905-4C/O52,Leva LV-22C0905-4C,Talla: 52,173.83,0.00
+__import__.product_template_jeans_431f309n,JEANS-431F309N/6,JEANS-431F309N/O6,Terno JEANS-431F309N,Talla: 6,60.78,0.00
+__import__.product_template_jeans_431f309n,JEANS-431F309N/8,JEANS-431F309N/O8,Terno JEANS-431F309N,Talla: 8,60.78,0.00
+__import__.product_template_jeans_431f309n,JEANS-431F309N/10,JEANS-431F309N/O10,Terno JEANS-431F309N,Talla: 10,60.78,0.00
+__import__.product_template_jeans_431f309n,JEANS-431F309N/12,JEANS-431F309N/O12,Terno JEANS-431F309N,Talla: 12,60.78,0.00
+__import__.product_template_pt_17001_7,PT-17001-7/40,PT-17001-7/O40,Pantalon PT-17001-7,Talla: 40,47.74,0.00
+__import__.product_template_zp_50224_cassini_vn,ZP-50224-CASSINI-VN/8,ZP-50224-CAS-VN/O8,Zapato ZP-50224-CASSINI-VN,Talla: 8,152.09,0.00
+__import__.product_template_lv_17001_9,LV-17001-9/56,LV-17001-9/O56,Leva LV-17001-9,Talla: 56,165.13,0.00
+__import__.product_template_zp_gam_az_cassini,ZP-GAM-AZ-CASSINI/9,ZPGAMAZCAS/O9,Zapato ZP-GAM-AZ-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_gam_az_cassini,ZP-GAM-AZ-CASSINI/9.5,ZPGAMAZCAS/O9.5,Zapato ZP-GAM-AZ-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_gam_az_cassini,ZP-GAM-AZ-CASSINI/8.5,ZPGAMAZCAS/O8.5,Zapato ZP-GAM-AZ-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_gam_az_cassini,ZP-GAM-AZ-CASSINI/8,ZPGAMAZCAS/O8,Zapato ZP-GAM-AZ-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_pt_17001_7,PT-17001-7/36,PT-17001-7/O36,Pantalon PT-17001-7,Talla: 36,56.43,0.00
+__import__.product_template_lv_18078_382,LV-18078-382/58,LV-18078-382/O58,Leva LV-18078-382,Talla: 58,165.13,0.00
+__import__.product_template_ds041_ro,DS041-RO/L,DS041-RO/OL,M. FALDA SHORT ROSA P/DAMA,Talla: L,52.59,0.00
+__import__.product_template_ds041_ro,DS041-RO/S,DS041-RO/OS,M. FALDA SHORT ROSA P/DAMA,Talla: S,52.59,0.00
+__import__.product_template_ds041_ne,DS041-NE/S,DS041-NE/OS,M. FALDA SHORT NEGRO P/DAMA,Talla: S,52.59,0.00
+__import__.product_template_ds041_ro,DS041-RO/M,DS041-RO/OM,M. FALDA SHORT ROSA P/DAMA,Talla: M,52.59,0.00
+__import__.product_template_dbz1_bl,DBZ1-BL/S,DBZ1-BL/OS,M. TOP FLOR P/DAMA BLACK,Talla: S,49.02,0.00
+__import__.product_template_dbz1_fu,DBZ1-FU/L,DBZ1-FU/OL,M. TOP FLOR P/DAMA FUCSIA,Talla: L,49.02,0.00
+__import__.product_template_dbz1_fu,DBZ1-FU/M,DBZ1-FU/OM,M. TOP FLOR P/DAMA FUCSIA,Talla: M,49.02,0.00
+__import__.product_template_dbz1_fu,DBZ1-FU/S,DBZ1-FU/OS,M. TOP FLOR P/DAMA FUCSIA,Talla: S,49.02,0.00
+__import__.product_template_dbz1_bl,DBZ1-BL/L,DBZ1-BL/OL,M. TOP FLOR P/DAMA BLACK,Talla: L,49.02,0.00
+__import__.product_template_dbz1_bl,DBZ1-BL/M,DBZ1-BL/OM,M. TOP FLOR P/DAMA BLACK,Talla: M,49.02,0.00
+__import__.product_template_de111,DE111/S,DE111/OS,M. ENTERIZO SOCALO ESTAMPADO,Talla: S,90.09,0.00
+__import__.product_template_ds041_ne,DS041-NE/M,DS041-NE/OM,M. FALDA SHORT NEGRO P/DAMA,Talla: M,52.59,0.00
+__import__.product_template_ds041_ne,DS041-NE/L,DS041-NE/OL,M. FALDA SHORT NEGRO P/DAMA,Talla: L,52.59,0.00
+__import__.product_template_dbz1_wh,DBZ1-WH/M,DBZ1-WH/OM,M. TOP FLOR P/DAMA WHITE,Talla: M,47.74,0.00
+__import__.product_template_de106,DE106/L,DE106/OL,M. ENTERIZO ALFORZAS BLANCO AZUL,Talla: L,62.41,0.00
+__import__.product_template_de106,DE106/S,DE106/OS,M. ENTERIZO ALFORZAS BLANCO AZUL,Talla: S,62.41,0.00
+__import__.product_template_dbz1_wh,DBZ1-WH/S,DBZ1-WH/OS,M. TOP FLOR P/DAMA WHITE,Talla: S,47.74,0.00
+__import__.product_template_de106,DE106/M,DE106/OM,M. ENTERIZO ALFORZAS BLANCO AZUL,Talla: M,62.41,0.00
+__import__.product_template_dbz1_wh,DBZ1-WH/L,DBZ1-WH/OL,M. TOP FLOR P/DAMA WHITE,Talla: L,47.74,0.00
+__import__.product_template_de111,DE111/M,DE111/OM,M. ENTERIZO SOCALO ESTAMPADO,Talla: M,90.09,0.00
+__import__.product_template_de111,DE111/L,DE111/OL,M. ENTERIZO SOCALO ESTAMPADO,Talla: L,90.09,0.00
+__import__.product_template_de107,DE107/S,DE107/OS,M. ENTERIZO NEGRO,Talla: S,90.09,0.00
+__import__.product_template_de107,DE107/M,DE107/OM,M. ENTERIZO NEGRO,Talla: M,90.09,0.00
+__import__.product_template_de107,DE107/L,DE107/OL,M. ENTERIZO NEGRO,Talla: L,87.74,0.00
+__import__.product_template_a151_82dc,A151-82DC-15-S1,A15182DC231501,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-15.5-S1,A15182DC231551,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-16.5-S1,A15182DC231651,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-15.5-S2,A15182DC231552,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-15-S2,A15182DC231502,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-16.5-S2,A15182DC231652,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_1_18,1-18-17-S1,10018F20231701,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_1_18,1-18-17-S2,10018F20231702,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a151_82bg,A151-82BG-17.5-S2,A15182B20231752,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (a151_82bg),"Talla: 17.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_a151_82bg,A151-82BG-17.5-S1,A15182B20231751,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (a151_82bg),"Talla: 17.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_187_22,187-22-16.5-S1,1872220231651,H. CAMISA P/S BRUNO CASSINI BLUE NAVY 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_187_22,187-22-16.5-S2,1872220231652,H. CAMISA P/S BRUNO CASSINI BLUE NAVY 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_187_22,187-22-17-S1,1872220231701,H. CAMISA P/S BRUNO CASSINI BLUE NAVY 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_187_22,187-22-17-S2,1872220231702,H. CAMISA P/S BRUNO CASSINI BLUE NAVY 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_a151_82dc,A151-82DC-17-S1,A15182DC231701,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-17.5-S2,A15182DC231752,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-14.5-S1,A15182DC231451,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a151_82dc,A151-82DC-17-S2,A15182DC231702,H. CAMISA D/P BRUNO CASSINI BLACK 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_cm0005pur,CM0005PUR-17-S1,C005PUR231701,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33 (cm0005pur),"Talla: 17, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005pur,CM0005PUR-17-S2,C005PUR231702,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33 (cm0005pur),"Talla: 17, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0005pur,CM0005PUR-16-S1,C005PUR231601,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33 (cm0005pur),"Talla: 16, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005pur,CM0005PUR-16.5-S1,C005PUR231651,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33 (cm0005pur),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005pur,CM0005PUR-16-S2,C005PUR231602,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33 (cm0005pur),"Talla: 16, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0005pur,CM0005PUR-16.5-S2,C005PUR231652,H. CAMISA P/S BRUNO CASSINI PURPLE 32-33 (cm0005pur),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0005mbu,CM0005MBU-17-S1,C005MBU231701,H. CAMISA P/S BRUNO CASSINI M. BLUE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005lbu,CM0005LBU-16.5-S1,C005LBU231651,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005lbu,CM0005LBU-16.5-S2,C005LBU231652,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22008_2,4S22008-2-17.5-S2,4S220082231752,H. CAMISA P/S BRUNO CASSINI BLUE PLAID 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22008_2,4S22008-2-17-S2,4S220082231702,H. CAMISA P/S BRUNO CASSINI BLUE PLAID 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22008_2,4S22008-2-17-S1,4S220082231701,H. CAMISA P/S BRUNO CASSINI BLUE PLAID 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_4s22008_2,4S22008-2-16.5-S2,4S220082231652,H. CAMISA P/S BRUNO CASSINI BLUE PLAID 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22008_2,4S22008-2-16.5-S1,4S220082231651,H. CAMISA P/S BRUNO CASSINI BLUE PLAID 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_a151_82,A151-82-17.5-S2,A1518220231752,H. CAMISA P/S BRUNO CASSINI BLACK 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0005lbu,CM0005LBU-15.5-S1,C005LBU231551,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005lbu,CM0005LBU-15.5-S2,C005LBU231552,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0005mbu,CM0005MBU-16.5-S2,C005MBU231652,H. CAMISA P/S BRUNO CASSINI M. BLUE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0005mbu,CM0005MBU-16.5-S1,C005MBU231651,H. CAMISA P/S BRUNO CASSINI M. BLUE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005lbu,CM0005LBU-17-S1,C005LBU231701,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005lbu,CM0005LBU-17-S2,C005LBU231702,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0005mbu,CM0005MBU-14.5-S1,C005MBU231451,H. CAMISA P/S BRUNO CASSINI M. BLUE 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0005mbu,CM0005MBU-17-S2,C005MBU231702,H. CAMISA P/S BRUNO CASSINI M. BLUE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_ss23101_02,SS23101-02-16.5-S1,523101220231651,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_ss23101_02,SS23101-02-16.5-S2,523101220231652,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_ss23101_02,SS23101-02-17-S2,523101220231702,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_ss23101_02,SS23101-02-17-S1,523101220231701,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_ss23101_01,SS23101-01-17-S1,523101120231701,H. CAMISA P/S BRUNO CASSINI WHITE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_ss23101_01,SS23101-01-16.5-S2,523101120231652,H. CAMISA P/S BRUNO CASSINI WHITE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_ss23101_01,SS23101-01-17-S2,523101120231702,H. CAMISA P/S BRUNO CASSINI WHITE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_ss23101_01,SS23101-01-16.5-S1,523101120231651,H. CAMISA P/S BRUNO CASSINI WHITE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",82.52,0.00
+__import__.product_template_ss23101_02,SS23101-02-15.5-S2,523101220231552,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",82.52,0.00
+__import__.product_template_cm0044mbu_n,CM0044MBU-N/S,C0044MBN231201,H. CAMISA NORMAL SHIRT PURPLE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0042ryb_n,CM0042RYB-N/S,C0042RYN231201,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0042ryb_n,CM0042RYB-N/L,C0042RYN231203,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0042ryb_n,CM0042RYB-N/M,C0042RYN231202,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0042ryb_n,CM0042RYB-N/XXL,C0042RYN231205,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0044mbu_n,CM0044MBU-N/XXL,C0044MBN231205,H. CAMISA NORMAL SHIRT PURPLE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0042ryb_n,CM0042RYB-N/XL,C0042RYN231204,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0044lbu_n,CM0044LBU-N/L,C0044LBN231203,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0044lbu_n,CM0044LBU-N/M,C0044LBN231202,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0044lbu_n,CM0044LBU-N/S,C0044LBN231201,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0044mbu_n,CM0044MBU-N/XL,C0044MBN231204,H. CAMISA NORMAL SHIRT PURPLE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_4s22026_2,4S22026-2-14.5-S1,452206220231451,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33 (4s22026_2),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_4s22026_2,4S22026-2-17.5-S2,452206220231752,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33 (4s22026_2),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_cm0044mbu_n,CM0044MBU-N/M,C0044MBN231202,H. CAMISA NORMAL SHIRT PURPLE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_4s22026_2,4S22026-2-17-S2,452206220231702,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33 (4s22026_2),"Talla: 17, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22026_2,4S22026-2-17-S1,452206220231701,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33 (4s22026_2),"Talla: 17, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_4s22026_2,4S22026-2-16.5-S2,452206220231652,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33 (4s22026_2),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22026_2,4S22026-2-16.5-S1,452206220231651,H. CAMISA P/S BRUNO CASSINI SKY BLUE 32-33 (4s22026_2),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0042mbu_n,CM0042MBU-N/M,C0042MBN231202,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_n),Talla: M,47.74,0.00
+__import__.product_template_cm0042mbu_n,CM0042MBU-N/S,C0042MBN231201,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_n),Talla: S,47.74,0.00
+__import__.product_template_cm0042mbu_n,CM0042MBU-N/L,C0042MBN231203,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_n),Talla: L,47.74,0.00
+__import__.product_template_cm0044mbu_n,CM0044MBU-N/L,C0044MBN231203,H. CAMISA NORMAL SHIRT PURPLE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0042dbu_n,CM0042DBU-N/XXL,C0042DBN231205,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI (cm0042dbu_n),Talla: XXL,47.74,0.00
+__import__.product_template_cm0042mbu_n,CM0042MBU-N/XXL,C0042MBN231205,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_n),Talla: XXL,47.74,0.00
+__import__.product_template_cm0042mbu_n,CM0042MBU-N/XL,C0042MBN231204,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_n),Talla: XL,47.74,0.00
+__import__.product_template_cm0044lbu_n,CM0044LBU-N/XXL,C0044LBN231205,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0044lbu_n,CM0044LBU-N/XL,C0044LBN231204,H. CAMISA NORMAL SHIRT SKY BLUE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_4s22009_2,4S22009-2-16.5-S2,4S220092231652,H. CAMISA P/S BRUNO CASSINI SKY BLUE ROMBO 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22009_2,4S22009-2-16.5-S1,4S220092231651,H. CAMISA P/S BRUNO CASSINI SKY BLUE ROMBO 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_4s22009_2,4S22009-2-15.5-S2,4S220092231552,H. CAMISA P/S BRUNO CASSINI SKY BLUE ROMBO 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22009_2,4S22009-2-15.5-S1,4S220092231551,H. CAMISA P/S BRUNO CASSINI SKY BLUE ROMBO 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_4s22009_1,4S22009-1-17-S2,4S220091201702,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (4s22009_1),"Talla: 17, Manga de Camisa: S2 - 34/35",56.44,0.00
+__import__.product_template_4s22009_1,4S22009-1-17-S1,4S220091201701,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (4s22009_1),"Talla: 17, Manga de Camisa: S1 - 32/33",56.44,0.00
+__import__.product_template_cm0042dbu_f,CM0042DBU-F/L,C0042DBF231203,H. CAMISA FRENCH SHIRT DK. BLUE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0042ryb_f,CM0042RYB-F/XL,C0042RYF231204,H. CAMISA FRENCH SHIRT BLUE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0042ryb_f,CM0042RYB-F/XXL,C0042RYF231205,H. CAMISA FRENCH SHIRT BLUE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0042dgr_f,CM0042DGR-F/XL,C0042DGF231204,H. CAMISA FRENCH SHIRT MINT BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0042ryb_f,CM0042RYB-F/S,C0042RYF231201,H. CAMISA FRENCH SHIRT BLUE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0042ryb_f,CM0042RYB-F/M,C0042RYF231202,H. CAMISA FRENCH SHIRT BLUE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0042ryb_f,CM0042RYB-F/L,C0042RYF231203,H. CAMISA FRENCH SHIRT BLUE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0044wht_f,CM0044WHT-F/S,C0044WHF231201,H. CAMISA FRENCH SHIRT WHITE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0044lbu_f,CM0044LBU-F/XXL,C0044LBF231205,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0044lbu_f,CM0044LBU-F/S,C0044LBF231201,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0044lbu_f,CM0044LBU-F/XL,C0044LBF231204,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0044lbu_f,CM0044LBU-F/L,C0044LBF231203,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0044lbu_f,CM0044LBU-F/M,C0044LBF231202,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_2011_1_f,2011-1-F/L,20111F20231203,H. CAMISA LINO FRENCH SHIRT WHITE BRUNO CASSINI,Talla: L,73.83,0.00
+__import__.product_template_2011_1_f,2011-1-F/M,20111F20231202,H. CAMISA LINO FRENCH SHIRT WHITE BRUNO CASSINI,Talla: M,73.83,0.00
+__import__.product_template_2011_1_f,2011-1-F/S,20111F20231201,H. CAMISA LINO FRENCH SHIRT WHITE BRUNO CASSINI,Talla: S,73.83,0.00
+__import__.product_template_2011_1_f,2011-1-F/XL,20111F20231204,H. CAMISA LINO FRENCH SHIRT WHITE BRUNO CASSINI,Talla: XL,73.83,0.00
+__import__.product_template_2011_1_f,2011-1-F/XXL,20111F20231205,H. CAMISA LINO FRENCH SHIRT WHITE BRUNO CASSINI,Talla: XXL,73.83,0.00
+__import__.product_template_2011_23_f,2011-23-F/L,201123F20231203,H. CAMISA LINO FRENCH SHIRT BLUE BRUNO CASSINI,Talla: L,73.83,0.00
+__import__.product_template_2011_23_f,2011-23-F/M,201123F20231202,H. CAMISA LINO FRENCH SHIRT BLUE BRUNO CASSINI,Talla: M,73.83,0.00
+__import__.product_template_2011_23_f,2011-23-F/S,201123F20231201,H. CAMISA LINO FRENCH SHIRT BLUE BRUNO CASSINI,Talla: S,73.83,0.00
+__import__.product_template_2011_23_f,2011-23-F/XL,201123F20231204,H. CAMISA LINO FRENCH SHIRT BLUE BRUNO CASSINI,Talla: XL,73.83,0.00
+__import__.product_template_2011_23_f,2011-23-F/XXL,201123F20231205,H. CAMISA LINO FRENCH SHIRT BLUE BRUNO CASSINI,Talla: XXL,73.83,0.00
+__import__.product_template_2011_55_f,2011-55-F/L,201155F231203,H. CAMISA LINO FRENCH SHIRT OLIVE BRUNO CASSINI,Talla: L,73.83,0.00
+__import__.product_template_2011_55_f,2011-55-F/M,201155F231202,H. CAMISA LINO FRENCH SHIRT OLIVE BRUNO CASSINI,Talla: M,73.83,0.00
+__import__.product_template_2011_55_f,2011-55-F/S,201155F231201,H. CAMISA LINO FRENCH SHIRT OLIVE BRUNO CASSINI,Talla: S,73.83,0.00
+__import__.product_template_2011_55_f,2011-55-F/XL,201155F231204,H. CAMISA LINO FRENCH SHIRT OLIVE BRUNO CASSINI,Talla: XL,73.83,0.00
+__import__.product_template_2011_55_f,2011-55-F/XXL,201155F231205,H. CAMISA LINO FRENCH SHIRT OLIVE BRUNO CASSINI,Talla: XXL,73.83,0.00
+__import__.product_template_cm0044wht_f,CM0044WHT-F/M,C0044WHF231202,H. CAMISA FRENCH SHIRT WHITE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0042mbu_f,CM0042MBU-F/XXL,C0042MBF231205,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_f),Talla: XXL,47.74,0.00
+__import__.product_template_cm0042mbu_f,CM0042MBU-F/XL,C0042MBF231204,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_f),Talla: XL,47.74,0.00
+__import__.product_template_cm0042mbu_f,CM0042MBU-F/S,C0042MBF231201,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_f),Talla: S,47.74,0.00
+__import__.product_template_cm0042mbu_f,CM0042MBU-F/M,C0042MBF231202,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_f),Talla: M,47.74,0.00
+__import__.product_template_cm0042mbu_f,CM0042MBU-F/L,C0042MBF231203,H. CAMISA FRENCH SHIRT SKY BLUE BRUNO CASSINI (cm0042mbu_f),Talla: L,47.74,0.00
+__import__.product_template_cm0044mbu_f,CM0044MBU-F/XXL,C0044MBF231205,H. CAMISA FRENCH SHIRT PURPLE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0044mbu_f,CM0044MBU-F/XL,C0044MBF231204,H. CAMISA FRENCH SHIRT PURPLE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0044mbu_f,CM0044MBU-F/S,C0044MBF231201,H. CAMISA FRENCH SHIRT PURPLE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0044mbu_f,CM0044MBU-F/M,C0044MBF231202,H. CAMISA FRENCH SHIRT PURPLE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0044mbu_f,CM0044MBU-F/L,C0044MBF231203,H. CAMISA FRENCH SHIRT PURPLE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0042dgr_f,CM0042DGR-F/L,C0042DGF231203,H. CAMISA FRENCH SHIRT MINT BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_cm0042dgr_f,CM0042DGR-F/XXL,C0042DGF231205,H. CAMISA FRENCH SHIRT MINT BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0042dbu_f,CM0042DBU-F/S,C0042DBF231201,H. CAMISA FRENCH SHIRT DK. BLUE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0042dbu_f,CM0042DBU-F/XXL,C0042DBF231205,H. CAMISA FRENCH SHIRT DK. BLUE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0042dbu_f,CM0042DBU-F/XL,C0042DBF231204,H. CAMISA FRENCH SHIRT DK. BLUE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0042dbu_f,CM0042DBU-F/M,C0042DBF231202,H. CAMISA FRENCH SHIRT DK. BLUE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0042dgr_f,CM0042DGR-F/M,C0042DGF231202,H. CAMISA FRENCH SHIRT MINT BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0042dgr_f,CM0042DGR-F/S,C0042DGF231201,H. CAMISA FRENCH SHIRT MINT BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_2011_55_n,2011-55-N/L,201155N231203,H. CAMISA LINO NORMAL SHIRT OLIVE BRUNO CASSINI,Talla: L,73.83,0.00
+__import__.product_template_2011_55_n,2011-55-N/M,201155N231202,H. CAMISA LINO NORMAL SHIRT OLIVE BRUNO CASSINI,Talla: M,73.83,0.00
+__import__.product_template_2011_55_n,2011-55-N/S,201155N231201,H. CAMISA LINO NORMAL SHIRT OLIVE BRUNO CASSINI,Talla: S,73.83,0.00
+__import__.product_template_2011_55_n,2011-55-N/XL,201155N231204,H. CAMISA LINO NORMAL SHIRT OLIVE BRUNO CASSINI,Talla: XL,73.83,0.00
+__import__.product_template_2011_55_n,2011-55-N/XXL,201155N231205,H. CAMISA LINO NORMAL SHIRT OLIVE BRUNO CASSINI,Talla: XXL,73.83,0.00
+__import__.product_template_cm0042dbu_n,CM0042DBU-N/M,C0042DBN231202,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI (cm0042dbu_n),Talla: M,47.74,0.00
+__import__.product_template_cm0042dbu_n,CM0042DBU-N/XL,C0042DBN231204,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI (cm0042dbu_n),Talla: XL,47.74,0.00
+__import__.product_template_cm0042dbu_n,CM0042DBU-N/S,C0042DBN231201,H. CAMISA NORMAL SHIRT BLUE BRUNO CASSINI (cm0042dbu_n),Talla: S,47.74,0.00
+__import__.product_template_cm0044wht_n,CM0044WHT-N/XL,C0044WHN231204,H. CAMISA NORMAL SHIRT WHITE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0044wht_n,CM0044WHT-N/M,C0044WHN231202,H. CAMISA NORMAL SHIRT WHITE BRUNO CASSINI,Talla: M,47.74,0.00
+__import__.product_template_cm0044wht_n,CM0044WHT-N/S,C0044WHN231201,H. CAMISA NORMAL SHIRT WHITE BRUNO CASSINI,Talla: S,47.74,0.00
+__import__.product_template_cm0044wht_f,CM0044WHT-F/XXL,C0044WHF231205,H. CAMISA FRENCH SHIRT WHITE BRUNO CASSINI,Talla: XXL,47.74,0.00
+__import__.product_template_cm0044wht_f,CM0044WHT-F/XL,C0044WHF231204,H. CAMISA FRENCH SHIRT WHITE BRUNO CASSINI,Talla: XL,47.74,0.00
+__import__.product_template_cm0044wht_n,CM0044WHT-N/L,C0044WHN231203,H. CAMISA NORMAL SHIRT WHITE BRUNO CASSINI,Talla: L,47.74,0.00
+__import__.product_template_8020_4_f,8020-4-F/M,802004F202302,H. CAMISA LINO FRENCH BRUNO CASSINI,Talla: M,82.52,0.00
+__import__.product_template_8020_4_f,8020-4-F/L,802004F202303,H. CAMISA LINO FRENCH BRUNO CASSINI,Talla: L,82.52,0.00
+__import__.product_template_8020_3_f,8020-3-F/XXL,802003F202305,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_3_f),Talla: XXL,82.52,0.00
+__import__.product_template_8020_3_f,8020-3-F/XL,802003F202304,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_3_f),Talla: XL,82.52,0.00
+__import__.product_template_8020_3_f,8020-3-F/S,802003F202301,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_3_f),Talla: S,82.52,0.00
+__import__.product_template_8020_3_f,8020-3-F/M,802003F202302,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_3_f),Talla: M,82.52,0.00
+__import__.product_template_8020_3_f,8020-3-F/L,802003F202303,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_3_f),Talla: L,82.52,0.00
+__import__.product_template_8020_15_f,8020-15-F/XXL,802015F202305,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_15_f),Talla: XXL,82.52,0.00
+__import__.product_template_8020_15_f,8020-15-F/XL,802015F202304,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_15_f),Talla: XL,82.52,0.00
+__import__.product_template_8020_15_f,8020-15-F/S,802015F202301,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_15_f),Talla: S,82.52,0.00
+__import__.product_template_8020_15_f,8020-15-F/M,802015F202302,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_15_f),Talla: M,82.52,0.00
+__import__.product_template_8020_15_f,8020-15-F/L,802015F202303,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_15_f),Talla: L,82.52,0.00
+__import__.product_template_8020_106_f,8020-106-F/XXL,8020106F202305,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_106_f),Talla: XXL,82.52,0.00
+__import__.product_template_8020_106_f,8020-106-F/XL,8020106F202304,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_106_f),Talla: XL,82.52,0.00
+__import__.product_template_8020_106_f,8020-106-F/S,8020106F202301,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_106_f),Talla: S,82.52,0.00
+__import__.product_template_8020_106_f,8020-106-F/M,8020106F202302,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_106_f),Talla: M,82.52,0.00
+__import__.product_template_8020_106_f,8020-106-F/L,8020106F202303,H. CAMISA LINO FRENCH BRUNO CASSINI (8020_106_f),Talla: L,82.52,0.00
+__import__.product_template_8020_4_f,8020-4-F/XXL,802004F202305,H. CAMISA LINO FRENCH BRUNO CASSINI,Talla: XXL,82.52,0.00
+__import__.product_template_8020_4_f,8020-4-F/XL,802004F202304,H. CAMISA LINO FRENCH BRUNO CASSINI,Talla: XL,82.52,0.00
+__import__.product_template_8020_4_f,8020-4-F/S,802004F202301,H. CAMISA LINO FRENCH BRUNO CASSINI,Talla: S,82.52,0.00
+__import__.product_template_pt_008_black_1,PT-008-BLACK-1/28,PT-008-BLACK-1/O28,Pantalon PT-008-BLACK-1,Talla: 28,56.43,0.00
+__import__.product_template_ern_sabat_1259,ERN-SABAT-1259-15-S2,ERNST125915002,H. CAMISA P/S BRUNO CASSINI WHITE 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_ern_sabat_1259,ERN-SABAT-1259-15-S1,ERNST125915001,H. CAMISA P/S BRUNO CASSINI WHITE 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_lv_22c0905_4c,LV-22C0905-4C/48,LV-22C0905-4C/O48,Leva LV-22C0905-4C,Talla: 48,165.13,0.00
+__import__.product_template_pt_22c0905_4c,PT-22C0905-4C/30,PT-22C0905-4C/O30,Pantalon PT-22C0905-4C,Talla: 30,47.74,0.00
+__import__.product_template_zp_pat_vn_cassini,ZP-PAT-VN-CASSINI/7,ZP-PAT-VN-CASSINI/O7,Zapato ZP-PAT-VN-CASSINI,Talla: 7,152.09,0.00
+__import__.product_template_zp_gam_az_s_f_cassini,ZP-GAM-AZ-S/F-CASSINI/9.5,ZPGAMAZSFCAS/O9.5,Zapato ZP-GAM-AZ-S/F-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_gam_cof_s_f_cassini,ZP-GAM-COF-S/F-CASSINI/9.5,ZPGAMCOFSFCAS/O9.5,Zapato ZP-GAM-COF-S/F-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/10,ZP-50224-CAS-BRW/O10,Zapato ZP-50224-CASSINI-BRW,Talla: 10,152.09,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/9,ZP-50224-CAS-BRW/O9,Zapato ZP-50224-CASSINI-BRW,Talla: 9,152.09,0.00
+__import__.product_template_zp_50224_cassini_cof,ZP-50224-CASSINI-COF/10,ZP-50224-CAS-COF/O10,Zapato ZP-50224-CASSINI-COF,Talla: 10,152.09,0.00
+__import__.product_template_zp_50224_cassini_cof,ZP-50224-CASSINI-COF/9.5,ZP-50224-CAS-COF/O9.5,Zapato ZP-50224-CASSINI-COF,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_cof,ZP-50224-CASSINI-COF/9,ZP-50224-CAS-COF/O9,Zapato ZP-50224-CASSINI-COF,Talla: 9,152.09,0.00
+__import__.product_template_zp_50224_cassini_cof,ZP-50224-CASSINI-COF/8.5,ZP-50224-CAS-COF/O8.5,Zapato ZP-50224-CASSINI-COF,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_cof,ZP-50224-CASSINI-COF/8,ZP-50224-CAS-COF/O8,Zapato ZP-50224-CASSINI-COF,Talla: 8,152.09,0.00
+__import__.product_template_zp_50224_cassini_cof,ZP-50224-CASSINI-COF/7.5,ZP-50224-CAS-COF/O7.5,Zapato ZP-50224-CASSINI-COF,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_cof,ZP-50224-CASSINI-COF/7,ZP-50224-CAS-COF/O7,Zapato ZP-50224-CASSINI-COF,Talla: 7,152.09,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/9.5,ZP-50224-CAS-BRW/O9.5,Zapato ZP-50224-CASSINI-BRW,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/8.5,ZP-50224-CAS-BRW/O8.5,Zapato ZP-50224-CASSINI-BRW,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/8,ZP-50224-CAS-BRW/O8,Zapato ZP-50224-CASSINI-BRW,Talla: 8,152.09,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/7.5,ZP-50224-CAS-BRW/O7.5,Zapato ZP-50224-CASSINI-BRW,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_50224_cassini_brw,ZP-50224-CASSINI-BRW/7,ZP-50224-CAS-BRW/O7,Zapato ZP-50224-CASSINI-BRW,Talla: 7,152.09,0.00
+__import__.product_template_pt_22c0905_4c,PT-22C0905-4C/32,PT-22C0905-4C/O32,Pantalon PT-22C0905-4C,Talla: 32,47.74,0.00
+__import__.product_template_lv_22c0905_4c,LV-22C0905-4C/50,LV-22C0905-4C/O50,Leva LV-22C0905-4C,Talla: 50,165.13,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/9.5,ZPCASSPSPTVN/O9.5,Zapato ZP-CASSINI-PS-PT-VN,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/10,ZPCASSPSPTVN/O10,Zapato ZP-CASSINI-PS-PT-VN,Talla: 10,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/9,ZPCASSPSPTVN/O9,Zapato ZP-CASSINI-PS-PT-VN,Talla: 9,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/8.5,ZPCASSPSPTVN/O8.5,Zapato ZP-CASSINI-PS-PT-VN,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/8,ZPCASSPSPTVN/O8,Zapato ZP-CASSINI-PS-PT-VN,Talla: 8,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/7,ZPCASSPSPTVN/O7,Zapato ZP-CASSINI-PS-PT-VN,Talla: 7,152.09,0.00
+__import__.product_template_zp_gam_ml_s_f_cassini,ZP-GAM-ML-S/F-CASSINI/9.5,ZPGAMMLSFCAS/O9.5,Zapato ZP-GAM-ML-S/F-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_gam_ml_s_f_cassini,ZP-GAM-ML-S/F-CASSINI/9,ZPGAMMLSFCAS/O9,Zapato ZP-GAM-ML-S/F-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_gam_ml_s_f_cassini,ZP-GAM-ML-S/F-CASSINI/8.5,ZPGAMMLSFCAS/O8.5,Zapato ZP-GAM-ML-S/F-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_pt_17001_7,PT-17001-7/34,PT-17001-7/O34,Pantalon PT-17001-7,Talla: 34,47.74,0.00
+__import__.product_template_zp_gam_cof_s_f_cassini,ZP-GAM-COF-S/F-CASSINI/9,ZPGAMCOFSFCAS/O9,Zapato ZP-GAM-COF-S/F-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_gam_cof_s_f_cassini,ZP-GAM-COF-S/F-CASSINI/7,ZPGAMCOFSFCAS/OO7,Zapato ZP-GAM-COF-S/F-CASSINI,Talla: 7,152.09,0.00
+__import__.product_template_zp_gam_ne_s_f_cassini,ZP-GAM-NE-S/F-CASSINI/9.5,ZPGAMNEGSFCAS/O9.5,Zapato ZP-GAM-NE-S/F-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_gam_ne_s_f_cassini,ZP-GAM-NE-S/F-CASSINI/9,ZPGAMNEGSFCAS/O9,Zapato ZP-GAM-NE-S/F-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_22c27428_67bc_2,22C27428-67BC-2/46,22C274286720234628,Terno 22C27428-67BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22c27428_67bc_2,22C27428-67BC-2/48,22C274286720234830,Terno 22C27428-67BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22c27428_67bc_2,22C27428-67BC-2/50,22C274286720235032,Terno 22C27428-67BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22c27428_67bc_2,22C27428-67BC-2/52,22C274286720235234,Terno 22C27428-67BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22c27428_67bc_2,22C27428-67BC-2/54,22C274286720235436,Terno 22C27428-67BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22c27428_67bc_2,22C27428-67BC-2/56,22C274286720235638,Terno 22C27428-67BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22c27428_67bc_2,22C27428-67BC-2/58,22C274286720235840,Terno 22C27428-67BC-2,Talla: 58,243.39,0.00
+__import__.product_template_22c27428_69bc_2,22C27428-69BC-2/46,22C274286920234628,Terno 22C27428-69BC-2,Talla: 46,217.30,0.00
+__import__.product_template_22c27428_69bc_2,22C27428-69BC-2/48,22C274286920234830,Terno 22C27428-69BC-2,Talla: 48,217.30,0.00
+__import__.product_template_22c27428_69bc_2,22C27428-69BC-2/50,22C274286920235032,Terno 22C27428-69BC-2,Talla: 50,217.30,0.00
+__import__.product_template_22c27428_69bc_2,22C27428-69BC-2/52,22C274286920235234,Terno 22C27428-69BC-2,Talla: 52,217.30,0.00
+__import__.product_template_22c27428_69bc_2,22C27428-69BC-2/54,22C274286920235436,Terno 22C27428-69BC-2,Talla: 54,217.30,0.00
+__import__.product_template_22c27428_69bc_2,22C27428-69BC-2/56,22C274286920235638,Terno 22C27428-69BC-2,Talla: 56,217.30,0.00
+__import__.product_template_22c27428_69bc_2,22C27428-69BC-2/58,22C274286920235840,Terno 22C27428-69BC-2,Talla: 58,217.30,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/46,23A15166202304628,Terno 23A1516-6BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/48,23A15166202304830,Terno 23A1516-6BC-2,Talla: 48,243.39,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/50,23A15166202305032,Terno 23A1516-6BC-2,Talla: 50,243.39,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/52,23A15166202305234,Terno 23A1516-6BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/54,23A15166202305436,Terno 23A1516-6BC-2,Talla: 54,243.39,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/56,23A15166202305638,Terno 23A1516-6BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23a1516_6bc_2,23A1516-6BC-2/58,23A15166202305840,Terno 23A1516-6BC-2,Talla: 58,243.39,0.00
+__import__.product_template_23a700112_12bc_2,23A700112-12BC-2/46,23A7001121220234628,Terno 23A700112-12BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23a700112_12bc_2,23A700112-12BC-2/48,23A7001121220234830,Terno 23A700112-12BC-2,Talla: 48,243.39,0.00
+__import__.product_template_23a700112_12bc_2,23A700112-12BC-2/50,23A7001121220235032,Terno 23A700112-12BC-2,Talla: 50,243.39,0.00
+__import__.product_template_23a700112_12bc_2,23A700112-12BC-2/52,23A7001121220235234,Terno 23A700112-12BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23a700112_12bc_2,23A700112-12BC-2/54,23A7001121220235436,Terno 23A700112-12BC-2,Talla: 54,243.39,0.00
+__import__.product_template_23a700112_12bc_2,23A700112-12BC-2/56,23A7001121220235638,Terno 23A700112-12BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23a700112_12bc_2,23A700112-12BC-2/58,23A7001121220235840,Terno 23A700112-12BC-2,Talla: 58,243.39,0.00
+__import__.product_template_23e9919_95bc_2,23E9919-95BC-2/46,23E99199524094628,Terno 23E9919-95BC-2,Talla: 46,260.78,0.00
+__import__.product_template_23e9919_95bc_2,23E9919-95BC-2/48,23E99199524094830,Terno 23E9919-95BC-2,Talla: 48,260.78,0.00
+__import__.product_template_23e9919_95bc_2,23E9919-95BC-2/50,23E99199524095032,Terno 23E9919-95BC-2,Talla: 50,260.78,0.00
+__import__.product_template_23e9919_95bc_2,23E9919-95BC-2/52,23E99199524095234,Terno 23E9919-95BC-2,Talla: 52,260.78,0.00
+__import__.product_template_23e9919_95bc_2,23E9919-95BC-2/54,23E99199524095436,Terno 23E9919-95BC-2,Talla: 54,260.78,0.00
+__import__.product_template_23e9919_95bc_2,23E9919-95BC-2/56,23E99199524095638,Terno 23E9919-95BC-2,Talla: 56,260.78,0.00
+__import__.product_template_23e9919_95bc_2,23E9919-95BC-2/58,23E99199524095840,Terno 23E9919-95BC-2,Talla: 58,260.78,0.00
+__import__.product_template_23e312010_1bc_2,23E312010-1BC-2/46,22E312010120234628,Terno 23E312010-1BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23e312010_1bc_2,23E312010-1BC-2/48,22E312010120234830,Terno 23E312010-1BC-2,Talla: 48,243.39,0.00
+__import__.product_template_23e312010_1bc_2,23E312010-1BC-2/50,22E312010120235032,Terno 23E312010-1BC-2,Talla: 50,243.39,0.00
+__import__.product_template_23e312010_1bc_2,23E312010-1BC-2/52,22E312010120235234,Terno 23E312010-1BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23e312010_1bc_2,23E312010-1BC-2/54,22E312010120235436,Terno 23E312010-1BC-2,Talla: 54,243.39,0.00
+__import__.product_template_23e312010_1bc_2,23E312010-1BC-2/56,22E312010120235638,Terno 23E312010-1BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23e312010_1bc_2,23E312010-1BC-2/58,22E312010120235840,Terno 23E312010-1BC-2,Talla: 58,243.39,0.00
+__import__.product_template_23e312010_3bc_2,23E312010-3BC-2/46,22E312010320234628,Terno 23E312010-3BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23e312010_3bc_2,23E312010-3BC-2/48,22E312010320234830,Terno 23E312010-3BC-2,Talla: 48,217.30,0.00
+__import__.product_template_23e312010_3bc_2,23E312010-3BC-2/50,22E312010320235032,Terno 23E312010-3BC-2,Talla: 50,217.30,0.00
+__import__.product_template_23e312010_3bc_2,23E312010-3BC-2/52,22E312010320235234,Terno 23E312010-3BC-2,Talla: 52,217.30,0.00
+__import__.product_template_23e312010_3bc_2,23E312010-3BC-2/54,22E312010320235436,Terno 23E312010-3BC-2,Talla: 54,217.30,0.00
+__import__.product_template_23e312010_3bc_2,23E312010-3BC-2/56,22E312010320235638,Terno 23E312010-3BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23e312010_3bc_2,23E312010-3BC-2/58,22E312010320235840,Terno 23E312010-3BC-2,Talla: 58,217.30,0.00
+__import__.product_template_23e312010_4bc_2,23E312010-4BC-2/46,23E312010424094628,Terno 23E312010-4BC-2,Talla: 46,243.39,0.00
+__import__.product_template_23e312010_4bc_2,23E312010-4BC-2/48,23E312010424094830,Terno 23E312010-4BC-2,Talla: 48,243.39,0.00
+__import__.product_template_23e312010_4bc_2,23E312010-4BC-2/50,23E312010424095032,Terno 23E312010-4BC-2,Talla: 50,243.39,0.00
+__import__.product_template_23e312010_4bc_2,23E312010-4BC-2/52,23E312010424095234,Terno 23E312010-4BC-2,Talla: 52,243.39,0.00
+__import__.product_template_23e312010_4bc_2,23E312010-4BC-2/54,23E312010424095436,Terno 23E312010-4BC-2,Talla: 54,243.39,0.00
+__import__.product_template_23e312010_4bc_2,23E312010-4BC-2/56,23E312010424095638,Terno 23E312010-4BC-2,Talla: 56,243.39,0.00
+__import__.product_template_23e312010_4bc_2,23E312010-4BC-2/58,23E312010424095840,Terno 23E312010-4BC-2,Talla: 58,243.39,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-15-S1,ERNSDC125915001,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-14.5-S1,ERNS125914501,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-15-S2,ERNSDC125915002,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_nx_bichek_03,NX-BICHEK-03-16.5-S2,NXBICH032016502,H. CAMISA P/S CUADROS BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_nx_bichek_03,NX-BICHEK-03-16.5-S1,NXBICH032016501,H. CAMISA P/S CUADROS BRUNO CASSINI 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-16.5-S1,ERNS125916501,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-16-S2,ERNS125916002,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-16-S1,ERNS125916001,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-17-S2,ERNS125917002,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-17-S1,ERNS125917001,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_sabat_1259dc,ERN-SABAT-1259DC-16.5-S2,ERNS125916502,H. CAMISA D/P BRUNO CASSINI WHITE 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_nx_bichek_03,NX-BICHEK-03-15.5-S2,NXBICH032015502,H. CAMISA P/S CUADROS BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_nx_bichek_03,NX-BICHEK-03-16-S1,NXBICH032016001,H. CAMISA P/S CUADROS BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_nx_bichek_03,NX-BICHEK-03-15.5-S1,NXBICH032015501,H. CAMISA P/S CUADROS BRUNO CASSINI 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_nx_bichek_03,NX-BICHEK-03-16-S2,NXBICH032016002,H. CAMISA P/S CUADROS BRUNO CASSINI 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ce_baj_15_3915,CE-BAJ-15-3915-17.5-S2,CEBAB202317502,H. CAMISA P/S BIG SIZE BRUNO CASSINI SKY BLUE 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-17-S2,ERNS102317002,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-17.5-S2,ERNS102317502,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-15.5-S2,ERNS102315502,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-15.5-S1,ERNS102315501,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_ern_sabat_10,ERN-SABAT-10-17-S1,ERNS102317001,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_pul,PUL-10,PUL-O10,PULSERA DE DAMAS,Talla: 10,14.61,0.00
+__import__.product_template_tl_x25_513a_a,TL-X25-513A.A/30,7453040771288,Terno TL-X25-513A.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_x25_513a_a,TL-X25-513A.A/32,7453040771295,Terno TL-X25-513A.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_513a_a,TL-X25-513A.A/34,7453040771301,Terno TL-X25-513A.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_513a_a,TL-X25-513A.A/36,7453040771318,Terno TL-X25-513A.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_513a_a,TL-X25-513A.A/38,7453040771325,Terno TL-X25-513A.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_513a_a,TL-X25-513A.A/40,7453040771332,Terno TL-X25-513A.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_x25_502c_a,TL-X25-502C.A/XL,7453040772933,H. BERMUDA P/HOMBRE TED LAPIDUS KHAKI,Talla: XL,34.70,0.00
+__import__.product_template_tl_x25_501f_a,TL-X25-501F.A/36,7453040771714,Terno TL-X25-501F.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_501f_a,TL-X25-501F.A/40,7453040771738,Terno TL-X25-501F.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_x25_501a_a,TL-X25-501A.A/40,7453040771233,Terno TL-X25-501A.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_b23_1103d_a,TL-B23-1103D.A/38,7453040837779,Terno TL-B23-1103D.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_x25_501a_a,TL-X25-501A.A/32,7453040771196,Terno TL-X25-501A.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_501a_a,TL-X25-501A.A/38,7453040771226,Terno TL-X25-501A.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_y23_104b_a,TL-Y23-104B.A/32,7453040767519,Terno TL-Y23-104B.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_y23_104b_a,TL-Y23-104B.A/30,7453040767502,Terno TL-Y23-104B.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_y23_104b_a,TL-Y23-104B.A/40,7453040767557,Terno TL-Y23-104B.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_y23_104b_a,TL-Y23-104B.A/38,7453040767540,Terno TL-Y23-104B.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_y23_104b_a,TL-Y23-104B.A/36,7453040767533,Terno TL-Y23-104B.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_y23_104b_a,TL-Y23-104B.A/34,7453040767526,Terno TL-Y23-104B.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_x25_501f_a,TL-X25-501F.A/34,7453040771707,Terno TL-X25-501F.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_501f_a,TL-X25-501F.A/38,7453040771721,Terno TL-X25-501F.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_501a_a,TL-X25-501A.A/34,7453040771202,Terno TL-X25-501A.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_501a_a,TL-X25-501A.A/36,7453040771219,Terno TL-X25-501A.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_501f_a,TL-X25-501F.A/30,7453040771684,Terno TL-X25-501F.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_y23_104a_a,TL-Y23-104A.A/38,7453040767489,Terno TL-Y23-104A.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_y23_104a_a,TL-Y23-104A.A/36,7453040767472,Terno TL-Y23-104A.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_y23_104a_a,TL-Y23-104A.A/34,7453040767465,Terno TL-Y23-104A.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_y23_104a_a,TL-Y23-104A.A/32,7453040767458,Terno TL-Y23-104A.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_y23_104a_a,TL-Y23-104A.A/40,7453040767496,Terno TL-Y23-104A.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_x25_501a_a,TL-X25-501A.A/30,7453040771189,Terno TL-X25-501A.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_b23_1103d_a,TL-B23-1103D.A/40,7453040837786,Terno TL-B23-1103D.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_x25_501f_a,TL-X25-501F.A/32,7453040771691,Terno TL-X25-501F.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_505b_a,TL-X25-505B.A/38,7453040772483,Terno TL-X25-505B.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_505d_a,TL-X25-505D.A/36,7453040772674,Terno TL-X25-505D.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_505d_a,TL-X25-505D.A/38,7453040772681,Terno TL-X25-505D.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_505d_a,TL-X25-505D.A/40,7453040772698,Terno TL-X25-505D.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_x25_505d_a,TL-X25-505D.A/34,7453040772667,Terno TL-X25-505D.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_509_a,TL-X25-509.A/34,7453040772728,Terno TL-X25-509.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_502a_a,TL-X25-502A.A/L,7453040772841,H. BERMUDA P/HOMBRE TED LAPIDUS WHITE,Talla: L,34.70,0.00
+__import__.product_template_tl_x25_502a_a,TL-X25-502A.A/XL,7453040772858,H. BERMUDA P/HOMBRE TED LAPIDUS WHITE,Talla: XL,34.70,0.00
+__import__.product_template_tl_x25_509_a,TL-X25-509.A/30,7453040772704,Terno TL-X25-509.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_x25_506_a,TL-X25-506.A/32,7453040772773,Terno TL-X25-506.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_506_a,TL-X25-506.A/34,7453040772780,Terno TL-X25-506.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_506_a,TL-X25-506.A/36,7453040772797,Terno TL-X25-506.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_506_a,TL-X25-506.A/30,7453040772766,Terno TL-X25-506.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_x25_506_a,TL-X25-506.A/40,7453040772810,Terno TL-X25-506.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_x25_502b_a,TL-X25-502B.A/L,7453040772889,H. BERMUDA P/HOMBRE TED LAPIDUS NAVY,Talla: L,34.70,0.00
+__import__.product_template_tl_x25_502a_a,TL-X25-502A.A/M,7453040772834,H. BERMUDA P/HOMBRE TED LAPIDUS WHITE,Talla: M,34.70,0.00
+__import__.product_template_tl_x25_502a_a,TL-X25-502A.A/S,7453040772827,H. BERMUDA P/HOMBRE TED LAPIDUS WHITE,Talla: S,34.70,0.00
+__import__.product_template_tl_x25_505b_a,TL-X25-505B.A/32,7453040772452,Terno TL-X25-505B.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_509_a,TL-X25-509.A/40,7453040772759,Terno TL-X25-509.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_b23_1103b_a,TL-B23-1103B.A/40,7453040837625,Terno TL-B23-1103B.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_b23_1103a_a,TL-B23-1103A.A/30,7453040837472,Terno TL-B23-1103A.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_b23_1103a_a,TL-B23-1103A.A/34,7453040837496,Terno TL-B23-1103A.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_b23_1103a_a,TL-B23-1103A.A/32,7453040837489,Terno TL-B23-1103A.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_b23_1103b_a,TL-B23-1103B.A/36,7453040837601,Terno TL-B23-1103B.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_b23_1103b_a,TL-B23-1103B.A/34,7453040837595,Terno TL-B23-1103B.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_b23_1103b_a,TL-B23-1103B.A/32,7453040837588,Terno TL-B23-1103B.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_b23_1103b_a,TL-B23-1103B.A/30,7453040837571,Terno TL-B23-1103B.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_b23_1103a_a,TL-B23-1103A.A/40,7453040837526,Terno TL-B23-1103A.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_b23_1103a_a,TL-B23-1103A.A/38,7453040837519,Terno TL-B23-1103A.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_b23_1103a_a,TL-B23-1103A.A/36,7453040837502,Terno TL-B23-1103A.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_b23_1103d_a,TL-B23-1103D.A/34,7453040837755,Terno TL-B23-1103D.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_b23_1103d_a,TL-B23-1103D.A/32,7453040837748,Terno TL-B23-1103D.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_b23_1103d_a,TL-B23-1103D.A/30,7453040837731,Terno TL-B23-1103D.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_b23_1103c_a,TL-B23-1103C.A/40,7453040837724,Terno TL-B23-1103C.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_b23_1103c_a,TL-B23-1103C.A/38,7453040837717,Terno TL-B23-1103C.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_b23_1103c_a,TL-B23-1103C.A/36,7453040837700,Terno TL-B23-1103C.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_b23_1103c_a,TL-B23-1103C.A/34,7453040837694,Terno TL-B23-1103C.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_b23_1103d_a,TL-B23-1103D.A/36,7453040837762,Terno TL-B23-1103D.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_b23_1103c_a,TL-B23-1103C.A/32,7453040837687,Terno TL-B23-1103C.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_b23_1103b_a,TL-B23-1103B.A/38,7453040837618,Terno TL-B23-1103B.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_b23_1103c_a,TL-B23-1103C.A/30,7453040837670,Terno TL-B23-1103C.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_x30_513a_a,TL-X30-513A.A/M,7453040776870,H. CAMISETA M/C HOMBRE TED LAPIDUS PINK,Talla: M,31.22,0.00
+__import__.product_template_tl_x30_513a_a,TL-X30-513A.A/S,7453040776863,H. CAMISETA M/C HOMBRE TED LAPIDUS PINK,Talla: S,31.22,0.00
+__import__.product_template_tl_x30_513b_a,TL-X30-513B.A/S,7453040776900,H. CAMISETA M/C HOMBRE TED LAPIDUS YELLOW,Talla: S,31.22,0.00
+__import__.product_template_tl_x30_513b_a,TL-X30-513B.A/XL,7453040776931,H. CAMISETA M/C HOMBRE TED LAPIDUS YELLOW,Talla: XL,31.22,0.00
+__import__.product_template_tl_x30_513c_a,TL-X30-513C.A/L,7453040776962,H. CAMISETA M/C HOMBRE TED LAPIDUS GREEN,Talla: L,31.22,0.00
+__import__.product_template_tl_x30_513c_a,TL-X30-513C.A/M,7453040776955,H. CAMISETA M/C HOMBRE TED LAPIDUS GREEN,Talla: M,31.22,0.00
+__import__.product_template_tl_x30_513c_a,TL-X30-513C.A/S,7453040776948,H. CAMISETA M/C HOMBRE TED LAPIDUS GREEN,Talla: S,31.22,0.00
+__import__.product_template_tl_x30_513c_a,TL-X30-513C.A/XL,7453040776979,H. CAMISETA M/C HOMBRE TED LAPIDUS GREEN,Talla: XL,31.22,0.00
+__import__.product_template_tl_x04_517_a,TL-X04-517.A/S,7453040782505,H. CAMISA M/C HOMBRE TED LAPIDUS LT. BLUE,Talla: S,39.04,0.00
+__import__.product_template_tl_x04_517_a,TL-X04-517.A/XL,7453040782536,H. CAMISA M/C HOMBRE TED LAPIDUS LT. BLUE,Talla: XL,39.04,0.00
+__import__.product_template_tl_x30_513a_a,TL-X30-513A.A/L,7453040776887,H. CAMISETA M/C HOMBRE TED LAPIDUS PINK,Talla: L,31.22,0.00
+__import__.product_template_tl_x04_517_a,TL-X04-517.A/L,7453040782529,H. CAMISA M/C HOMBRE TED LAPIDUS LT. BLUE,Talla: L,39.04,0.00
+__import__.product_template_tl_x30_513b_a,TL-X30-513B.A/M,7453040776917,H. CAMISETA M/C HOMBRE TED LAPIDUS YELLOW,Talla: M,31.22,0.00
+__import__.product_template_tl_x30_513a_a,TL-X30-513A.A/XL,7453040776894,H. CAMISETA M/C HOMBRE TED LAPIDUS PINK,Talla: XL,31.22,0.00
+__import__.product_template_tl_x30_513b_a,TL-X30-513B.A/L,7453040776924,H. CAMISETA M/C HOMBRE TED LAPIDUS YELLOW,Talla: L,31.22,0.00
+__import__.product_template_tl_x04_517_a,TL-X04-517.A/M,7453040782512,H. CAMISA M/C HOMBRE TED LAPIDUS LT. BLUE,Talla: M,39.04,0.00
+__import__.product_template_tl_x04_515_a,TL-X04-515.A/L,7453040782369,H. CAMISA M/C HOMBRE TED LAPIDUS RED,Talla: L,39.04,0.00
+__import__.product_template_tl_x04_515_a,TL-X04-515.A/XL,7453040782376,H. CAMISA M/C HOMBRE TED LAPIDUS RED,Talla: XL,39.04,0.00
+__import__.product_template_tl_x04_515_a,TL-X04-515.A/M,7453040782352,H. CAMISA M/C HOMBRE TED LAPIDUS RED,Talla: M,39.04,0.00
+__import__.product_template_tl_x04_515_a,TL-X04-515.A/S,7453040782345,H. CAMISA M/C HOMBRE TED LAPIDUS RED,Talla: S,39.04,0.00
+__import__.product_template_lbpc_b21_101s_ch,LBPC-B21-101S-CH/36,7448335854807,Terno LBPC-B21-101S-CH,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ch,LBPC-B21-101S-CH/32,7448337126131,Terno LBPC-B21-101S-CH,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ink,LBPC-B21-101S-INK/30,7448333155128,Terno LBPC-B21-101S-INK,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ch,LBPC-B21-101S-CH/38,7448335185178,Terno LBPC-B21-101S-CH,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ka,LBPC-B21-101S-KA/32,7448349569568,Terno LBPC-B21-101S-KA,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ka,LBPC-B21-101S-KA/34,7448351368333,Terno LBPC-B21-101S-KA,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ink,LBPC-B21-101S-INK/36,7448345656606,Terno LBPC-B21-101S-INK,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_b21_101s_nv,LBPC-B21-101S-NV/36,7448334355350,Terno LBPC-B21-101S-NV,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_b21_101s_nv,LBPC-B21-101S-NV/34,7448337247225,Terno LBPC-B21-101S-NV,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ch,LBPC-B21-101S-CH/30,7448350249282,Terno LBPC-B21-101S-CH,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ch,LBPC-B21-101S-CH/34,7448345391378,Terno LBPC-B21-101S-CH,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ink,LBPC-B21-101S-INK/32,7448335073031,Terno LBPC-B21-101S-INK,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ink,LBPC-B21-101S-INK/34,7448335329350,Terno LBPC-B21-101S-INK,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ink,LBPC-B21-101S-INK/38,7448349321333,Terno LBPC-B21-101S-INK,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_b21_101s_ka,LBPC-B21-101S-KA/30,7448355866866,Terno LBPC-B21-101S-KA,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_b03_102r_wh,LBPC-B03-102R-WH/XL,7448341092095,H. CAMISA M/C LONG BEACH WHITE,Talla: XL,41.65,0.00
+__import__.product_template_lbpc_b03_102r_wh,LBPC-B03-102R-WH/S,7448351149130,H. CAMISA M/C LONG BEACH WHITE,Talla: S,41.65,0.00
+__import__.product_template_lbpc_b03_102r_wh,LBPC-B03-102R-WH/M,7448334369395,H. CAMISA M/C LONG BEACH WHITE,Talla: M,41.65,0.00
+__import__.product_template_lbpc_b03_102r_wh,LBPC-B03-102R-WH/L,7448344641610,H. CAMISA M/C LONG BEACH WHITE,Talla: L,41.65,0.00
+__import__.product_template_lbpc_b03_102r_sk,LBPC-B03-102R-SK/XL,7448332940978,H. CAMISA M/C LONG BEACH SKY,Talla: XL,41.65,0.00
+__import__.product_template_lbpc_b03_102r_sk,LBPC-B03-102R-SK/S,7448348734752,H. CAMISA M/C LONG BEACH SKY,Talla: S,41.65,0.00
+__import__.product_template_lbpc_b03_102r_sk,LBPC-B03-102R-SK/M,7448344026042,H. CAMISA M/C LONG BEACH SKY,Talla: M,41.65,0.00
+__import__.product_template_lbpc_b03_102r_sk,LBPC-B03-102R-SK/L,7448340183138,H. CAMISA M/C LONG BEACH SKY,Talla: L,41.65,0.00
+__import__.product_template_lbpc_b21_101s_nv,LBPC-B21-101S-NV/38,7448347112148,Terno LBPC-B21-101S-NV,Talla: 38,43.39,0.00
+__import__.product_template_cb_h21_003ka,CB-H21-003KA/XL,7448337365301,H. PANTALON P/HOMBRE CUBAVERA BANANA CREPE,Talla: XL,126.00,0.00
+__import__.product_template_cb_h22_006bw,CB-H22-006BW/32,7448335488491,Terno CB-H22-006BW,Talla: 32,82.52,0.00
+__import__.product_template_cb_h21_003nv,CB-H21-003NV/XL,7448330169159,H. PANTALON P/HOMBRE CUBAVERA BLUE PRINT,Talla: XL,117.30,0.00
+__import__.product_template_cb_h20_005nv,CB-H20-005NV/32,7448342012023,Terno CB-H20-005NV,Talla: 32,117.30,0.00
+__import__.product_template_cb_h20_005nv,CB-H20-005NV/36,7448330583542,Terno CB-H20-005NV,Talla: 36,117.30,0.00
+__import__.product_template_cb_sp21_003bw,CB-SP21-003BW/XL,7448339918963,H. PANTALON P/HOMBRE CUBAVERA BRIGHT WHITE,Talla: XL,126.00,0.00
+__import__.product_template_cb_sp21_003bw,CB-SP21-003BW/S,7448332247299,H. PANTALON P/HOMBRE CUBAVERA BRIGHT WHITE,Talla: S,126.00,0.00
+__import__.product_template_cb_sp21_003bw,CB-SP21-003BW/M,7448331384339,H. PANTALON P/HOMBRE CUBAVERA BRIGHT WHITE,Talla: M,126.00,0.00
+__import__.product_template_cb_sp21_003bw,CB-SP21-003BW/L,7448335314387,H. PANTALON P/HOMBRE CUBAVERA BRIGHT WHITE,Talla: L,126.00,0.00
+__import__.product_template_cb_h20_005nv,CB-H20-005NV/34,7448331736732,Terno CB-H20-005NV,Talla: 34,117.30,0.00
+__import__.product_template_cb_h22_006bw,CB-H22-006BW/30,7448341625613,Terno CB-H22-006BW,Talla: 30,82.52,0.00
+__import__.product_template_cb_h21_003nv,CB-H21-003NV/M,7448341323342,H. PANTALON P/HOMBRE CUBAVERA BLUE PRINT,Talla: M,117.30,0.00
+__import__.product_template_cb_h21_003nv,CB-H21-003NV/L,7448333025001,H. PANTALON P/HOMBRE CUBAVERA BLUE PRINT,Talla: L,117.30,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/36,7448345224225,Terno CB-H22-006NV,Talla: 36,82.52,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/30,7448333973975,Terno CB-H22-006NV,Talla: 30,82.52,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/34,7448339420442,Terno CB-H22-006NV,Talla: 34,82.52,0.00
+__import__.product_template_cuwfd002_112,CUWFD002-112/XL,401065128324,H. CAMISA M/C CUBAVERA BRILLIANT WHITE,Talla: XL,79.91,0.00
+__import__.product_template_lbpc_b04_102s_lc,LBPC-B04-102S-LC/XL,7448333651613,H. CAMISA M/C LONG BEACH LILAC,Talla: XL,41.65,0.00
+__import__.product_template_lbpc_b04_102s_lc,LBPC-B04-102S-LC/L,7448335227281,H. CAMISA M/C LONG BEACH LILAC,Talla: L,41.65,0.00
+__import__.product_template_lbpc_b04_102s_lc,LBPC-B04-102S-LC/M,7448335896814,H. CAMISA M/C LONG BEACH LILAC,Talla: M,41.65,0.00
+__import__.product_template_lbpc_b04_102s_lc,LBPC-B04-102S-LC/S,7448343118182,H. CAMISA M/C LONG BEACH LILAC,Talla: S,41.65,0.00
+__import__.product_template_cb_h21_003nv,CB-H21-003NV/S,7448331245289,H. PANTALON P/HOMBRE CUBAVERA BLUE PRINT,Talla: S,117.30,0.00
+__import__.product_template_cb_h22_006bw,CB-H22-006BW/34,7448342266235,Terno CB-H22-006BW,Talla: 34,82.52,0.00
+__import__.product_template_cb_h20_005nv,CB-H20-005NV/38,7448341293232,Terno CB-H20-005NV,Talla: 38,117.30,0.00
+__import__.product_template_cb_h20_005nv,CB-H20-005NV/30,7448338831812,Terno CB-H20-005NV,Talla: 30,117.30,0.00
+__import__.product_template_cb_h21_003ka,CB-H21-003KA/L,7448336626656,H. PANTALON P/HOMBRE CUBAVERA BANANA CREPE,Talla: L,126.00,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/32,7448339436474,Terno CB-H22-006NV,Talla: 32,82.52,0.00
+__import__.product_template_cb_h22_006bw,CB-H22-006BW/36,7448339467492,Terno CB-H22-006BW,Talla: 36,82.52,0.00
+__import__.product_template_cuwsd012_112,CUWSD012-112/M,051054297885,H. CAMISA M/C CUBAVERA BRILLIANT WHITE (cuwsd012_112),Talla: M,78.17,0.00
+__import__.product_template_cuwsd012_112,CUWSD012-112/L,051054297892,H. CAMISA M/C CUBAVERA BRILLIANT WHITE (cuwsd012_112),Talla: L,78.17,0.00
+__import__.product_template_cb_h20_005nv,CB-H20-005NV/40,7448338548581,Terno CB-H20-005NV,Talla: 40,117.30,0.00
+__import__.product_template_cuwsd012_112,CUWSD012-112/S,051054297878,H. CAMISA M/C CUBAVERA BRILLIANT WHITE (cuwsd012_112),Talla: S,78.17,0.00
+__import__.product_template_cuwsd012_112,CUWSD012-112/XL,051054297908,H. CAMISA M/C CUBAVERA BRILLIANT WHITE (cuwsd012_112),Talla: XL,78.17,0.00
+__import__.product_template_cuwsd077_477,CUWSD077-477/L,401065384270,H. CAMISA M/C CUBAVERA PARISIAN BLUE,Talla: L,73.83,0.00
+__import__.product_template_cuwsd077_477,CUWSD077-477/M,401065384300,H. CAMISA M/C CUBAVERA PARISIAN BLUE,Talla: M,73.83,0.00
+__import__.product_template_cuwsd077_477,CUWSD077-477/XL,401065383532,H. CAMISA M/C CUBAVERA PARISIAN BLUE,Talla: XL,73.83,0.00
+__import__.product_template_cuwsd077_477,CUWSD077-477/S,401065384362,H. CAMISA M/C CUBAVERA PARISIAN BLUE,Talla: S,73.83,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/38,7448332644630,Terno CB-H22-006NV,Talla: 38,82.52,0.00
+__import__.product_template_cb_h22_006nv,CB-H22-006NV/40,7448354766723,Terno CB-H22-006NV,Talla: 40,82.52,0.00
+__import__.product_template_cb_h22_006bw,CB-H22-006BW/40,7448331973960,Terno CB-H22-006BW,Talla: 40,82.52,0.00
+__import__.product_template_cb_h21_003ka,CB-H21-003KA/S,7448337540586,H. PANTALON P/HOMBRE CUBAVERA BANANA CREPE,Talla: S,126.00,0.00
+__import__.product_template_cb_h21_003ka,CB-H21-003KA/M,7448333534534,H. PANTALON P/HOMBRE CUBAVERA BANANA CREPE,Talla: M,126.00,0.00
+__import__.product_template_cb_h22_006bw,CB-H22-006BW/38,7448331879873,Terno CB-H22-006BW,Talla: 38,82.52,0.00
+__import__.product_template_lbpc_a03_217s_rs,LBPC-A03-217S-RS/S,7448350549535,H. CAMISA M/C LONG BEACH ROSE,Talla: S,41.65,0.00
+__import__.product_template_cuwmd013_482,CUWMD013-482/L,401053468135,H. CAMISA M/C CUBAVERA SWIN CAP,Talla: L,82.52,0.00
+__import__.product_template_cuwfd002_112,CUWFD002-112/L,401065128218,H. CAMISA M/C CUBAVERA BRILLIANT WHITE,Talla: L,79.91,0.00
+__import__.product_template_cuwfd002_112,CUWFD002-112/M,401065128249,H. CAMISA M/C CUBAVERA BRILLIANT WHITE,Talla: M,79.91,0.00
+__import__.product_template_cuwmd013_482,CUWMD013-482/XL,401053468241,H. CAMISA M/C CUBAVERA SWIN CAP,Talla: XL,82.52,0.00
+__import__.product_template_cuwsa020_003,CUWSA020-003/L,085142850997,H. CAMISA M/C CUBAVERA JET BLACK,Talla: L,82.52,0.00
+__import__.product_template_cuwsa020_003,CUWSA020-003/XL,085142851000,H. CAMISA M/C CUBAVERA JET BLACK,Talla: XL,82.52,0.00
+__import__.product_template_cuwsa020_003,CUWSA020-003/S,085142850973,H. CAMISA M/C CUBAVERA JET BLACK,Talla: S,82.52,0.00
+__import__.product_template_cuwsa020_003,CUWSA020-003/M,085142850980,H. CAMISA M/C CUBAVERA JET BLACK,Talla: M,82.52,0.00
+__import__.product_template_cuwmd013_482,CUWMD013-482/S,401053468227,H. CAMISA M/C CUBAVERA SWIN CAP,Talla: S,82.52,0.00
+__import__.product_template_cuwsp001_408,CUWSP001-408/L,7448332267204,H. CAMISA M/C CUBAVERA DRESS BLUES,Talla: L,73.83,0.00
+__import__.product_template_cuwsp001_408,CUWSP001-408/M,7448340180151,H. CAMISA M/C CUBAVERA DRESS BLUES,Talla: M,73.83,0.00
+__import__.product_template_cuwsp001_408,CUWSP001-408/S,7448336490400,H. CAMISA M/C CUBAVERA DRESS BLUES,Talla: S,73.83,0.00
+__import__.product_template_cuwsp001_408,CUWSP001-408/XL,7448336264223,H. CAMISA M/C CUBAVERA DRESS BLUES,Talla: XL,73.83,0.00
+__import__.product_template_cuwmd013_482,CUWMD013-482/M,401053468166,H. CAMISA M/C CUBAVERA SWIN CAP,Talla: M,82.52,0.00
+__import__.product_template_cuwsp007_100,CUWSP007-100/L,7448332327342,H. CAMISA M/C CUBAVERA BRIGHT WHITE,Talla: L,73.83,0.00
+__import__.product_template_cuwsp007_100,CUWSP007-100/M,7448335729716,H. CAMISA M/C CUBAVERA BRIGHT WHITE,Talla: M,73.83,0.00
+__import__.product_template_cuwsp007_100,CUWSP007-100/S,7448338238284,H. CAMISA M/C CUBAVERA BRIGHT WHITE,Talla: S,73.83,0.00
+__import__.product_template_cuwsp009_426,CUWSP009-426/XL,7448341714744,H. CAMISA M/C CUBAVERA DELF,Talla: XL,73.83,0.00
+__import__.product_template_cuwsp007_100,CUWSP007-100/XL,7448333326344,H. CAMISA M/C CUBAVERA BRIGHT WHITE,Talla: XL,73.83,0.00
+__import__.product_template_cuwsp008_412,CUWSP008-412/L,7448334940983,H. CAMISA M/C CUBAVERA NAVY BLAZER,Talla: L,73.83,0.00
+__import__.product_template_cuwsp008_412,CUWSP008-412/M,7448348521581,H. CAMISA M/C CUBAVERA NAVY BLAZER,Talla: M,73.83,0.00
+__import__.product_template_cuwsp008_412,CUWSP008-412/S,7448333810850,H. CAMISA M/C CUBAVERA NAVY BLAZER,Talla: S,73.83,0.00
+__import__.product_template_cuwsp008_412,CUWSP008-412/XL,7448332034097,H. CAMISA M/C CUBAVERA NAVY BLAZER,Talla: XL,73.83,0.00
+__import__.product_template_cuwsp009_426,CUWSP009-426/L,7448342856832,H. CAMISA M/C CUBAVERA DELF,Talla: L,73.83,0.00
+__import__.product_template_cuwsp009_426,CUWSP009-426/M,7448356164169,H. CAMISA M/C CUBAVERA DELF,Talla: M,73.83,0.00
+__import__.product_template_cuwsp009_426,CUWSP009-426/S,7448344475437,H. CAMISA M/C CUBAVERA DELF,Talla: S,73.83,0.00
+__import__.product_template_cuwsb025_824,CUWSB025-824/S,401040979750,H. CAMISA M/C CUBAVERA CORAL ROSE,Talla: S,81.65,0.00
+__import__.product_template_cuwsb025_824,CUWSB025-824/M,401040979699,H. CAMISA M/C CUBAVERA CORAL ROSE,Talla: M,81.65,0.00
+__import__.product_template_cuwsb025_824,CUWSB025-824/XL,401040979774,H. CAMISA M/C CUBAVERA CORAL ROSE,Talla: XL,81.65,0.00
+__import__.product_template_cuwsb025_824,CUWSB025-824/L,401040979668,H. CAMISA M/C CUBAVERA CORAL ROSE,Talla: L,81.65,0.00
+__import__.product_template_cuwfd002_112,CUWFD002-112/S,401065128300,H. CAMISA M/C CUBAVERA BRILLIANT WHITE,Talla: S,79.91,0.00
+__import__.product_template_cuwfc005_683,CUWFC005-683/L,085142852076,H. CAMISA M/C CUBAVERA CANYON CLAY,Talla: L,78.17,0.00
+__import__.product_template_cuwfc005_683,CUWFC005-683/S,085142852052,H. CAMISA M/C CUBAVERA CANYON CLAY,Talla: S,78.17,0.00
+__import__.product_template_cuwfc005_683,CUWFC005-683/M,085142852069,H. CAMISA M/C CUBAVERA CANYON CLAY,Talla: M,78.17,0.00
+__import__.product_template_cuwfc005_683,CUWFC005-683/XL,085142852083,H. CAMISA M/C CUBAVERA CANYON CLAY,Talla: XL,78.17,0.00
+__import__.product_template_cuwsd064_112,CUWSD064-112/L,401065406118,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE,Talla: L,82.52,0.00
+__import__.product_template_cuwsd064_112,CUWSD064-112/M,401065406149,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE,Talla: M,82.52,0.00
+__import__.product_template_cuwsd064_112,CUWSD064-112/S,401065406200,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE,Talla: S,82.52,0.00
+__import__.product_template_cuwsd066_112,CUWSD066-112/XL,401065404145,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE (cuwsd066_112),Talla: XL,82.52,0.00
+__import__.product_template_cuwsd066_112,CUWSD066-112/S,401065404121,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE (cuwsd066_112),Talla: S,82.52,0.00
+__import__.product_template_cuwsd066_112,CUWSD066-112/M,401065404060,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE (cuwsd066_112),Talla: M,82.52,0.00
+__import__.product_template_cuwsd066_112,CUWSD066-112/L,401065404039,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE (cuwsd066_112),Talla: L,82.52,0.00
+__import__.product_template_cuwsd064_112,CUWSD064-112/XL,401065406224,H. CAMISA CUBAVERA M/C LINO P/CABALLERO BRILLIANT WHITE,Talla: XL,82.52,0.00
+__import__.product_template_pant_lauren,PANT-LAUREN/L,PANT-LAUREN/OL,M. PANTALON P/DAMA NEGRO / BLANCO,Talla: L,86.87,0.00
+__import__.product_template_pant_lauren,PANT-LAUREN/M,PANT-LAUREN/OM,M. PANTALON P/DAMA NEGRO / BLANCO,Talla: M,86.87,0.00
+__import__.product_template_pant_lauren,PANT-LAUREN/S,PANT-LAUREN/OS,M. PANTALON P/DAMA NEGRO / BLANCO,Talla: S,86.87,0.00
+__import__.product_template_ve_maribel,VE-MARIBEL/L,VE-MARIBEL/OL,VESTIDO MARIBEL ROJO-AZUL,Talla: L,115.09,0.00
+__import__.product_template_ve_maribel,VE-MARIBEL/M,VE-MARIBEL/OM,VESTIDO MARIBEL ROJO-AZUL,Talla: M,115.90,0.00
+__import__.product_template_bw4624_641,BW4624/641-7,BW4624/O641-7,Corbata BW4624/641,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_zp_cassini_ps_pt_vn,ZP-CASSINI-PS-PT-VN/7.5,ZPCASSPSPTVN/O7.5,Zapato ZP-CASSINI-PS-PT-VN,Talla: 7.5,152.09,0.00
+__import__.product_template_fd11080_cp27,FD11080-CP27/S,FD11080-CP27/OS,VESTIDO,Talla: S,70.45,0.00
+__import__.product_template_fd11080_cp27,FD11080-CP27/M,FD11080-CP27/OM,VESTIDO,Talla: M,70.45,0.00
+__import__.product_template_fd11080_cp27,FD11080-CP27/L,FD11080-CP27/OL,VESTIDO,Talla: L,70.45,0.00
+__import__.product_template_ft11389_p1335,FT11389-P1335/L,FT11389-P1335/OL,BLUSA,Talla: L,47.74,0.00
+__import__.product_template_ft9708,FT9708/L,FT9708/OL,BLUSA (ft9708),Talla: L,55.57,0.00
+__import__.product_template_ft9708,FT9708/M,FT9708/OM,BLUSA (ft9708),Talla: M,55.57,0.00
+__import__.product_template_ft9708,FT9708/S,FT9708/OS,BLUSA (ft9708),Talla: S,55.57,0.00
+__import__.product_template_ft11389_p1335,FT11389-P1335/S,FT11389-P1335/OS,BLUSA,Talla: S,47.74,0.00
+__import__.product_template_ft11389_p1335,FT11389-P1335/M,FT11389-P1335/OM,BLUSA,Talla: M,47.74,0.00
+__import__.product_template_pt_tl_10_656c,PT-TL-10-656C/50,PT-TL-10-656C/O50,Pantalon PT-TL-10-656C,Talla: 50,47.74,0.00
+__import__.product_template_pt_22c0905_4c,PT-22C0905-4C/40,PT-22C0905-4C/O40,Pantalon PT-22C0905-4C,Talla: 40,47.74,0.00
+__import__.product_template_lv_22c0905_4c,LV-22C0905-4C/58,LV-22C0905-4C/O58,Leva LV-22C0905-4C,Talla: 58,165.13,0.00
+__import__.product_template_t1005b_fuc_sep,T1005B-FUC-SEP/L,T1005B-FUC-SEP/OL,M. CAMISA P/DAMA FUCHSIA,Talla: L,43.39,0.00
+__import__.product_template_zp_pat_co_c_cassini,ZP-PAT-CO-C-CASSINI/7,ZPCASSPACOC/O7,Zapato ZP-PAT-CO-C-CASSINI,Talla: 7,152.09,0.00
+__import__.product_template_t1653,T1653/S,T1653/OS,BLUSA TWIST FRONT SATIN ROJO,Talla: S,55.57,0.00
+__import__.product_template_t1653,T1653/M,T1653/OM,BLUSA TWIST FRONT SATIN ROJO,Talla: M,55.57,0.00
+__import__.product_template_t1653,T1653/L,T1653/OL,BLUSA TWIST FRONT SATIN ROJO,Talla: L,55.57,0.00
+__import__.product_template_t1532,T1532/S,T1532/OS,TOP-BLACK P/DAMAS,Talla: S,49.02,0.00
+__import__.product_template_t1532,T1532/M,T1532/OM,TOP-BLACK P/DAMAS,Talla: M,49.02,0.00
+__import__.product_template_t1532,T1532/L,T1532/OL,TOP-BLACK P/DAMAS,Talla: L,49.02,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/12,ZP-CASSINI-PS-PT-COF/O12,Zapato ZP-CASSINI-PS-PT-COF,Talla: 12,160.78,0.00
+__import__.product_template_pant_renata,PANT-RENATA/L,PANT-RENATA/OL,M. PANTALON P/DAMA BLANCO / NEGRO,Talla: L,66.00,0.00
+__import__.product_template_set_julia,SET-JULIA/S,SET-JULIA/OS,CONJUNTO / VESTIR,Talla: S,117.30,0.00
+__import__.product_template_set_julia,SET-JULIA/M,SET-JULIA/OM,CONJUNTO / VESTIR,Talla: M,117.30,0.00
+__import__.product_template_ve_meli,VE-MELI/M,VE-MELI/OM,VESTIDO (ve_meli),Talla: M,123.13,0.00
+__import__.product_template_pant_renata,PANT-RENATA/S,PANT-RENATA/OS,M. PANTALON P/DAMA BLANCO / NEGRO,Talla: S,66.00,0.00
+__import__.product_template_ve_meli,VE-MELI/S,VE-MELI/OS,VESTIDO (ve_meli),Talla: S,123.13,0.00
+__import__.product_template_set_julia,SET-JULIA/L,SET-JULIA/OL,CONJUNTO / VESTIR,Talla: L,117.30,0.00
+__import__.product_template_ve_milady,VE-MILADY/S,VE-MILADY/OS,VESTIDO (ve_milady),Talla: S,112.41,0.00
+__import__.product_template_ve_juliana,VE-JULIANA/L,VE-JULIANA/OL,VESTIDO (ve_juliana),Talla: L,107.05,0.00
+__import__.product_template_ve_milady,VE-MILADY/M,VE-MILADY/OM,VESTIDO (ve_milady),Talla: M,112.41,0.00
+__import__.product_template_ve_juliana,VE-JULIANA/M,VE-JULIANA/OM,VESTIDO (ve_juliana),Talla: M,107.05,0.00
+__import__.product_template_pant_renata,PANT-RENATA/M,PANT-RENATA/OM,M. PANTALON P/DAMA BLANCO / NEGRO,Talla: M,66.00,0.00
+__import__.product_template_ve_sara,VE-SARA/L,VE-SARA/L,VESTIDO LIMON LILA,Talla: L,147.23,0.00
+__import__.product_template_ve_sara,VE-SARA/M,VE-SARA/M,VESTIDO LIMON LILA,Talla: M,147.23,0.00
+__import__.product_template_ve_sara,VE-SARA/S,VE-SARA/S,VESTIDO LIMON LILA,Talla: S,147.23,0.00
+__import__.product_template_ve_lina,VE-LINA/L,VE-LINA/OL,VESTIDO VERDE-FUCSIA-ESTAMP,Talla: L,146.00,0.00
+__import__.product_template_ve_lina,VE-LINA/M,VE-LINA/OM,VESTIDO VERDE-FUCSIA-ESTAMP,Talla: M,146.00,0.00
+__import__.product_template_ve_lina,VE-LINA/S,VE-LINA/OS,VESTIDO VERDE-FUCSIA-ESTAMP,Talla: S,146.00,0.00
+__import__.product_template_ve_lola,VE-LOLA/L,VE-LOLA/OL,VESTIDO NEGRO-ROSA,Talla: L,125.80,0.00
+__import__.product_template_ve_lola,VE-LOLA/M,VE-LOLA/OM,VESTIDO NEGRO-ROSA,Talla: M,125.80,0.00
+__import__.product_template_ve_lola,VE-LOLA/S,VE-LOLA/OS,VESTIDO NEGRO-ROSA,Talla: S,125.80,0.00
+__import__.product_template_bl_clarisse,BL-CLARISSE/L,BLCLARI/OL,BLUSA NUDE-BLACK-WHITE,Talla: L,43.39,0.00
+__import__.product_template_bl_clarisse,BL-CLARISSE/M,BLCLARI/OM,BLUSA NUDE-BLACK-WHITE,Talla: M,43.39,0.00
+__import__.product_template_bl_clarisse,BL-CLARISSE/S,BLCLARI/OS,BLUSA NUDE-BLACK-WHITE,Talla: S,43.39,0.00
+__import__.product_template_pt_9a700112_3,PT-9A700112-3/40,PT-9A700112-3/O40,Pantalon PT-9A700112-3,Talla: 40,56.43,0.00
+__import__.product_template_zp_gam_vn_s_f_cassini,ZP-GAM-VN-S/F-CASSINI/8.5,ZPGAMVNSFCAS/O8.5,Zapato ZP-GAM-VN-S/F-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_gam_vn_s_f_cassini,ZP-GAM-VN-S/F-CASSINI/8,ZPGAMVNSFCAS/O8,Zapato ZP-GAM-VN-S/F-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_0050_23,#0050/23-7,005020230023701,Corbata #0050/23,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_0050_23,#0050/23-7.5,005020230023705,Corbata #0050/23,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf10294_19,MF10294/19-7.5,MF10294202319705,Corbata MF10294/19,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf10294_19,MF10294/19-7,MF10294202319701,Corbata MF10294/19,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf10294_18,MF10294/18-7,MF10294202318701,Corbata MF10294/18,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf8997_37,MF8997/37-7.5,MF89972023037705,Corbata MF8997/37,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf8997_41,MF8997/41-7.5,MF89972023041705,Corbata MF8997/41,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf10294_18,MF10294/18-7.5,MF10294202318705,Corbata MF10294/18,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw3966_17,BW3966/17-7.5,BW39662023017705,Corbata BW3966/17,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf8997_38,MF8997/38-7,MF89972023038701,Corbata MF8997/38,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf8997_38,MF8997/38-7.5,MF89972023038705,Corbata MF8997/38,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf90005_19,MF90005/19-7,MF90005202319701,Corbata MF90005/19,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf90005_13,MF90005/13-7.5,MF90005202313705,Corbata MF90005/13,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf90005_13,MF90005/13-7,MF90005202313701,Corbata MF90005/13,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf8997_41,MF8997/41-7,MF89972023041701,Corbata MF8997/41,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf90005_19,MF90005/19-7.5,MF90005202319705,Corbata MF90005/19,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf7984_10,MF7984/10-7,MF7984202310701,Corbata MF7984/10,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf90005_20,MF90005/20-7.5,MF90005202320705,Corbata MF90005/20,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf90005_20,MF90005/20-7,MF90005202320701,Corbata MF90005/20,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf8997_37,MF8997/37-7,MF89972023037701,Corbata MF8997/37,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf7984_10,MF7984/10-7.5,MF7984202310705,Corbata MF7984/10,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf7984_9,MF7984/9-7.5,MF7984202309705,Corbata MF7984/9,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf7984_9,MF7984/9-7,MF7984202309701,Corbata MF7984/9,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw3966_17,BW3966/17-7,BW39662023017701,Corbata BW3966/17,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw3966_10,BW3966/10-7.5,BW39662023010705,Corbata BW3966/10,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw3497_18,BW3497/18-7,BW3497202318701,Corbata BW3497/18,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw3966_10,BW3966/10-7,BW39662023010701,Corbata BW3966/10,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw3497_18,BW3497/18-7.5,BW3497202318705,Corbata BW3497/18,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_24,MF3870/24-7.5,MF3870202324705,Corbata MF3870/24,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_29,MF3870/29-7.5,MF3870202329705,Corbata MF3870/29,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_34,MF3870/34-7.5,MF3870202334705,Corbata MF3870/34,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_34,MF3870/34-7,MF3870202334701,Corbata MF3870/34,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_35,MF3870/35-7,MF3870202335701,Corbata MF3870/35,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_35,MF3870/35-7.5,MF3870202335705,Corbata MF3870/35,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_7,MF3870/7-7.5,MF3870202307705,Corbata MF3870/7,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_7,MF3870/7-7,MF3870202307701,Corbata MF3870/7,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_6,MF3870/6-7.5,MF3870202306705,Corbata MF3870/6,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_12,MF3870/12-7,MF3870202312701,Corbata MF3870/12,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_11,MF3870/11-7.5,MF3870202311705,Corbata MF3870/11,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_21,MF3870/21-7,MF3870202321701,Corbata MF3870/21,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_19,MF3870/19-7.5,MF3870202319705,Corbata MF3870/19,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_23,MF3870/23-7,MF3870202323701,Corbata MF3870/23,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_1,MF3870/1-7.5,MF3870202301705,Corbata MF3870/1,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_25,MF3870/25-7,MF3870202325701,Corbata MF3870/25,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_25,MF3870/25-7.5,MF3870202325705,Corbata MF3870/25,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_29,MF3870/29-7,MF3870202329701,Corbata MF3870/29,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_23,MF3870/23-7.5,MF3870202323705,Corbata MF3870/23,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_12,MF3870/12-7.5,MF3870202312705,Corbata MF3870/12,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_24,MF3870/24-7,MF3870202324701,Corbata MF3870/24,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_45,MF3870/45-7.5,MF3870202345705,Corbata MF3870/45,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_65,MF3870/65-7.5,MF3870202365705,Corbata MF3870/65,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_40,MF3870/40-7.5,MF3870202340705,Corbata MF3870/40,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_65,MF3870/65-7,MF3870202365701,Corbata MF3870/65,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_6,MF3870/6-7,MF3870202306701,Corbata MF3870/6,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_5,MF3870/5-7,MF3870202305701,Corbata MF3870/5,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_5,MF3870/5-7.5,MF3870202305705,Corbata MF3870/5,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_38,MF3870/38-7,MF3870202338701,Corbata MF3870/38,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_38,MF3870/38-7.5,MF3870202338705,Corbata MF3870/38,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf3870_40,MF3870/40-7,MF3870202340701,Corbata MF3870/40,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_21,MF3870/21-7.5,MF3870202321705,Corbata MF3870/21,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_k178_14,K178/14-7,K1782023014701,Corbata K178/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_k178_14,K178/14-7.5,K1782023014705,Corbata K178/14,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_k178_16,K178/16-7,K1782023016701,Corbata K178/16,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_k178_16,K178/16-7.5,K1782023016705,Corbata K178/16,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_k178_4,K178/4-7,K1782023004701,Corbata K178/4,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_k178_4,K178/4-7.5,K1782023004705,Corbata K178/4,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_k178_8,K178/8-7,K1782023008701,Corbata K178/8,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_k178_8,K178/8-7.5,K1782023008705,Corbata K178/8,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf8997_11,MF8997/11-7.5,MF8997202311705,Corbata MF8997/11,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_601,S299/601-7,S29920230601701,Corbata S299/601,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_601,S299/601-7.5,S29920230601705,Corbata S299/601,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_642,S299/642-7,S29920230642701,Corbata S299/642,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_642,S299/642-7.5,S29920230642705,Corbata S299/642,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_647,S299/647-7,S29920230647701,Corbata S299/647,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_647,S299/647-7.5,S29920230647705,Corbata S299/647,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_621,S299/621-7,S29920230621701,Corbata S299/621,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_621,S299/621-7.5,S29920230621705,Corbata S299/621,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_626,S299/626-7,S29920230626701,Corbata S299/626,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_626,S299/626-7.5,S29920230626705,Corbata S299/626,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_629,S299/629-7,S29920230629701,Corbata S299/629,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_629,S299/629-7.5,S29920230629705,Corbata S299/629,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_h0145_19,H0145/19-7.5,H01452023019705,Corbata H0145/19,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_603,S299/603-7,S29920230603701,Corbata S299/603,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_603,S299/603-7.5,S29920230603705,Corbata S299/603,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_619,S299/619-7,S29920230619701,Corbata S299/619,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_619,S299/619-7.5,S29920230619705,Corbata S299/619,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_s299_620,S299/620-7,S29920230620701,Corbata S299/620,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_620,S299/620-7.5,S29920230620705,Corbata S299/620,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1338_36,P1338/36-7,P13382023036701,Corbata P1338/36,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1338_36,P1338/36-7.5,P13382023036705,Corbata P1338/36,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_h0145_29,H0145/29-7.5,H01452023029705,Corbata H0145/29,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_h0145_25,H0145/25-7.5,H01452023025705,Corbata H0145/25,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_h0145_25,H0145/25-7,H01452023025701,Corbata H0145/25,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_h0145_29,H0145/29-7,H01452023029701,Corbata H0145/29,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1072_40,P1072/40-7,P10722023040701,Corbata P1072/40,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1072_36,P1072/36-7.5,P10722023036705,Corbata P1072/36,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1072_36,P1072/36-7,P10722023036701,Corbata P1072/36,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1072_35,P1072/35-7.5,P10722023035705,Corbata P1072/35,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1072_35,P1072/35-7,P10722023035701,Corbata P1072/35,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1338_21,P1338/21-7,P13382023021701,Corbata P1338/21,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1338_21,P1338/21-7.5,P13382023021705,Corbata P1338/21,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1072_40,P1072/40-7.5,P10722023040705,Corbata P1072/40,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1072_34,P1072/34-7.5,P10722023034705,Corbata P1072/34,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1072_34,P1072/34-7,P10722023034701,Corbata P1072/34,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_h0145_19,H0145/19-7,H01452023019701,Corbata H0145/19,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_648,BW4624/648-7.5,BW46242023648705,Corbata BW4624/648,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw4624_647,BW4624/647-7.5,BW46242023647705,Corbata BW4624/647,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw4624_618,BW4624/618-7,BW46242023618701,Corbata BW4624/618,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_647,BW4624/647-7,BW46242023647701,Corbata BW4624/647,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_626,BW4624/626-7,BW46242023626701,Corbata BW4624/626,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1661_1,P1661/1-7.5,P16612023001705,Corbata P1661/1,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1661_2,P1661/2-7,P16612023002701,Corbata P1661/2,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1661_2,P1661/2-7.5,P16612023002705,Corbata P1661/2,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw4624_618,BW4624/618-7.5,BW46242023618705,Corbata BW4624/618,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw4624_626,BW4624/626-7.5,BW46242023626705,Corbata BW4624/626,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw4624_641,BW4624/641-7.5,BW46242023641705,Corbata BW4624/641,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_bw4624_64,BW4624/64-7,BW46242023641701,Corbata BW4624/64,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1657_10,P1657/10-7.5,P16572023010705,Corbata P1657/10,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_606,MF-10845/606-7.5,MF1084523606705,Corbata MF-10845/606,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_606,MF-10845/606-7,MF1084523606701,Corbata MF-10845/606,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1661_4,P1661/4-7,P16612023004701,Corbata P1661/4,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1661_6,P1661/6-7.5,P16612023006705,Corbata P1661/6,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1661_6,P1661/6-7,P16612023006701,Corbata P1661/6,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1661_4,P1661/4-7.5,P16612023004705,Corbata P1661/4,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1661_20,P1661/20-7,P16612023020701,Corbata P1661/20,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1661_20,P1661/20-7.5,P16612023020705,Corbata P1661/20,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1657_10,P1657/10-7,P16572023010701,Corbata P1657/10,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_620,MF-10845/620-7,MF1084523620701,Corbata MF-10845/620,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_614,MF-10845/614-7.5,MF1084523614705,Corbata MF-10845/614,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_614,MF-10845/614-7,MF1084523614701,Corbata MF-10845/614,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_609,MF-10845/609-7.5,MF1084523609705,Corbata MF-10845/609,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_609,MF-10845/609-7,MF1084523609701,Corbata MF-10845/609,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_608,MF-10845/608-7.5,MF1084523608705,Corbata MF-10845/608,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_608,MF-10845/608-7,MF1084523608701,Corbata MF-10845/608,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1661_1,P1661/1-7,P16612023001701,Corbata P1661/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_634,MF-10845/634-7.5,MF1084523634705,Corbata MF-10845/634,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_634,MF-10845/634-7,MF1084523634701,Corbata MF-10845/634,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_620,MF-10845/620-7.5,MF1084523620705,Corbata MF-10845/620,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1650_3,P1650/3-7,P16502023003701,Corbata P1650/3,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1650_3,P1650/3-7.5,P16502023003705,Corbata P1650/3,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_642,MF-10845/642-7,MF1084523642701,Corbata MF-10845/642,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_641,MF-10845/641-7,MF1084523641701,Corbata MF-10845/641,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_641,MF-10845/641-7.5,MF1084523641705,Corbata MF-10845/641,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_642,MF-10845/642-7.5,MF1084523642705,Corbata MF-10845/642,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1650_1,P1650/1-7.5,P16502023001705,Corbata P1650/1,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1650_1,P1650/1-7,P16502023001701,Corbata P1650/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_648,BW4624/648-7,BW46242023648701,Corbata BW4624/648,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1657_8,P1657/8-7.5,P16572023008705,Corbata P1657/8,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_14,P1666/P1662/14-7,P16662023014701,Corbata P1666/P1662/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_79,P897/79-7.5,P89720230079705,Corbata P897/79,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p897_82,P897/82-7,P89720230082701,Corbata P897/82,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1666_p1662_13,P1666/P1662/13-7,P16662023013701,Corbata P1666/P1662/13,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_81,P897/81-7.5,P89720230081705,Corbata P897/81,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_30,P1666/P1662/30-7.5,P16662023030705,Corbata P1666/P1662/30,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_4,P1666/P1662/4-7,P16662023004701,Corbata P1666/P1662/4,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_82,P897/82-7.5,P89720230082705,Corbata P897/82,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_6,P1666/P1662/6-7,P16662023006701,Corbata P1666/P1662/6,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1666_p1662_2,P1666/P1662/2-7,P16662023002701,Corbata P1666/P1662/2,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1666_p1662_2,P1666/P1662/2-7.5,P16662023002705,Corbata P1666/P1662/2,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_30,P1666/P1662/30-7,P16662023030701,Corbata P1666/P1662/30,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1657_20,P1657/20-7.5,P16572023020705,Corbata P1657/20,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1657_3,P1657/3-7,P16572023003701,Corbata P1657/3,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1657_20,P1657/20-7,P16572023020701,Corbata P1657/20,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1657_6,P1657/6-7,P16572023006701,Corbata P1657/6,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1666_p1662_6,P1666/P1662/6-7.5,P16662023006705,Corbata P1666/P1662/6,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1657_3,P1657/3-7.5,P16572023003705,Corbata P1657/3,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_13,P1666/P1662/13-7.5,P16662023013705,Corbata P1666/P1662/13,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1657_6,P1657/6-7.5,P16572023006705,Corbata P1657/6,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_14,P1666/P1662/14-7.5,P16662023014705,Corbata P1666/P1662/14,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_18,P1666/P1662/18-7.5,P16662023018705,Corbata P1666/P1662/18,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_18,P1666/P1662/18-7,P16662023018701,Corbata P1666/P1662/18,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_77,P897/77-7.5,P89720230077705,Corbata P897/77,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_647,MF-10845/647-7.5,MF1084523647705,Corbata MF-10845/647,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_647,MF-10845/647-7,MF1084523647701,Corbata MF-10845/647,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_646,MF-10845/646-7.5,MF1084523646705,Corbata MF-10845/646,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_646,MF-10845/646-7,MF1084523646701,Corbata MF-10845/646,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_645,MF-10845/645-7.5,MF1084523645705,Corbata MF-10845/645,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_645,MF-10845/645-7,MF1084523645701,Corbata MF-10845/645,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1657_8,P1657/8-7,P16572023008701,Corbata P1657/8,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_632,MF-10845/632-7.5,MF1084523632705,Corbata MF-10845/632,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_632,MF-10845/632-7,MF1084523632701,Corbata MF-10845/632,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_621,MF-10845/621-7.5,MF1084523621705,Corbata MF-10845/621,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_621,MF-10845/621-7,MF1084523621701,Corbata MF-10845/621,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf_10845_638,MF-10845/638-7.5,MF1084523638705,Corbata MF-10845/638,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_mf_10845_638,MF-10845/638-7,MF1084523638701,Corbata MF-10845/638,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_65,P897/65-7,P89720230065701,Corbata P897/65,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_81,P897/81-7,P89720230081701,Corbata P897/81,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_79,P897/79-7,P89720230079701,Corbata P897/79,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_77,P897/77-7,P89720230077701,Corbata P897/77,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_65,P897/65-7.5,P89720230065705,Corbata P897/65,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_p1666_p1662_4,P1666/P1662/4-7.5,P16662023004705,Corbata P1666/P1662/4,Ancho Corbata: 7.5 cm,21.65,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/10,ZPCASCHAROLINA/O10,Zapato ZP-CASSSINI-CHAROLINA,Talla: 10,152.09,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/9.5,ZPCASCHAROLINA/O9.5,Zapato ZP-CASSSINI-CHAROLINA,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/9,ZPCASCHAROLINA/O9,Zapato ZP-CASSSINI-CHAROLINA,Talla: 9,152.09,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/8.5,ZPCASCHAROLINA/O8.5,Zapato ZP-CASSSINI-CHAROLINA,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/8,ZPCASCAROLINA/O8,Zapato ZP-CASSSINI-CHAROLINA,Talla: 8,152.09,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/7.5,ZPCASCHAROLINA/O7.5,Zapato ZP-CASSSINI-CHAROLINA,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_casssini_charolina,ZP-CASSSINI-CHAROLINA/7,ZPCASCHAROLINA/O7,Zapato ZP-CASSSINI-CHAROLINA,Talla: 7,152.09,0.00
+__import__.product_template_ar,AR-15,AR-15,ARETES P/DAMA V. MODELOS,Talla: 15,17.30,0.00
+__import__.product_template_bl_ariana_est,BL-ARIANA EST/S,BLARIAE/S,BLUSA ARIANA EST AZUL T. S-M-L,Talla: S,59.04,0.00
+__import__.product_template_bl_ariana_est,BL-ARIANA EST/M,BLARIAE/M,BLUSA ARIANA EST AZUL T. S-M-L,Talla: M,59.04,0.00
+__import__.product_template_bl_ariana_est,BL-ARIANA EST/L,BLARIAE/L,BLUSA ARIANA EST AZUL T. S-M-L,Talla: L,59.04,0.00
+__import__.product_template_pt_tahiri,PT-TAHIRI/S,PTTAHI/S,PANTALON TAHIRI LILA T.S-M,Talla: S,79.38,0.00
+__import__.product_template_pt_tahiri,PT-TAHIRI/M,TP-TAHI/M,PANTALON TAHIRI LILA T.S-M,Talla: M,79.38,0.00
+__import__.product_template_tp_alma,TP-ALMA/M,TP-ALMA/OM,TOP ALMA LILA T.S-M,Talla: M,52.97,0.00
+__import__.product_template_tp_alma,TP-ALMA/S,TPALMA/S,TOP ALMA LILA T.S-M,Talla: S,52.96,0.00
+__import__.product_template_ve_isabela,VE-ISABELA/S,VEISABE/S,VESTIDO ISABELA CELESTE T S MOSTAZA ROSA T.M,Talla: S,133.84,0.00
+__import__.product_template_ve_isabela,VE-ISABELA/M,VEISABE/M,VESTIDO ISABELA CELESTE T S MOSTAZA ROSA T.M,Talla: M,133.84,0.00
+__import__.product_template_ve_grazzia_uni,VE-GRAZZIA UNI/L,VEGRAZIU/OL,VESTIDO GRAZZIA UNICOLOR VERDE T. S-M-L,Talla: L,108.84,0.00
+__import__.product_template_ve_grazzia_uni,VE-GRAZZIA UNI/M,VEGRAZIU/OM,VESTIDO GRAZZIA UNICOLOR VERDE T. S-M-L,Talla: M,108.84,0.00
+__import__.product_template_ve_grazzia_uni,VE-GRAZZIA UNI/S,VEGRAZU/OS,VESTIDO GRAZZIA UNICOLOR VERDE T. S-M-L,Talla: S,133.84,0.00
+__import__.product_template_ve_silvana,VE-SILVANA/S,VESILVA/OS,VESTIDO SILVANA PISTACHO T S. MAGENTA T M,Talla: S,131.16,0.00
+__import__.product_template_ve_silvana,VE-SILVANA/M,VESILVA/OM,VESTIDO SILVANA PISTACHO T S. MAGENTA T M,Talla: M,131.16,0.00
+__import__.product_template_ve_dalila,VE-DALILA/S,VEDALILA/OS,VESTIDO DALILA FUCSIA T.S-M-L,Talla: S,107.05,0.00
+__import__.product_template_ve_dalila,VE-DALILA/M,VEDALILA/OM,VESTIDO DALILA FUCSIA T.S-M-L,Talla: M,107.05,0.00
+__import__.product_template_ve_dalila,VE-DALILA/L,VEDALILA/OL,VESTIDO DALILA FUCSIA T.S-M-L,Talla: L,107.05,0.00
+__import__.product_template_set_charlotte,SET-CHARLOTTE/S,SETCHAR/OS,"SET CHARLOTTE, VERDE T.S",Talla: S,108.61,0.00
+__import__.product_template_pt_10036a_18_498,PT-10036A-18-498/40,10036A18149840,Pantalon PT-10036A-18-498,Talla: 40,47.74,0.00
+__import__.product_template_pt_10036a_18_498,PT-10036A-18-498/38,10036A18149838,Pantalon PT-10036A-18-498,Talla: 38,47.74,0.00
+__import__.product_template_pt_10036a_18_498,PT-10036A-18-498/36,10036A18149836,Pantalon PT-10036A-18-498,Talla: 36,47.74,0.00
+__import__.product_template_pt_10036a_18_498,PT-10036A-18-498/34,10036A18149834,Pantalon PT-10036A-18-498,Talla: 34,47.74,0.00
+__import__.product_template_pt_10036a_18_498,PT-10036A-18-498/32,10036A18149832,Pantalon PT-10036A-18-498,Talla: 32,47.74,0.00
+__import__.product_template_pt_10036a_18_498,PT-10036A-18-498/30,10036A18149830,Pantalon PT-10036A-18-498,Talla: 30,47.74,0.00
+__import__.product_template_pt_17001_5,PT-17001-5/40,17001520230440,Pantalon PT-17001-5,Talla: 40,47.74,0.00
+__import__.product_template_pt_17001_5,PT-17001-5/38,17001520230438,Pantalon PT-17001-5,Talla: 38,47.74,0.00
+__import__.product_template_pt_17001_5,PT-17001-5/36,17001520230436,Pantalon PT-17001-5,Talla: 36,47.74,0.00
+__import__.product_template_pt_17001_5,PT-17001-5/34,17001520230434,Pantalon PT-17001-5,Talla: 34,47.74,0.00
+__import__.product_template_pt_17001_5,PT-17001-5/32,17001520230432,Pantalon PT-17001-5,Talla: 32,47.74,0.00
+__import__.product_template_pt_17001_5,PT-17001-5/30,17001520230430,Pantalon PT-17001-5,Talla: 30,47.74,0.00
+__import__.product_template_pt_10036a_18_217b,PT-10036A-18-217B/40,10036A18217B40,Pantalon PT-10036A-18-217B,Talla: 40,47.74,0.00
+__import__.product_template_pt_10036a_18_217b,PT-10036A-18-217B/38,10036A18217B38,Pantalon PT-10036A-18-217B,Talla: 38,47.74,0.00
+__import__.product_template_pt_10036a_18_217b,PT-10036A-18-217B/36,10036A18217B36,Pantalon PT-10036A-18-217B,Talla: 36,47.74,0.00
+__import__.product_template_pt_10036a_18_217b,PT-10036A-18-217B/34,10036A18217B34,Pantalon PT-10036A-18-217B,Talla: 34,47.74,0.00
+__import__.product_template_pt_10036a_18_217b,PT-10036A-18-217B/32,10036A18217B32,Pantalon PT-10036A-18-217B,Talla: 32,47.74,0.00
+__import__.product_template_pt_10036a_18_217b,PT-10036A-18-217B/30,10036A18217B30,Pantalon PT-10036A-18-217B,Talla: 30,47.74,0.00
+__import__.product_template_fl_mediterraneo,FL-MEDITERRANEO/XL,FL-MEDITERRANEO/OXL,FALDA P/DAMA MEDITERRENO,Talla: XL,77.59,0.00
+__import__.product_template_fl_mediterraneo,FL-MEDITERRANEO/L,FL-MEDITERRANEO/OL,FALDA P/DAMA MEDITERRENO,Talla: L,77.59,0.00
+__import__.product_template_zp_gam_ne_s_f_cassini,ZP-GAM-NE-S/F-CASSINI/7.5,ZPGAMNEGSFCAS/OO7.5,Zapato ZP-GAM-NE-S/F-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_gam_ne_s_f_cassini,ZP-GAM-NE-S/F-CASSINI/7,ZPGAMNEGSFCAS/OO7,Zapato ZP-GAM-NE-S/F-CASSINI,Talla: 7,152.09,0.00
+__import__.product_template_zp_gam_ne_s_f_cassini,ZP-GAM-NE-S/F-CASSINI/8,ZPGAMNEGSFCAS/OO8,Zapato ZP-GAM-NE-S/F-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_gam_ne_s_f_cassini,ZP-GAM-NE-S/F-CASSINI/8.5,ZPGAMNEGSFCAS/O8.5,Zapato ZP-GAM-NE-S/F-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_gam_az_s_f_cassini,ZP-GAM-AZ-S/F-CASSINI/8.5,ZPGAMAZSFCAS/OO8.5,Zapato ZP-GAM-AZ-S/F-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_gam_az_s_f_cassini,ZP-GAM-AZ-S/F-CASSINI/8,ZPGAMAZSFCAS/OO8,Zapato ZP-GAM-AZ-S/F-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_gam_az_s_f_cassini,ZP-GAM-AZ-S/F-CASSINI/7,ZPGAMAZSFCAS/OO7,Zapato ZP-GAM-AZ-S/F-CASSINI,Talla: 7,152.09,0.00
+__import__.product_template_zp_gam_ml_s_f_cassini,ZP-GAM-ML-S/F-CASSINI/8,ZPGAMMLSFCAS/OO8,Zapato ZP-GAM-ML-S/F-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_gam_ml_s_f_cassini,ZP-GAM-ML-S/F-CASSINI/7,ZPGAMMLSFCAS/OO7,Zapato ZP-GAM-ML-S/F-CASSINI,Talla: 7,152.09,0.00
+__import__.product_template_zp_gam_ml_s_f_cassini,ZP-GAM-ML-S/F-CASSINI/7.5,ZPGAMMLSFCAS/OO7.5,Zapato ZP-GAM-ML-S/F-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_gam_vn_s_f_cassini,ZP-GAM-VN-S/F-CASSINI/7.5,ZPGAMVNSFCAS/O7.5,Zapato ZP-GAM-VN-S/F-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_gam_cof_s_f_cassini,ZP-GAM-COF-S/F-CASSINI/7.5,ZPGAMCOFSFCAS/OO7.5,Zapato ZP-GAM-COF-S/F-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_gam_cof_s_f_cassini,ZP-GAM-COF-S/F-CASSINI/8,ZPGAMCOFSFCAS/OO8,Zapato ZP-GAM-COF-S/F-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_gam_az_s_f_cassini,ZP-GAM-AZ-S/F-CASSINI/7.5,ZPGAMAZSFCAS/OO7.5,Zapato ZP-GAM-AZ-S/F-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/7,ZPCASSPSPTCOF/O7,Zapato ZP-CASSINI-PS-PT-COF,Talla: 7,152.09,0.00
+__import__.product_template_zp_loafer_h,ZP-LOAFER-H/7.5,ZP-LOAFER-H/O7.5,Zapato ZP-LOAFER-H,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_loafer_h,ZP-LOAFER-H/8,ZP-LOAFER-H/O8,Zapato ZP-LOAFER-H,Talla: 8,152.09,0.00
+__import__.product_template_zp_loafer_h,ZP-LOAFER-H/8.5,ZP-LOAFER-H/O8.5,Zapato ZP-LOAFER-H,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_loafer_h,ZP-LOAFER-H/9,ZP-LOAFER-H/O9,Zapato ZP-LOAFER-H,Talla: 9,152.09,0.00
+__import__.product_template_zp_loafer_h,ZP-LOAFER-H/9.5,ZP-LOAFER-H/O9.5,Zapato ZP-LOAFER-H,Talla: 9.5,152.09,0.00
+__import__.product_template_23241_fuc,23241-FUC/L,23241-FUC/OL,M. BLUSA P/DAMA FUCSIA,Talla: L,56.43,0.00
+__import__.product_template_23241_fuc,23241-FUC/M,23241-FUC/OM,M. BLUSA P/DAMA FUCSIA,Talla: M,56.43,0.00
+__import__.product_template_23241_fuc,23241-FUC/S,23241-FUC/OS,M. BLUSA P/DAMA FUCSIA,Talla: S,56.43,0.00
+__import__.product_template_fd11046_sg,FD11046-SG/S,FD11046-SG/OS,M. VESTIDO P/DAMA SUMMER GREEN,Talla: S,85.63,0.00
+__import__.product_template_fd11046_sg,FD11046-SG/M,FD11046-SG/OM,M. VESTIDO P/DAMA SUMMER GREEN,Talla: M,85.63,0.00
+__import__.product_template_fd11046_sg,FD11046-SG/L,FD11046-SG/OL,M. VESTIDO P/DAMA SUMMER GREEN,Talla: L,85.63,0.00
+__import__.product_template_r738_bg,R738-BG/M,R738-BG/OM,M. PANTALON SUBLIME P/DAMA BEIGE,Talla: M,53.48,0.00
+__import__.product_template_r738_bg,R738-BG/L,R738-BG/OL,M. PANTALON SUBLIME P/DAMA BEIGE,Talla: L,53.48,0.00
+__import__.product_template_r738_bg,R738-BG/S,R738-BG/OS,M. PANTALON SUBLIME P/DAMA BEIGE,Talla: S,53.48,0.00
+__import__.product_template_zp_gam_az_cassini,ZP-GAM-AZ-CASSINI/7.5,ZPGAMAZCAS/O7.5,Zapato ZP-GAM-AZ-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_gam_cof_cassini,ZP-GAM-COF-CASSINI/8.5,ZPGAMCOFCAS/O8.5,Zapato ZP-GAM-COF-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_gam_cof_cassini,ZP-GAM-COF-CASSINI/9.5,ZPGAMCOFCAS/O9.5,Zapato ZP-GAM-COF-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_gam_cof_cassini,ZP-GAM-COF-CASSINI/9,ZPGAMCOFCAS/O9,Zapato ZP-GAM-COF-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_gam_cof_cassini,ZP-GAM-COF-CASSINI/8,ZPGAMCOFCAS/O8,Zapato ZP-GAM-COF-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_gam_cof_cassini,ZP-GAM-COF-CASSINI/7.5,ZPGAMCOFCAS/O7.5,Zapato ZP-GAM-COF-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_sp_wht_ba,SP-WHT-BA/10,SP-WHT-BA/O10,Terno SP-WHT-BA,Talla: 10,47.74,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/7,ZPCASSPSPTBRW/O7,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 7,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/7,ZPCASSPSPTBLK/O7,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 7,152.09,0.00
+__import__.product_template_cuwsd016_555,CUWSD016-555/M,051054298080,H. CAMISA M/C CUBAVERA RED VIOLET,Talla: M,88.61,0.00
+__import__.product_template_cuwsd016_555,CUWSD016-555/S,051054298073,H. CAMISA M/C CUBAVERA RED VIOLET,Talla: S,88.61,0.00
+__import__.product_template_cuwsd016_555,CUWSD016-555/L,051054298097,H. CAMISA M/C CUBAVERA RED VIOLET,Talla: L,88.61,0.00
+__import__.product_template_cuksd041_494,CUKSD041-494/XL,713610170406,H. POLO P/HOMBRE M/C CRYSTAL BLUE CUBAVERA,Talla: XL,56.43,0.00
+__import__.product_template_cuwfa034_022,CUWFA034-022/S,84971407419,H. CAMISA P/HOMBRE M/C JET BLACK CUBAVERA,Talla: S,72.09,0.00
+__import__.product_template_cuwfa034_022,CUWFA034-022/L,84971407433,H. CAMISA P/HOMBRE M/C JET BLACK CUBAVERA,Talla: L,72.09,0.00
+__import__.product_template_cuwfa034_022,CUWFA034-022/XL,84971407440,H. CAMISA P/HOMBRE M/C JET BLACK CUBAVERA,Talla: XL,72.09,0.00
+__import__.product_template_cuwfa034_022,CUWFA034-022/M,84971407426,H. CAMISA P/HOMBRE M/C JET BLACK CUBAVERA,Talla: M,72.09,0.00
+__import__.product_template_cuksd041_494,CUKSD041-494/M,713610170383,H. POLO P/HOMBRE M/C CRYSTAL BLUE CUBAVERA,Talla: M,56.43,0.00
+__import__.product_template_cuksd041_494,CUKSD041-494/S,713610170376,H. POLO P/HOMBRE M/C CRYSTAL BLUE CUBAVERA,Talla: S,56.43,0.00
+__import__.product_template_cuwf2105_bw_b,CUWF2105-BW-B/L,7448338059018,H. CAMISA P/HOMBRE M/C BRIGHT WHITE CUBAVERA,Talla: L,97.30,0.00
+__import__.product_template_cuwf2105_bw_b,CUWF2105-BW-B/M,7448336837816,H. CAMISA P/HOMBRE M/C BRIGHT WHITE CUBAVERA,Talla: M,97.30,0.00
+__import__.product_template_cuwf2105_bw_b,CUWF2105-BW-B/S,7448335874812,H. CAMISA P/HOMBRE M/C BRIGHT WHITE CUBAVERA,Talla: S,97.30,0.00
+__import__.product_template_cuksd041_494,CUKSD041-494/L,713610170390,H. POLO P/HOMBRE M/C CRYSTAL BLUE CUBAVERA,Talla: L,56.43,0.00
+__import__.product_template_cuwf2105_bw_b,CUWF2105-BW-B/XL,7448331826839,H. CAMISA P/HOMBRE M/C BRIGHT WHITE CUBAVERA,Talla: XL,97.30,0.00
+__import__.product_template_cuwsd016_555,CUWSD016-555/XL,051054298103,H. CAMISA M/C CUBAVERA RED VIOLET,Talla: XL,88.61,0.00
+__import__.product_template_opksb005_786,OPKSB005-786/S,799016206338,H. POLO P/HOMBRE M/C PENGUIN GREEN SHEEN,Talla: S,53.83,0.00
+__import__.product_template_opksb005_786,OPKSB005-786/XL,799016206345,H. POLO P/HOMBRE M/C PENGUIN GREEN SHEEN,Talla: XL,53.83,0.00
+__import__.product_template_opksb005_786,OPKSB005-786/L,799016206314,H. POLO P/HOMBRE M/C PENGUIN GREEN SHEEN,Talla: L,53.83,0.00
+__import__.product_template_opksb005_786,OPKSB005-786/M,799016206321,H. POLO P/HOMBRE M/C PENGUIN GREEN SHEEN,Talla: M,53.83,0.00
+__import__.product_template_tl_x03_226_a,TL-X03-226.A/M,7453040780594,H. CAMISA M/L NAVY TED LAPIDUS,Talla: M,39.91,0.00
+__import__.product_template_tl_x03_226_a,TL-X03-226.A/S,7453040780587,H. CAMISA M/L NAVY TED LAPIDUS,Talla: S,39.91,0.00
+__import__.product_template_tl_x03_214b_a,TL-X03-214B.A/L,7453040780365,H. CAMISA M/L LT. DENIM TED LAPIDUS,Talla: L,39.91,0.00
+__import__.product_template_tl_x03_214b_a,TL-X03-214B.A/M,7453040780358,H. CAMISA M/L LT. DENIM TED LAPIDUS,Talla: M,39.91,0.00
+__import__.product_template_tl_x03_214b_a,TL-X03-214B.A/S,7453040780341,H. CAMISA M/L LT. DENIM TED LAPIDUS,Talla: S,39.91,0.00
+__import__.product_template_tl_x03_214b_a,TL-X03-214B.A/XL,7453040780372,H. CAMISA M/L LT. DENIM TED LAPIDUS,Talla: XL,39.91,0.00
+__import__.product_template_tl_x03_222_a,TL-X03-222.A/L,7453040780488,H. CAMISA M/L MULTICOLOR TED LAPIDUS,Talla: L,39.91,0.00
+__import__.product_template_tl_x03_222_a,TL-X03-222.A/M,7453040780471,H. CAMISA M/L MULTICOLOR TED LAPIDUS,Talla: M,39.91,0.00
+__import__.product_template_tl_x03_226_a,TL-X03-226.A/XL,7453040780617,H. CAMISA M/L NAVY TED LAPIDUS,Talla: XL,39.91,0.00
+__import__.product_template_tl_20_500c,TL-20-500C/40,7453040450442,Terno TL-20-500C,Talla: 40,43.39,0.00
+__import__.product_template_tl_x25_501b_a,TL-X25-501B.A/30,7453040772544,Terno TL-X25-501B.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_x25_501b_a,TL-X25-501B.A/32,7453040772551,Terno TL-X25-501B.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_501b_a,TL-X25-501B.A/34,7453040772568,Terno TL-X25-501B.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_501b_a,TL-X25-501B.A/36,7453040772575,Terno TL-X25-501B.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_501b_a,TL-X25-501B.A/38,7453040772582,Terno TL-X25-501B.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_501d_a,TL-X25-501D.A/30,7453040771486,Terno TL-X25-501D.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_x25_501d_a,TL-X25-501D.A/32,7453040771493,Terno TL-X25-501D.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_501d_a,TL-X25-501D.A/34,7453040771509,Terno TL-X25-501D.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_501d_a,TL-X25-501D.A/36,7453040771516,Terno TL-X25-501D.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_501d_a,TL-X25-501D.A/38,7453040771523,Terno TL-X25-501D.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_501d_a,TL-X25-501D.A/40,7453040771530,Terno TL-X25-501D.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_x03_214a_a,TL-X03-214A.A/L,7453040780280,H. CAMISA M/L DK. DENIM TED LAPIDUS,Talla: L,39.91,0.00
+__import__.product_template_tl_x03_214a_a,TL-X03-214A.A/M,7453040780273,H. CAMISA M/L DK. DENIM TED LAPIDUS,Talla: M,39.91,0.00
+__import__.product_template_tl_x03_214a_a,TL-X03-214A.A/S,TL-X03-214A.A/S,H. CAMISA M/L DK. DENIM TED LAPIDUS,Talla: S,39.91,0.00
+__import__.product_template_tl_x03_214a_a,TL-X03-214A.A/XL,7453040780297,H. CAMISA M/L DK. DENIM TED LAPIDUS,Talla: XL,39.91,0.00
+__import__.product_template_tl_x25_501b_a,TL-X25-501B.A/40,7453040772599,Terno TL-X25-501B.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_x25_501c_a,TL-X25-501C.A/30,7453040771387,Terno TL-X25-501C.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_x25_501c_a,TL-X25-501C.A/32,7453040771394,Terno TL-X25-501C.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_501c_a,TL-X25-501C.A/34,7453040771400,Terno TL-X25-501C.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_501c_a,TL-X25-501C.A/36,7453040771417,Terno TL-X25-501C.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_501c_a,TL-X25-501C.A/38,7453040771424,Terno TL-X25-501C.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_501c_a,TL-X25-501C.A/40,7453040771431,Terno TL-X25-501C.A,Talla: 40,34.70,0.00
+__import__.product_template_opwb1101_670,OPWB1101-670/L,7448336230273,H. CAMISA POPLIN M/L P/HOMBRE PENGUIN VEILED ROSE,Talla: L,79.04,0.00
+__import__.product_template_opwb1101_670,OPWB1101-670/XL,7448330770713,H. CAMISA POPLIN M/L P/HOMBRE PENGUIN VEILED ROSE,Talla: XL,79.04,0.00
+__import__.product_template_opwb1101_670,OPWB1101-670/M,7448332935943,H. CAMISA POPLIN M/L P/HOMBRE PENGUIN VEILED ROSE,Talla: M,79.04,0.00
+__import__.product_template_opwb1101_670,OPWB1101-670/S,7448341864845,H. CAMISA POPLIN M/L P/HOMBRE PENGUIN VEILED ROSE,Talla: S,79.04,0.00
+__import__.product_template_tl_x25_501g_a,TL-X25-501G.A/34,7453040771769,Terno TL-X25-501G.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_x25_501g_a,TL-X25-501G.A/36,7453040771776,Terno TL-X25-501G.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_x25_501g_a,TL-X25-501G.A/38,7453040771783,Terno TL-X25-501G.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_x25_501g_a,TL-X25-501G.A/40,7453040771790,Terno TL-X25-501G.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_x25_501g_a,TL-X25-501G.A/32,7453040771752,Terno TL-X25-501G.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_x25_501g_a,TL-X25-501G.A/30,7453040771745,Terno TL-X25-501G.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_20_500c,TL-20-500C/38,7453040450336,Terno TL-20-500C,Talla: 38,43.39,0.00
+__import__.product_template_tl_x03_222_a,TL-X03-222.A/S,7453040780464,H. CAMISA M/L MULTICOLOR TED LAPIDUS,Talla: S,39.91,0.00
+__import__.product_template_tl_x03_222_a,TL-X03-222.A/XL,7453040780495,H. CAMISA M/L MULTICOLOR TED LAPIDUS,Talla: XL,39.91,0.00
+__import__.product_template_tl_x03_226_a,TL-X03-226.A/L,7453040780600,H. CAMISA M/L NAVY TED LAPIDUS,Talla: L,39.91,0.00
+__import__.product_template_tl_20_500c,TL-20-500C/34,7453040450114,Terno TL-20-500C,Talla: 34,43.39,0.00
+__import__.product_template_tl_20_500c,TL-20-500C/32,7453040450008,Terno TL-20-500C,Talla: 32,43.39,0.00
+__import__.product_template_tl_20_500c,TL-20-500C/30,7453040449897,Terno TL-20-500C,Talla: 30,43.39,0.00
+__import__.product_template_tl_20_500b,TL-20-500B/40,7453040743704,Terno TL-20-500B,Talla: 40,43.39,0.00
+__import__.product_template_tl_20_500b,TL-20-500B/38,7453040743698,Terno TL-20-500B,Talla: 38,43.39,0.00
+__import__.product_template_tl_20_500b,TL-20-500B/36,7453040743681,Terno TL-20-500B,Talla: 36,43.39,0.00
+__import__.product_template_tl_20_500a,TL-20-500A/38,7453040743636,Terno TL-20-500A,Talla: 38,43.39,0.00
+__import__.product_template_tl_20_500b,TL-20-500B/34,7453040743674,Terno TL-20-500B,Talla: 34,43.39,0.00
+__import__.product_template_tl_20_500b,TL-20-500B/32,7453040743667,Terno TL-20-500B,Talla: 32,43.39,0.00
+__import__.product_template_tl_20_500b,TL-20-500B/30,7453040743650,Terno TL-20-500B,Talla: 30,43.39,0.00
+__import__.product_template_tl_20_500a,TL-20-500A/40,7453040743643,Terno TL-20-500A,Talla: 40,43.39,0.00
+__import__.product_template_tl_20_500a,TL-20-500A/30,7453040743599,Terno TL-20-500A,Talla: 30,43.39,0.00
+__import__.product_template_tl_20_500a,TL-20-500A/32,7453040743605,Terno TL-20-500A,Talla: 32,43.39,0.00
+__import__.product_template_tl_20_500a,TL-20-500A/34,7453040743612,Terno TL-20-500A,Talla: 34,43.39,0.00
+__import__.product_template_tl_20_500a,TL-20-500A/36,7453040743629,Terno TL-20-500A,Talla: 36,43.39,0.00
+__import__.product_template_pt_008_bg_black,PT-008-BG-BLACK/42,008BBG120220642,Pantalon PT-008-BG-BLACK,Talla: 42,56.43,0.00
+__import__.product_template_18102_449,18102-449/46,1810244920230346,Leva 18102-449,Talla: 46,165.13,0.00
+__import__.product_template_18102_449,18102-449/48,1810244920230348,Leva 18102-449,Talla: 48,165.13,0.00
+__import__.product_template_18102_449,18102-449/50,1810244920230350,Leva 18102-449,Talla: 50,165.13,0.00
+__import__.product_template_18102_449,18102-449/52,1810244920230352,Leva 18102-449,Talla: 52,165.13,0.00
+__import__.product_template_18102_449,18102-449/54,1810244920230354,Leva 18102-449,Talla: 54,165.13,0.00
+__import__.product_template_18102_449,18102-449/56,1810244920230356,Leva 18102-449,Talla: 56,165.13,0.00
+__import__.product_template_18102_449,18102-449/58,1810244920230358,Leva 18102-449,Talla: 58,165.13,0.00
+__import__.product_template_18102_449,18102-449/60,1810244920230360,Leva 18102-449,Talla: 60,165.13,0.00
+__import__.product_template_1611_10,1611-10/46,16111020230346,Leva 1611-10,Talla: 46,165.13,0.00
+__import__.product_template_1611_10,1611-10/48,16111020230348,Leva 1611-10,Talla: 48,165.13,0.00
+__import__.product_template_1611_10,1611-10/50,16111020230350,Leva 1611-10,Talla: 50,165.13,0.00
+__import__.product_template_1611_10,1611-10/52,16111020230352,Leva 1611-10,Talla: 52,165.13,0.00
+__import__.product_template_1611_10,1611-10/54,16111020230354,Leva 1611-10,Talla: 54,165.13,0.00
+__import__.product_template_1611_10,1611-10/56,16111020230356,Leva 1611-10,Talla: 56,165.13,0.00
+__import__.product_template_1611_10,1611-10/58,16111020230358,Leva 1611-10,Talla: 58,165.13,0.00
+__import__.product_template_1611_10,1611-10/60,16111020230360,Leva 1611-10,Talla: 60,165.13,0.00
+__import__.product_template_1611_11,1611-11/60,16111120230360,Leva 1611-11,Talla: 60,165.13,0.00
+__import__.product_template_1611_9,1611-9/52,1611920230352,Leva 1611-9,Talla: 52,165.13,0.00
+__import__.product_template_1611_9,1611-9/54,1611920230354,Leva 1611-9,Talla: 54,165.13,0.00
+__import__.product_template_1611_9,1611-9/56,1611920230356,Leva 1611-9,Talla: 56,165.13,0.00
+__import__.product_template_1611_9,1611-9/58,1611920230358,Leva 1611-9,Talla: 58,165.13,0.00
+__import__.product_template_1611_9,1611-9/60,1611920230360,Leva 1611-9,Talla: 60,165.13,0.00
+__import__.product_template_1611_9,1611-9/46,1611920230346,Leva 1611-9,Talla: 46,165.13,0.00
+__import__.product_template_1611_9,1611-9/48,1611920230348,Leva 1611-9,Talla: 48,165.13,0.00
+__import__.product_template_1611_9,1611-9/50,1611920230350,Leva 1611-9,Talla: 50,165.13,0.00
+__import__.product_template_18078_387,18078-387/46,1807838720230346,Leva 18078-387,Talla: 46,165.13,0.00
+__import__.product_template_18078_387,18078-387/48,1807838720230348,Leva 18078-387,Talla: 48,165.13,0.00
+__import__.product_template_18078_387,18078-387/50,1807838720230350,Leva 18078-387,Talla: 50,165.13,0.00
+__import__.product_template_18078_387,18078-387/52,1807838720230352,Leva 18078-387,Talla: 52,165.13,0.00
+__import__.product_template_18078_387,18078-387/54,1807838720230354,Leva 18078-387,Talla: 54,165.13,0.00
+__import__.product_template_18078_387,18078-387/56,1807838720230356,Leva 18078-387,Talla: 56,165.13,0.00
+__import__.product_template_18078_387,18078-387/58,1807838720230358,Leva 18078-387,Talla: 58,165.13,0.00
+__import__.product_template_18078_387,18078-387/60,1807838720230360,Leva 18078-387,Talla: 60,165.13,0.00
+__import__.product_template_18078_386,18078-386/46,1807838620230346,Leva 18078-386,Talla: 46,165.13,0.00
+__import__.product_template_18078_386,18078-386/48,1807838620230348,Leva 18078-386,Talla: 48,165.13,0.00
+__import__.product_template_18078_386,18078-386/50,1807838620230350,Leva 18078-386,Talla: 50,165.13,0.00
+__import__.product_template_18078_386,18078-386/52,1807838620230352,Leva 18078-386,Talla: 52,165.13,0.00
+__import__.product_template_18078_386,18078-386/54,1807838620230354,Leva 18078-386,Talla: 54,165.13,0.00
+__import__.product_template_18078_386,18078-386/56,1807838620230356,Leva 18078-386,Talla: 56,165.13,0.00
+__import__.product_template_18078_386,18078-386/58,1807838620230358,Leva 18078-386,Talla: 58,165.13,0.00
+__import__.product_template_18078_386,18078-386/60,1807838620230360,Leva 18078-386,Talla: 60,165.13,0.00
+__import__.product_template_ve_ginebra_fu,VE-GINEBRA-FU/S,VE-GINEBRA-FU/OS,M. VESTIDO P/DAMA GINEBRA FUCSIA ROSA,Talla: S,108.84,0.00
+__import__.product_template_ve_ginebra_fu,VE-GINEBRA-FU/M,VE-GINEBRA-FU/OM,M. VESTIDO P/DAMA GINEBRA FUCSIA ROSA,Talla: M,108.84,0.00
+__import__.product_template_ve_ginebra_fu,VE-GINEBRA-FU/L,VE-GINEBRA-FU/OL,M. VESTIDO P/DAMA GINEBRA FUCSIA ROSA,Talla: L,108.84,0.00
+__import__.product_template_ve_paris_am_bl,VE-PARIS-AM-BL/L,VE-PARIS-AM-BL/OL,M. VESTIDO P/DAMA PARIS AMARILLO BLANCO,Talla: L,84.73,0.00
+__import__.product_template_ve_yesica_wh,VE-YESICA-WH/L,VE-YESICA-WH/OL,M. VESTIDO P/DAMA YESICA BLANCO,Talla: L,111.52,0.00
+__import__.product_template_ve_malu_mo,VE-MALU-MO/M,VE-MALU-MO/OM,M. VESTIDO P/DAMA MALU MORADO ROJO,Talla: M,121.34,0.00
+__import__.product_template_ve_malu_mo,VE-MALU-MO/S,VE-MALU-MO/OS,M. VESTIDO P/DAMA MALU MORADO ROJO,Talla: S,121.34,0.00
+__import__.product_template_ve_madison_ve,VE-MADISON-VE/S,VE-MADISON-VE/OS,M. VESTIDO P/DAMA MADISON VERDE,Talla: S,98.13,0.00
+__import__.product_template_ve_isa_rj,VE-ISA-RJ/M,VE-ISA-RJ/OM,M. VESTIDO P/DAMA ISA ROJO AZUL,Talla: M,88.30,0.00
+__import__.product_template_18078_382_bc_2,18078-382-BC-2/46,180783822023034628,Terno 18078-382-BC-2,Talla: 46,217.30,0.00
+__import__.product_template_18078_382_bc_2,18078-382-BC-2/48,180783822023034830,Terno 18078-382-BC-2,Talla: 48,217.30,0.00
+__import__.product_template_18078_382_bc_2,18078-382-BC-2/50,180783822023035032,Terno 18078-382-BC-2,Talla: 50,217.30,0.00
+__import__.product_template_18078_382_bc_2,18078-382-BC-2/52,180783822023035234,Terno 18078-382-BC-2,Talla: 52,217.30,0.00
+__import__.product_template_18078_382_bc_2,18078-382-BC-2/54,180783822023035436,Terno 18078-382-BC-2,Talla: 54,217.30,0.00
+__import__.product_template_18078_382_bc_2,18078-382-BC-2/56,180783822023035638,Terno 18078-382-BC-2,Talla: 56,217.30,0.00
+__import__.product_template_18078_382_bc_2,18078-382-BC-2/58,180783822023035840,Terno 18078-382-BC-2,Talla: 58,217.30,0.00
+__import__.product_template_17001_10bc_2,17001-10BC-2/46,17001102023034628,Terno 17001-10BC-2,Talla: 46,243.39,0.00
+__import__.product_template_17001_10bc_2,17001-10BC-2/48,17001102023034830,Terno 17001-10BC-2,Talla: 48,243.39,0.00
+__import__.product_template_17001_10bc_2,17001-10BC-2/50,17001102023035032,Terno 17001-10BC-2,Talla: 50,243.39,0.00
+__import__.product_template_17001_10bc_2,17001-10BC-2/52,17001102023035234,Terno 17001-10BC-2,Talla: 52,217.30,0.00
+__import__.product_template_17001_10bc_2,17001-10BC-2/54,17001102023035436,Terno 17001-10BC-2,Talla: 54,217.30,0.00
+__import__.product_template_17001_10bc_2,17001-10BC-2/56,17001102023035638,Terno 17001-10BC-2,Talla: 56,217.30,0.00
+__import__.product_template_17001_10bc_2,17001-10BC-2/58,17001102023035840,Terno 17001-10BC-2,Talla: 58,217.30,0.00
+__import__.product_template_10036a_8_495_bc_2,10036A-8-495-BC-2/46,10036849520234628,Terno 10036A-8-495-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_10036a_8_495_bc_2,10036A-8-495-BC-2/48,10036849520234830,Terno 10036A-8-495-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_10036a_8_495_bc_2,10036A-8-495-BC-2/50,10036849520235032,Terno 10036A-8-495-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_10036a_8_495_bc_2,10036A-8-495-BC-2/52,10036849520235234,Terno 10036A-8-495-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_10036a_8_495_bc_2,10036A-8-495-BC-2/54,10036849520235436,Terno 10036A-8-495-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_10036a_8_495_bc_2,10036A-8-495-BC-2/56,10036849520235638,Terno 10036A-8-495-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_10036a_8_495_bc_2,10036A-8-495-BC-2/58,10036849520235840,Terno 10036A-8-495-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_17001_7_bc_2,17001-7-BC-2/46,1700172023034628,Terno 17001-7-BC-2,Talla: 46,217.30,0.00
+__import__.product_template_17001_7_bc_2,17001-7-BC-2/48,1700172023034830,Terno 17001-7-BC-2,Talla: 48,217.30,0.00
+__import__.product_template_17001_7_bc_2,17001-7-BC-2/50,1700172023035032,Terno 17001-7-BC-2,Talla: 50,217.30,0.00
+__import__.product_template_17001_7_bc_2,17001-7-BC-2/52,1700172023035234,Terno 17001-7-BC-2,Talla: 52,217.30,0.00
+__import__.product_template_17001_7_bc_2,17001-7-BC-2/54,1700172023035436,Terno 17001-7-BC-2,Talla: 54,217.30,0.00
+__import__.product_template_17001_7_bc_2,17001-7-BC-2/56,1700172023035638,Terno 17001-7-BC-2,Talla: 56,217.30,0.00
+__import__.product_template_17001_7_bc_2,17001-7-BC-2/58,1700172023035840,Terno 17001-7-BC-2,Talla: 58,217.30,0.00
+__import__.product_template_17001_8_bc_2,17001-8-BC-2/46,1700182023034628,Terno 17001-8-BC-2,Talla: 46,217.30,0.00
+__import__.product_template_17001_8_bc_2,17001-8-BC-2/48,1700182023034830,Terno 17001-8-BC-2,Talla: 48,217.30,0.00
+__import__.product_template_17001_8_bc_2,17001-8-BC-2/50,1700182023035032,Terno 17001-8-BC-2,Talla: 50,217.30,0.00
+__import__.product_template_17001_8_bc_2,17001-8-BC-2/52,1700182023035234,Terno 17001-8-BC-2,Talla: 52,217.30,0.00
+__import__.product_template_17001_8_bc_2,17001-8-BC-2/54,1700182023035436,Terno 17001-8-BC-2,Talla: 54,217.30,0.00
+__import__.product_template_17001_8_bc_2,17001-8-BC-2/56,1700182023035638,Terno 17001-8-BC-2,Talla: 56,217.30,0.00
+__import__.product_template_17001_8_bc_2,17001-8-BC-2/58,1700182023035840,Terno 17001-8-BC-2,Talla: 58,217.30,0.00
+__import__.product_template_10036a_18_498_bc_2,10036A-18-498-BC-2/46,1003618498234628,Terno 10036A-18-498-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_10036a_18_498_bc_2,10036A-18-498-BC-2/48,1003618498234830,Terno 10036A-18-498-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_10036a_18_498_bc_2,10036A-18-498-BC-2/50,1003618498235032,Terno 10036A-18-498-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_10036a_18_498_bc_2,10036A-18-498-BC-2/52,1003618498235234,Terno 10036A-18-498-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_10036a_18_498_bc_2,10036A-18-498-BC-2/54,1003618498235436,Terno 10036A-18-498-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_10036a_18_498_bc_2,10036A-18-498-BC-2/56,1003618498235638,Terno 10036A-18-498-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_10036a_18_498_bc_2,10036A-18-498-BC-2/58,1003618498235840,Terno 10036A-18-498-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_10036a_18_217bc_2,10036A-18-217BC-2/46,1003618217234628,Terno 10036A-18-217BC-2,Talla: 46,243.39,0.00
+__import__.product_template_10036a_18_217bc_2,10036A-18-217BC-2/48,1003618217234830,Terno 10036A-18-217BC-2,Talla: 48,243.39,0.00
+__import__.product_template_10036a_18_217bc_2,10036A-18-217BC-2/50,1003618217235032,Terno 10036A-18-217BC-2,Talla: 50,243.39,0.00
+__import__.product_template_10036a_18_217bc_2,10036A-18-217BC-2/52,1003618217235234,Terno 10036A-18-217BC-2,Talla: 52,243.39,0.00
+__import__.product_template_10036a_18_217bc_2,10036A-18-217BC-2/54,1003618217235436,Terno 10036A-18-217BC-2,Talla: 54,243.39,0.00
+__import__.product_template_10036a_18_217bc_2,10036A-18-217BC-2/56,1003618217235638,Terno 10036A-18-217BC-2,Talla: 56,243.39,0.00
+__import__.product_template_10036a_18_217bc_2,10036A-18-217BC-2/58,1003618217235840,Terno 10036A-18-217BC-2,Talla: 58,243.39,0.00
+__import__.product_template_10036a_18_216bc_2,10036A-18-216BC-2/46,1003618216234628,Terno 10036A-18-216BC-2,Talla: 46,217.30,0.00
+__import__.product_template_10036a_18_216bc_2,10036A-18-216BC-2/48,1003618216234830,Terno 10036A-18-216BC-2,Talla: 48,217.30,0.00
+__import__.product_template_10036a_18_216bc_2,10036A-18-216BC-2/50,1003618216235032,Terno 10036A-18-216BC-2,Talla: 50,217.30,0.00
+__import__.product_template_10036a_18_216bc_2,10036A-18-216BC-2/52,1003618216235234,Terno 10036A-18-216BC-2,Talla: 52,217.30,0.00
+__import__.product_template_10036a_18_216bc_2,10036A-18-216BC-2/54,1003618216235436,Terno 10036A-18-216BC-2,Talla: 54,217.30,0.00
+__import__.product_template_10036a_18_216bc_2,10036A-18-216BC-2/56,1003618216235638,Terno 10036A-18-216BC-2,Talla: 56,217.30,0.00
+__import__.product_template_10036a_18_216bc_2,10036A-18-216BC-2/58,1003618216235840,Terno 10036A-18-216BC-2,Talla: 58,217.30,0.00
+__import__.product_template_pul,PUL-12,PUL-12,PULSERA DE DAMAS,Talla: 12,14.70,0.00
+__import__.product_template_sh_se9011_la,SH-SE9011-LA/S,SH-SE9011-LA/OS,M. SHORT P/DAMA LAVENDER,Talla: S,47.23,0.00
+__import__.product_template_sh_se9011_la,SH-SE9011-LA/M,SH-SE9011-LA/OM,M. SHORT P/DAMA LAVENDER,Talla: M,47.23,0.00
+__import__.product_template_sh_se9011_la,SH-SE9011-LA/L,SH-SE9011-LA/OL,M. SHORT P/DAMA LAVENDER,Talla: L,47.23,0.00
+__import__.product_template_sh_se9021_ol,SH-SE9021-OL/L,SH-SE9021-OL/OL,M. SHORT P/DAMA OLIVE,Talla: L,40.98,0.00
+__import__.product_template_sh_se9021_ol,SH-SE9021-OL/M,SH-SE9021-OL/OM,M. SHORT P/DAMA OLIVE,Talla: M,40.98,0.00
+__import__.product_template_sh_se9021_ol,SH-SE9021-OL/S,SH-SE9021-OL/OS,M. SHORT P/DAMA OLIVE,Talla: S,40.98,0.00
+__import__.product_template_sh_se9021_bl,SH-SE9021-BL/L,SH-SE9021-BL/OL,M. SHORT P/DAMA BLACK,Talla: L,40.98,0.00
+__import__.product_template_sh_se9021_bl,SH-SE9021-BL/M,SH-SE9021-BL/OM,M. SHORT P/DAMA BLACK,Talla: M,40.98,0.00
+__import__.product_template_sh_se9021_bl,SH-SE9021-BL/S,SH-SE9021-BL/OS,M. SHORT P/DAMA BLACK,Talla: S,40.98,0.00
+__import__.product_template_bl_se9021_bl,BL-SE9021-BL/S,BL-SE9021-BL/OS,M. BLUSA P/DAMA BLACK,Talla: S,43.39,0.00
+__import__.product_template_bl_se9021_bl,BL-SE9021-BL/M,BL-SE9021-BL/OM,M. BLUSA P/DAMA BLACK,Talla: M,43.39,0.00
+__import__.product_template_bl_se9021_bl,BL-SE9021-BL/L,BL-SE9021-BL/OL,M. BLUSA P/DAMA BLACK,Talla: L,43.39,0.00
+__import__.product_template_p2310_bg,P2310-BG/S,P2310-BG/OS,M. SHORT P/DAMA BEIGE,Talla: S,40.98,0.00
+__import__.product_template_p2310_bg,P2310-BG/M,P2310-BG/OM,M. SHORT P/DAMA BEIGE,Talla: M,40.98,0.00
+__import__.product_template_p2310_bl,P2310-BL/S,P2310-BL/OS,M. SHORT P/DAMA BLACK (p2310_bl),Talla: S,40.98,0.00
+__import__.product_template_p2310_bl,P2310-BL/L,P2310-BL/OL,M. SHORT P/DAMA BLACK (p2310_bl),Talla: L,40.98,0.00
+__import__.product_template_p2310_bl,P2310-BL/M,P2310-BL/OM,M. SHORT P/DAMA BLACK (p2310_bl),Talla: M,40.98,0.00
+__import__.product_template_p2310_or,P2310-OR/L,P2310-OR/OL,M. SHORT P/DAMA ORANGE,Talla: L,40.98,0.00
+__import__.product_template_p2310_or,P2310-OR/M,P2310-OR/OM,M. SHORT P/DAMA ORANGE,Talla: M,40.98,0.00
+__import__.product_template_p2310_or,P2310-OR/S,P2310-OR/OS,M. SHORT P/DAMA ORANGE,Talla: S,40.98,0.00
+__import__.product_template_p2310_bg,P2310-BG/L,P2310-BG/OL,M. SHORT P/DAMA BEIGE,Talla: L,40.98,0.00
+__import__.product_template_swt7991_wh,SWT7991-WH/L,SWT7991-WH/OL,M. BLUSA P/DAMA WHITE,Talla: L,37.30,0.00
+__import__.product_template_swt7991_wh,SWT7991-WH/M,SWT7991-WH/OM,M. BLUSA P/DAMA WHITE,Talla: M,37.30,0.00
+__import__.product_template_swt7991_wh,SWT7991-WH/S,SWT7991-WH/OS,M. BLUSA P/DAMA WHITE,Talla: S,37.30,0.00
+__import__.product_template_fd9223_p1009_in_ga,FD9223-P1009-IN-GA/S,FD9223-P1009INGA/OS,M. VESTIDO P/DAMA INDIGO GARDEN,Talla: S,69.55,0.00
+__import__.product_template_fd10659_p1026_an_ja,FD10659-P1026-AN-JA/M,FD10659-P1026/OM,M. VESTIDO P/DAMA WASHED ANTIQUE JADE,Talla: M,83.84,0.00
+__import__.product_template_fd10659_p1026_an_ja,FD10659-P1026-AN-JA/L,FD10659-P1026/OL,M. VESTIDO P/DAMA WASHED ANTIQUE JADE,Talla: L,83.84,0.00
+__import__.product_template_fd10659_p1026_an_ja,FD10659-P1026-AN-JA/S,FD10659-P1026/OS,M. VESTIDO P/DAMA WASHED ANTIQUE JADE,Talla: S,83.84,0.00
+__import__.product_template_fd4571_p413_ma_bl,FD4571-P413-MA-BL/L,FD4571-P413-MA-BL/OL,M. VESTIDO P/DAMA MAUVE BLUSH,Talla: L,71.34,0.00
+__import__.product_template_fd4571_p413_ma_bl,FD4571-P413-MA-BL/M,FD4571-P413-MA-BL/OM,M. VESTIDO P/DAMA MAUVE BLUSH,Talla: M,71.34,0.00
+__import__.product_template_fd4571_p413_ma_bl,FD4571-P413-MA-BL/S,FD4571-P413-MA-BL/OS,M. VESTIDO P/DAMA MAUVE BLUSH,Talla: S,71.34,0.00
+__import__.product_template_d2114_b_wh_br,D2114-B-WH-BR/L,D2114-B-WH-BR/OL,M. VESTIDO P/DAMA WASHED FLORAL WHITE BROWN,Talla: L,44.55,0.00
+__import__.product_template_d2114_b_wh_br,D2114-B-WH-BR/S,D2114-B-WH-BR/OS,M. VESTIDO P/DAMA WASHED FLORAL WHITE BROWN,Talla: S,44.55,0.00
+__import__.product_template_d2114_b_wh_br,D2114-B-WH-BR/M,D2114-B-WH-BR/OM,M. VESTIDO P/DAMA WASHED FLORAL WHITE BROWN,Talla: M,44.55,0.00
+__import__.product_template_fd9223_p1009_in_ga,FD9223-P1009-IN-GA/M,FD9223-P1009INGA/OM,M. VESTIDO P/DAMA INDIGO GARDEN,Talla: M,69.55,0.00
+__import__.product_template_fd9223_p1009_in_ga,FD9223-P1009-IN-GA/L,FD9223-P1009INGA/OL,M. VESTIDO P/DAMA INDIGO GARDEN,Talla: L,69.55,0.00
+__import__.product_template_swt7470_li,SWT7470-LI/L,SWT7470-LI/L,M. TOP P/DAMA KNIT VISCOSE LIME,Talla: L,40.09,0.00
+__import__.product_template_swt7470_li,SWT7470-LI/S,SWT7470-LI/S,M. TOP P/DAMA KNIT VISCOSE LIME,Talla: S,40.09,0.00
+__import__.product_template_swt7470_li,SWT7470-LI/M,SWT7470-LI/M,M. TOP P/DAMA KNIT VISCOSE LIME,Talla: M,40.09,0.00
+__import__.product_template_et_lucero_mo_bl,ET-LUCERO-MO-BL/S,ET-LUCERO-MO-BL/OS,M. ENTERIZO LUCERO P/DAMA MORADO BLANCO,Talla: S,104.38,0.00
+__import__.product_template_et_lucero_mo_bl,ET-LUCERO-MO-BL/M,ET-LUCERO-MO-BL/OM,M. ENTERIZO LUCERO P/DAMA MORADO BLANCO,Talla: M,104.38,0.00
+__import__.product_template_ve_paris_am_bl,VE-PARIS-AM-BL/S,VE-PARIS-AM-BL/OS,M. VESTIDO P/DAMA PARIS AMARILLO BLANCO,Talla: S,84.73,0.00
+__import__.product_template_ve_paris_am_bl,VE-PARIS-AM-BL/M,VE-PARIS-AM-BL/OM,M. VESTIDO P/DAMA PARIS AMARILLO BLANCO,Talla: M,84.73,0.00
+__import__.product_template_fl_nohemi_li_rj,FL-NOHEMI-LI-RJ/L,FL-NOHEMI-LI-RJ/OL,M. FALDA NOHEMI P/DAMA LILA ROJO,Talla: L,95.45,0.00
+__import__.product_template_fl_nohemi_li_rj,FL-NOHEMI-LI-RJ/M,FL-NOHEMI-LI-RJ/OM,M. FALDA NOHEMI P/DAMA LILA ROJO,Talla: M,95.45,0.00
+__import__.product_template_fl_nohemi_li_rj,FL-NOHEMI-LI-RJ/S,FL-NOHEMI-LI-RJ/OS,M. FALDA NOHEMI P/DAMA LILA ROJO,Talla: S,95.45,0.00
+__import__.product_template_tp_silvia_mo_az,TP-SILVIA-MO-AZ/L,TP-SILVIA-MO-AZ/OL,M. TOP SILVIA P/DAMA MORADO AZUL,Talla: L,55.27,0.00
+__import__.product_template_tp_silvia_mo_az,TP-SILVIA-MO-AZ/M,TP-SILVIA-MO-AZ/OM,M. TOP SILVIA P/DAMA MORADO AZUL,Talla: M,55.27,0.00
+__import__.product_template_ve_yesica_na,VE-YESICA-NA/M,VE-YESICA-NA/OM,M. VESTIDO YESICA P/DAMA NARANJA,Talla: M,111.52,0.00
+__import__.product_template_pt_pilar_li,PT-PILAR-LI/L,PT-PILAR-LI/OL,M. PANTALON PILAR P/DAMA LILA,Talla: L,60.63,0.00
+__import__.product_template_pt_pilar_li,PT-PILAR-LI/M,PT-PILAR-LI/OM,M. PANTALON PILAR P/DAMA LILA,Talla: M,60.63,0.00
+__import__.product_template_pt_pilar_li,PT-PILAR-LI/S,PT-PILAR-LI/OS,M. PANTALON PILAR P/DAMA LILA,Talla: S,60.63,0.00
+__import__.product_template_pt_pilar_mo,PT-PILAR-MO/L,PT-PILAR-MO/OL,M. PANTALON PILAR P/DAMA MORADO,Talla: L,60.63,0.00
+__import__.product_template_pt_pilar_mo,PT-PILAR-MO/M,PT-PILAR-MO/OM,M. PANTALON PILAR P/DAMA MORADO,Talla: M,60.63,0.00
+__import__.product_template_pt_pilar_mo,PT-PILAR-MO/S,PT-PILAR-MO/OS,M. PANTALON PILAR P/DAMA MORADO,Talla: S,60.63,0.00
+__import__.product_template_bl_dafne_az_ro,BL-DAFNE-AZ-RO/L,BL-DAFNE-AZ-RO/OL,BLUSA DAFNE P/DAMA AZUL ROSA,Talla: L,55.57,0.00
+__import__.product_template_bl_dafne_az_ro,BL-DAFNE-AZ-RO/M,BL-DAFNE-AZ-RO/OM,BLUSA DAFNE P/DAMA AZUL ROSA,Talla: M,55.57,0.00
+__import__.product_template_bl_dafne_az_ro,BL-DAFNE-AZ-RO/S,BL-DAFNE-AZ-RO/OS,BLUSA DAFNE P/DAMA AZUL ROSA,Talla: S,55.57,0.00
+__import__.product_template_bl_dafne_na_ca,BL-DAFNE-NA-CA/S,BL-DAFNE-NA-CA/OS,BLUSA DAFNE P/DAMA NARANJA CAFE,Talla: S,55.57,0.00
+__import__.product_template_z5911_oro,Z5911-ORO-6,Z5911-ORO-6,Corbata Z5911-ORO,Ancho Corbata: 6 cm,95.57,0.00
+__import__.product_template_z5911_oro,Z5911-ORO-7,Z5911-ORO-7,Corbata Z5911-ORO,Ancho Corbata: 7 cm,98.12,0.00
+__import__.product_template_z5911_oro,Z5911-ORO-8,Z5911-ORO-8,Corbata Z5911-ORO,Talla: 8,98.12,0.00
+__import__.product_template_z_ch161_davi,Z-CH161-DAVI-6,Z-CH161-DAVI-6,Corbata Z-CH161-DAVI,Ancho Corbata: 6 cm,128.61,0.00
+__import__.product_template_z_ch161_davi,Z-CH161-DAVI-7,Z-CH161-DAVI-7,Corbata Z-CH161-DAVI,Ancho Corbata: 7 cm,128.61,0.00
+__import__.product_template_z_ch161_davi,Z-CH161-DAVI-8,Z-CH161-DAVI-8,Corbata Z-CH161-DAVI,Talla: 8,128.61,0.00
+__import__.product_template_z2625_negro,Z2625-NEGRO-8,Z2625-NEGRO-O8,ZAPATO NEGRO,Talla: 8,76.43,0.00
+__import__.product_template_z2625_negro,Z2625-NEGRO-7,Z2625-NEGRO-O7,ZAPATO NEGRO,Ancho Corbata: 7 cm,76.43,0.00
+__import__.product_template_z2625_negro,Z2625-NEGRO-6,Z2625-NEGRO-O6,ZAPATO NEGRO,Ancho Corbata: 6 cm,76.43,0.00
+__import__.product_template_z923_negro,Z923-NEGRO-8,Z923-NEGRO-8,ZAPATO NEGRO (z923_negro),Talla: 8,123.13,0.00
+__import__.product_template_z923_negro,Z923-NEGRO-7,Z923-NEGRO-7,ZAPATO NEGRO (z923_negro),Ancho Corbata: 7 cm,119.91,0.00
+__import__.product_template_z923_negro,Z923-NEGRO-6,Z923-NEGRO-6,ZAPATO NEGRO (z923_negro),Ancho Corbata: 6 cm,119.91,0.00
+__import__.product_template_z723_plata,Z723-PLATA-8,Z723-PLATA-8,ZAPATO PLATA,Talla: 8,119.91,0.00
+__import__.product_template_z723_plata,Z723-PLATA-7,Z723-PLATA-7,ZAPATO PLATA,Ancho Corbata: 7 cm,119.91,0.00
+__import__.product_template_z723_plata,Z723-PLATA-6,Z723-PLATA-6,ZAPATO PLATA,Ancho Corbata: 6 cm,123.13,0.00
+__import__.product_template_lv_12342_1,LV-12342-1/50,LV-12342-1/O50,Leva LV-12342-1,Talla: 50,69.48,0.00
+__import__.product_template_dk5007_47,DK5007-47/46,DK50074720221046,Leva DK5007-47,Talla: 46,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/60,DK50075520221060,Leva DK5007-55,Talla: 60,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/58,DK50075520221058,Leva DK5007-55,Talla: 58,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/56,DK50075520221056,Leva DK5007-55,Talla: 56,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/54,DK50075520221054,Leva DK5007-55,Talla: 54,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/52,DK50075520221052,Leva DK5007-55,Talla: 52,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/50,DK50075520221050,Leva DK5007-55,Talla: 50,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/48,DK50075520221048,Leva DK5007-55,Talla: 48,165.13,0.00
+__import__.product_template_dk5007_55,DK5007-55/46,DK50075520221046,Leva DK5007-55,Talla: 46,165.13,0.00
+__import__.product_template_dk5007_47,DK5007-47/60,DK50074720221060,Leva DK5007-47,Talla: 60,165.13,0.00
+__import__.product_template_dk5007_47,DK5007-47/58,DK50074720221058,Leva DK5007-47,Talla: 58,165.13,0.00
+__import__.product_template_dk5007_47,DK5007-47/56,DK50074720221056,Leva DK5007-47,Talla: 56,165.13,0.00
+__import__.product_template_dk5007_47,DK5007-47/54,DK50074720221054,Leva DK5007-47,Talla: 54,165.13,0.00
+__import__.product_template_dk5007_47,DK5007-47/52,DK50074720221052,Leva DK5007-47,Talla: 52,165.13,0.00
+__import__.product_template_dk5007_47,DK5007-47/50,DK50074720221050,Leva DK5007-47,Talla: 50,165.13,0.00
+__import__.product_template_dk5007_47,DK5007-47/48,DK50074720221048,Leva DK5007-47,Talla: 48,165.13,0.00
+__import__.product_template_22e2712_red,22E2712-RED/60,22E2712R20221060,Leva 22E2712-RED,Talla: 60,165.13,0.00
+__import__.product_template_22e2712_red,22E2712-RED/58,22E2712R20221058,Leva 22E2712-RED,Talla: 58,165.13,0.00
+__import__.product_template_22e2712_red,22E2712-RED/56,22E2712R20221056,Leva 22E2712-RED,Talla: 56,165.13,0.00
+__import__.product_template_22e2712_red,22E2712-RED/54,22E2712R20221054,Leva 22E2712-RED,Talla: 54,165.13,0.00
+__import__.product_template_22e2712_red,22E2712-RED/52,22E2712R20221052,Leva 22E2712-RED,Talla: 52,165.13,0.00
+__import__.product_template_22e2712_red,22E2712-RED/50,22E2712R20221050,Leva 22E2712-RED,Talla: 50,152.09,0.00
+__import__.product_template_22e2712_red,22E2712-RED/48,22E2712R20221048,Leva 22E2712-RED,Talla: 48,152.09,0.00
+__import__.product_template_22e2712_red,22E2712-RED/46,22E2712R20221046,Leva 22E2712-RED,Talla: 46,165.13,0.00
+__import__.product_template_22a700112_2bc_2,22A700112-2BC-2/50,22A700112220225032,Terno 22A700112-2BC-2,Talla: 50,217.30,0.00
+__import__.product_template_22a700112_2bc_2,22A700112-2BC-2/58,22A700112220225840,Terno 22A700112-2BC-2,Talla: 58,217.30,0.00
+__import__.product_template_22a700112_2bc_2,22A700112-2BC-2/56,22A700112220225638,Terno 22A700112-2BC-2,Talla: 56,217.30,0.00
+__import__.product_template_22a700112_2bc_2,22A700112-2BC-2/54,22A700112220225436,Terno 22A700112-2BC-2,Talla: 54,217.30,0.00
+__import__.product_template_22a700112_2bc_2,22A700112-2BC-2/52,22A700112220225234,Terno 22A700112-2BC-2,Talla: 52,217.30,0.00
+__import__.product_template_22a700112_2bc_2,22A700112-2BC-2/48,22A700112220224830,Terno 22A700112-2BC-2,Talla: 48,217.30,0.00
+__import__.product_template_22a700112_2bc_2,22A700112-2BC-2/46,22A700112220224628,Terno 22A700112-2BC-2,Talla: 46,217.30,0.00
+__import__.product_template_22e2712_3bc_2,22E2712-3BC-2/58,22E271232022105840,Terno 22E2712-3BC-2,Talla: 58,243.39,0.00
+__import__.product_template_22e2712_3bc_2,22E2712-3BC-2/56,22E271232022105638,Terno 22E2712-3BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22e2712_3bc_2,22E2712-3BC-2/54,22E271232022105436,Terno 22E2712-3BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22e2712_3bc_2,22E2712-3BC-2/52,22E271232022105234,Terno 22E2712-3BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22e2712_3bc_2,22E2712-3BC-2/50,22E271232022105032,Terno 22E2712-3BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22e2712_3bc_2,22E2712-3BC-2/48,22E271232022104830,Terno 22E2712-3BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22e2712_3bc_2,22E2712-3BC-2/46,22E271232022104628,Terno 22E2712-3BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22c0905_17bc_2,22C0905-17BC-2/46,22C0905172022104628,Terno 22C0905-17BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22c0905_17bc_2,22C0905-17BC-2/48,22C0905172022104830,Terno 22C0905-17BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22c0905_17bc_2,22C0905-17BC-2/50,22C0905172022105032,Terno 22C0905-17BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22c0905_17bc_2,22C0905-17BC-2/52,22C0905172022105234,Terno 22C0905-17BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22c0905_17bc_2,22C0905-17BC-2/54,22C0905172022105436,Terno 22C0905-17BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22c0905_17bc_2,22C0905-17BC-2/56,22C0905172022105638,Terno 22C0905-17BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22c0905_17bc_2,22C0905-17BC-2/58,22C0905172022105840,Terno 22C0905-17BC-2,Talla: 58,243.39,0.00
+__import__.product_template_442199090_37,442199090/37-38,442199090/O37-38,H. HORMA P/ZAPATOS BRUNO CASSINI TL 37-38,Talla: 38,30.35,0.00
+__import__.product_template_442199090_39,442199090/39-40,442199090/O39-40,H. HORMA P/ZAPATOS BRUNO CASSINI TL 39-40,Talla: 40,30.35,0.00
+__import__.product_template_442199090_41,442199090/41-42,442199090/O41-42,H. HORMA P/ZAPATOS BRUNO CASSINI TL 41-42,Talla: 42,30.35,0.00
+__import__.product_template_442199090_43,442199090/43-44,442199090/O43-44,H. HORMA P/ZAPATOS BRUNO CASSINI TL 43-44,Talla: 44,30.35,0.00
+__import__.product_template_ar,AR-12,AR-12,ARETES P/DAMA V. MODELOS,Talla: 12,14.61,0.00
+__import__.product_template_pt_17001_2,PT-17001-2/40,PT-17001-2/O40,Pantalon PT-17001-2,Talla: 40,56.43,0.00
+__import__.product_template_pt_17001_2,PT-17001-2/38,PT-17001-2/O38,Pantalon PT-17001-2,Talla: 38,56.43,0.00
+__import__.product_template_pt_17001_2,PT-17001-2/36,PT-17001-2/O36,Pantalon PT-17001-2,Talla: 36,56.43,0.00
+__import__.product_template_pt_17001_2,PT-17001-2/34,PT-17001-2/O34,Pantalon PT-17001-2,Talla: 34,56.43,0.00
+__import__.product_template_pt_17001_2,PT-17001-2/32,PT-17001-2/O32,Pantalon PT-17001-2,Talla: 32,56.43,0.00
+__import__.product_template_pt_17001_2,PT-17001-2/30,PT-17001-2/O30,Pantalon PT-17001-2,Talla: 30,56.43,0.00
+__import__.product_template_pt_17001_2,PT-17001-2/28,PT-17001-2/O28,Pantalon PT-17001-2,Talla: 28,56.43,0.00
+__import__.product_template_12001bg,12001BG-19-S2,12001B202281902,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35,"Talla: 19, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_12001bg,12001BG-19-S1,12001B202281901,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35,"Talla: 19, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_12001bg,12001BG-17.5-S1,12001B202281751,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35,"Talla: 17.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_12001bg,12001BG-17.5-S2,12001B202281752,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a3025dc,A3025DC-17-S2,A3025D202281702,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (a3025dc),"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a3025dc,A3025DC-17-S1,A3025D202281701,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (a3025dc),"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a3025dc,A3025DC-16.5-S2,A3025D202281652,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (a3025dc),"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a3025dc,A3025DC-16.5-S1,A3025D202281651,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (a3025dc),"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_a3025dc,A3025DC-15.5-S2,A3025D202281552,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (a3025dc),"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_a3025dc,A3025DC-15.5-S1,A3025D202281551,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (a3025dc),"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_12001dc,12001DC-16.5-S2,12001D202281652,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (12001dc),"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_12001dc,12001DC-16.5-S1,12001D202281651,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (12001dc),"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_11701dc,11701DC-17-S2,11701D202281702,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (11701dc),"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_11701dc,11701DC-17-S1,11701D202281701,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (11701dc),"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_11701dc,11701DC-16-S2,11701D202281602,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (11701dc),"Talla: 16, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_11701dc,11701DC-16-S1,11701D202281601,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (11701dc),"Talla: 16, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_11701dc,11701DC-15.5-S2,11701D202281552,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (11701dc),"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_11701dc,11701DC-15.5-S1,11701D202281551,H. CAMISA D/P BRUNO CASSINI WHITE 34-35 (11701dc),"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_c1100_1,C1100-1-16.5-S2,C1100120221652,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_8831,8831-16.5-S1,8831202281651,Camisa 8831,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_8831,8831-16.5-S2,8831202281652,Camisa 8831,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-14.5-S1,C11001220281451,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-15-S1,C11001220281501,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-15-S2,C11001220281502,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-15.5-S1,C11001220281551,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-15.5-S2,C11001220281552,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-16.5-S1,C11001220281651,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-17-S1,C11001220281701,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-17-S2,C11001220281702,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-17.5-S2,C11001220281752,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_9_2,C1100-9-2-14.5-S1,C11009220281451,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_9_2,C1100-9-2-15-S1,C11009220281501,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_9_2,C1100-9-2-15-S2,C11009220281502,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_9_2,C1100-9-2-15.5-S1,C11009220281551,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_9_2,C1100-9-2-15.5-S2,C11009220281552,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-14.5-S1,C1100120221451,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-15-S1,C1100120221501,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-15-S2,C1100120221502,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-15.5-S1,C1100120221551,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-15.5-S2,C1100120221552,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-16-S1,C1100120221601,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-16-S2,C1100120221602,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-16.5-S1,C1100120221651,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1_2,C1100-1-2-16.5-S2,C11001220281652,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-17-S1,C1100120221701,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-17-S2,C1100120221702,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_1,C1100-1-17.5-S2,C1100120221752,H. CAMISA P/S BRUNO CASSINI CUADRO CELESTE 34-35,"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_a3025,A3025-16.5-S1,A3025202281651,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a3025,A3025-16-S2,A3025202281602,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a3025,A3025-14.5-S1,A3025202281451,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a3025,A3025-15.5-S1,A3025202281551,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a3025,A3025-15.5-S2,A3025202281552,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a3025,A3025-16-S1,A3025202281601,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a3025,A3025-16.5-S2,A3025202281652,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a3025,A3025-17-S1,A3025202281701,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_a3025,A3025-17-S2,A3025202281702,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_a3025,A3025-17.5-S2,A3025202281752,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (a3025),"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_603_9,603-9-16.5-S1,6039202281651,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_9,603-9-14.5-S1,6039202281451,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_9,603-9-15-S1,6039202281501,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_9,603-9-15-S2,6039202281502,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_9,603-9-15.5-S1,6039202281551,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_9,603-9-15.5-S2,6039202281552,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_9,603-9-16-S1,6039202281601,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_9,603-9-16-S2,6039202281602,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_9,603-9-16.5-S2,6039202281652,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_9,603-9-17-S1,6039202281701,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_9,603-9-17-S2,6039202281702,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_9,603-9-17.5-S2,6039202281752,H. CAMISA P/S BRUNO CASSINI LINEN ORANGE 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_2,603-2-14.5-S1,6032202281451,H. CAMISA P/S BRUNO CASSINI LINEN SKY 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_2,603-2-15.5-S1,6032202281551,H. CAMISA P/S BRUNO CASSINI LINEN SKY 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_2,603-2-15.5-S2,6032202281552,H. CAMISA P/S BRUNO CASSINI LINEN SKY 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_2,603-2-16.5-S1,6032202281651,H. CAMISA P/S BRUNO CASSINI LINEN SKY 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_2,603-2-16.5-S2,6032202281652,H. CAMISA P/S BRUNO CASSINI LINEN SKY 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_4,603-4-14.5-S1,6034202281451,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_4,603-4-15-S1,6034202281501,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_4,603-4-15-S2,6034202281502,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_4,603-4-15.5-S1,6034202281551,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_4,603-4-15.5-S2,6034202281552,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_4,603-4-16.5-S1,6034202281651,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_4,603-4-16.5-S2,6034202281652,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_4,603-4-17-S1,6034202281701,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_4,603-4-17-S2,6034202281702,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_4,603-4-17.5-S2,6034202281752,H. CAMISA P/S BRUNO CASSINI LINEN RED 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_3,K818-3-16.5-S2,K8183202281652,H. CAMISA P/S BRUNO CASSINI BLUE POINT 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_3,K818-3-16.5-S1,K8183202281651,H. CAMISA P/S BRUNO CASSINI BLUE POINT 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-14.5-S1,AD7025P8781451,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-15-S1,AD7025P8781501,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-15-S2,AD7025P8781502,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-15.5-S1,AD7025P8781551,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-15.5-S2,AD7025P8781552,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-16-S1,AD7025P8781601,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-16-S2,AD7025P8781602,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-16.5-S1,AD7025P8781651,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-16.5-S2,AD7025P8781652,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-17-S1,AD7025P8781701,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-17-S2,AD7025P8781702,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_7,AD7025P8-7-17.5-S2,AD7025P8781752,H. CAMISA P/S BRUNO CASSINI CUADROS BLUE 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-17-S2,AD7025P2821702,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-17-S1,AD7025P2821701,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-16.5-S2,AD7025P2821652,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-16.5-S1,AD7025P2821651,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-16-S2,AD7025P2821602,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-16-S1,AD7025P2821601,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-15.5-S2,AD7025P2821552,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-15.5-S1,AD7025P2821551,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-15-S2,AD7025P2821502,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-15-S1,AD7025P2821501,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_2,AD7025P8-2-14.5-S1,AD7025P2821451,H. CAMISA P/S BRUNO CASSINI CUADROS SKY BLUE 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k820_6,K820-6-17-S1,K8206202281701,H. CAMISA P/S BRUNO CASSINI RED POINT 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k820_6,K820-6-17-S2,K8206202281702,H. CAMISA P/S BRUNO CASSINI RED POINT 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_17604,17604-15.5-S1,17604202281551,Camisa 17604,"Talla: 15.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17604,17604-14.5-S1,17604202281451,Camisa 17604,"Talla: 14.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17604,17604-15-S1,17604202281501,Camisa 17604,"Talla: 15, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17604,17604-15-S2,17604202281502,Camisa 17604,"Talla: 15, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17604,17604-15.5-S2,17604202281552,Camisa 17604,"Talla: 15.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17604,17604-16-S1,17604202281601,Camisa 17604,"Talla: 16, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17604,17604-16-S2,17604202281602,Camisa 17604,"Talla: 16, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17604,17604-16.5-S1,17604202281651,Camisa 17604,"Talla: 16.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17604,17604-16.5-S2,17604202281652,Camisa 17604,"Talla: 16.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17604,17604-17.5-S2,17604202281752,Camisa 17604,"Talla: 17.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17604,17604-17-S2,17604202281702,Camisa 17604,"Talla: 17, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17604,17604-17-S1,17604202281701,Camisa 17604,"Talla: 17, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_20002,20002-16.5-S1,20002202491651,Camisa 20002,"Talla: 16.5, Manga de Camisa: S1 - 32/33",47.74,0.00
+__import__.product_template_20002,20002-16.5-S2,20002202491652,Camisa 20002,"Talla: 16.5, Manga de Camisa: S2 - 34/35",47.74,0.00
+__import__.product_template_c1100_5,C1100-5-15.5-S1,C11005202281551,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_5,C1100-5-15.5-S2,C11005202281552,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_5,C1100-5-16.5-S1,C11005202281651,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_5,C1100-5-16.5-S2,C11005202281652,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_4,K818-4-15-S1,K8184202281501,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k818_4,K818-4-15-S2,K8184202281502,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_4,K818-4-16-S1,K8184202281601,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k818_4,K818-4-16-S2,K8184202281602,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_4,K818-4-16.5-S1,K8184202281651,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k818_4,K818-4-16.5-S2,K8184202281652,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_4,K818-4-17-S1,K8184202281701,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k818_4,K818-4-17-S2,K8184202281702,H. CAMISA P/S BRUNO CASSINI LILA POINT 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_1,K818-1-16.5-S2,K8181202281652,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (k818_1),"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_k818_1,K818-1-16.5-S1,K8181202281651,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (k818_1),"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k820_3,K820-3-14.5-S1,K8203202281451,H. CAMISA P/S BRUNO CASSINI BLUE POINT 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k820_3,K820-3-17-S1,K8203202281701,H. CAMISA P/S BRUNO CASSINI BLUE POINT 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_k820_3,K820-3-17-S2,K8203202281702,H. CAMISA P/S BRUNO CASSINI BLUE POINT 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-14.5-S1,C11002202281451,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-15-S1,C11002202281501,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-15-S2,C11002202281502,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-15.5-S1,C11002202281551,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-15.5-S2,C11002202281552,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-16-S1,C11002202281601,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-16-S2,C11002202281602,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-16.5-S1,C11002202281651,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-16.5-S2,C11002202281652,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-17-S1,C11002202281701,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-17-S2,C11002202281702,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_2,C1100-2-17.5-S2,C11002202281752,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 32-33 (c1100_2),"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_605_3,605-3-14.5-S1,6053202281451,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_605_3,605-3-15-S1,6053202281501,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 15, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_605_3,605-3-15-S2,6053202281502,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 15, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_605_3,605-3-15.5-S1,6053202281551,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_605_3,605-3-15.5-S2,6053202281552,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_605_3,605-3-16-S1,6053202281601,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 16, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_605_3,605-3-16-S2,6053202281602,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 16, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_605_3,605-3-16.5-S1,6053202281651,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_605_3,605-3-16.5-S2,6053202281652,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_605_3,605-3-17-S1,6053202281701,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_605_3,605-3-17-S2,6053202281702,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_605_3,605-3-17.5-S2,6053202281752,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (605_3),"Talla: 17.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_c1100_9,C1100-9-14.5-S1,C1100920221451,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33 (c1100_9),"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_9,C1100-9-15.5-S1,C1100920221551,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33 (c1100_9),"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_9,C1100-9-15.5-S2,C1100920221552,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33 (c1100_9),"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_9,C1100-9-16.5-S1,C1100920221651,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33 (c1100_9),"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_9,C1100-9-16.5-S2,C1100920221652,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33 (c1100_9),"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_c1100_9,C1100-9-17-S1,C1100920221701,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33 (c1100_9),"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_c1100_9,C1100-9-17-S2,C1100920221702,H. CAMISA P/S BRUNO CASSINI CUADRO SKY 32-33 (c1100_9),"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_1,603-1-15-S1,6031202281501,H. CAMISA P/S BRUNO CASSINI LINEN PINK 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_1,603-1-15-S2,6031202281502,H. CAMISA P/S BRUNO CASSINI LINEN PINK 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_1,603-1-15.5-S1,6031202281551,H. CAMISA P/S BRUNO CASSINI LINEN PINK 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_1,603-1-15.5-S2,6031202281552,H. CAMISA P/S BRUNO CASSINI LINEN PINK 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_603_1,603-1-16.5-S1,6031202281651,H. CAMISA P/S BRUNO CASSINI LINEN PINK 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_1,603-1-16.5-S2,6031202281652,H. CAMISA P/S BRUNO CASSINI LINEN PINK 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-14.5-S1,AD7025P81081451,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-15-S1,AD7025P81081501,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-15-S2,AD7025P81081502,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-15.5-S1,AD7025P81081551,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-15.5-S2,AD7025P81081552,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-16-S1,AD7025P81081601,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-16-S2,AD7025P81081602,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-16.5-S1,AD7025P81081651,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-16.5-S2,AD7025P81081652,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-17-S1,AD7025P81081701,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-17-S2,AD7025P81081702,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_10,AD7025P8-10-17.5-S2,AD7025P81081752,H. CAMISA P/S BRUNO CASSINI CUADROS ORANGE 32-33,"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-15-S1,AD7025P8381501,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-17-S2,AD7025P8381702,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-17-S1,AD7025P8381701,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-16.5-S2,AD7025P8381652,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-16.5-S1,AD7025P8381651,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-16-S2,AD7025P8381602,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 16, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-16-S1,AD7025P8381601,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 16, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-15.5-S2,AD7025P8381552,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-15.5-S1,AD7025P8381551,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-15-S2,AD7025P8381502,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_ad7025p8_3,AD7025P8-3-14.5-S1,AD7025P8381451,H. CAMISA P/S BRUNO CASSINI CUADROS VIOLET 32-33,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_di_val_942_84,DI-VAL-942/84-38,DI-VAL-942/O84-38,ZAPATOS P/DAMA DI VALENTINA NARANJA,Talla: 38,86.00,0.00
+__import__.product_template_di_val_942_84,DI-VAL-942/84-36,DI-VAL-942/O84-36,ZAPATOS P/DAMA DI VALENTINA NARANJA,Talla: 36,86.00,0.00
+__import__.product_template_di_val_942_82,DI-VAL-942/82-38,DI-VAL-942/O82-38,ZAPATOS P/DAMA DI VALENTINA NEGRO,Talla: 38,86.00,0.00
+__import__.product_template_di_val_942_82,DI-VAL-942/82-36,DI-VAL-942/O82-36,ZAPATOS P/DAMA DI VALENTINA NEGRO,Talla: 36,86.00,0.00
+__import__.product_template_di_val_942_83,DI-VAL-942/83-38,DI-VAL-942/O83-38,ZAPATOS P/DAMA DI VALENTINA BLANCO,Talla: 38,86.00,0.00
+__import__.product_template_di_val_942_83,DI-VAL-942/83-36,DI-VAL-942/O83-36,ZAPATOS P/DAMA DI VALENTINA BLANCO,Talla: 36,86.00,0.00
+__import__.product_template_di_val_942_164,DI-VAL-942/164-38,DI-VAL-942/O164-38,ZAPATOS P/DAMA DI VALENTINA ROSADO,Talla: 38,86.00,0.00
+__import__.product_template_di_val_942_164,DI-VAL-942/164-36,DI-VAL-942/O164-36,ZAPATOS P/DAMA DI VALENTINA ROSADO,Talla: 36,86.00,0.00
+__import__.product_template_di_val_942_165,DI-VAL-942/165-38,DI-VAL-942/165-38,ZAPATOS P/DAMA DI VALENTINA BEIGE,Talla: 38,88.30,0.00
+__import__.product_template_di_val_942_165,DI-VAL-942/165-36,DI-VAL-942/O165-36,ZAPATOS P/DAMA DI VALENTINA BEIGE,Talla: 36,86.00,0.00
+__import__.product_template_sp_wht_ba,SP-WHT-BA/9.5,SP-WHT-BA/O9.5,Terno SP-WHT-BA,Talla: 9.5,47.74,0.00
+__import__.product_template_sp_wht_ba,SP-WHT-BA/9,SP-WHT-BA/O9,Terno SP-WHT-BA,Talla: 9,47.74,0.00
+__import__.product_template_sp_wht_ba,SP-WHT-BA/8.5,SP-WHT-BA/O8.5,Terno SP-WHT-BA,Talla: 8.5,47.74,0.00
+__import__.product_template_sp_wht_ba,SP-WHT-BA/8,SP-WHT-BA/O8,Terno SP-WHT-BA,Talla: 8,47.74,0.00
+__import__.product_template_sp_wht_ba,SP-WHT-BA/7.5,SP-WHT-BA/O7.5,Terno SP-WHT-BA,Talla: 7.5,47.74,0.00
+__import__.product_template_zp_pat_cof_h_cassini,ZP-PAT-COF-H-CASSINI/9.5,ZPCASSHECOF/O9.5,Zapato ZP-PAT-COF-H-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_pat_cof_h_cassini,ZP-PAT-COF-H-CASSINI/9,ZPCASSHECOF/O9,Zapato ZP-PAT-COF-H-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_pat_cof_h_cassini,ZP-PAT-COF-H-CASSINI/8.5,ZPCASSHECOF/O8.5,Zapato ZP-PAT-COF-H-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_pat_cof_h_cassini,ZP-PAT-COF-H-CASSINI/8,ZPCASSHECOF/O8,Zapato ZP-PAT-COF-H-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_pat_cof_h_cassini,ZP-PAT-COF-H-CASSINI/7.5,ZPCASSHECOF/O7.5,Zapato ZP-PAT-COF-H-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/58,374212022065840,Terno 3742-1BC-2,Talla: 58,217.30,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/56,374212022065638,Terno 3742-1BC-2,Talla: 56,217.30,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/54,374212022065436,Terno 3742-1BC-2,Talla: 54,217.30,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/52,374212022065234,Terno 3742-1BC-2,Talla: 52,217.30,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/50,374212022065032,Terno 3742-1BC-2,Talla: 50,217.30,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/48,374212022064830,Terno 3742-1BC-2,Talla: 48,217.30,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/46,374212022064628,Terno 3742-1BC-2,Talla: 46,217.30,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/58,3705212022065840,Terno 3705-21BC-2,Talla: 58,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/56,3705212022065638,Terno 3705-21BC-2,Talla: 56,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/54,3705212022065436,Terno 3705-21BC-2,Talla: 54,217.30,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/52,3705212022065234,Terno 3705-21BC-2,Talla: 52,217.30,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/50,3705212022065032,Terno 3705-21BC-2,Talla: 50,217.30,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/48,3705212022064830,Terno 3705-21BC-2,Talla: 48,217.30,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/46,3705212022064628,Terno 3705-21BC-2,Talla: 46,217.30,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/46,3705252022064628,Terno 3705-25BC-2,Talla: 46,243.39,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/48,3705252022064830,Terno 3705-25BC-2,Talla: 48,243.39,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/50,3705252022065032,Terno 3705-25BC-2,Talla: 50,243.39,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/52,3705252022065234,Terno 3705-25BC-2,Talla: 52,243.39,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/54,3705252022065436,Terno 3705-25BC-2,Talla: 54,243.39,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/56,3705252022065638,Terno 3705-25BC-2,Talla: 56,243.39,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/58,3705252022065840,Terno 3705-25BC-2,Talla: 58,243.39,0.00
+__import__.product_template_17001_2bc_2,17001-2BC-2/58,170012202265840,Terno 17001-2BC-2,Talla: 58,217.30,0.00
+__import__.product_template_17001_2bc_2,17001-2BC-2/56,170012202265638,Terno 17001-2BC-2,Talla: 56,217.30,0.00
+__import__.product_template_17001_2bc_2,17001-2BC-2/54,170012202265436,Terno 17001-2BC-2,Talla: 54,217.30,0.00
+__import__.product_template_17001_2bc_2,17001-2BC-2/52,170012202265234,Terno 17001-2BC-2,Talla: 52,217.30,0.00
+__import__.product_template_17001_2bc_2,17001-2BC-2/50,170012202265032,Terno 17001-2BC-2,Talla: 50,217.30,0.00
+__import__.product_template_17001_2bc_2,17001-2BC-2/48,170012202264830,Terno 17001-2BC-2,Talla: 48,217.30,0.00
+__import__.product_template_17001_2bc_2,17001-2BC-2/46,170012202264628,Terno 17001-2BC-2,Talla: 46,217.30,0.00
+__import__.product_template_zp_pat_co_c_cassini,ZP-PAT-CO-C-CASSINI/10,ZPCASSPACOC/O10,Zapato ZP-PAT-CO-C-CASSINI,Talla: 10,152.09,0.00
+__import__.product_template_zp_pat_co_c_cassini,ZP-PAT-CO-C-CASSINI/9.5,ZPCASSPACOC/O9.5,Zapato ZP-PAT-CO-C-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_pat_co_c_cassini,ZP-PAT-CO-C-CASSINI/9,ZPCASSPACOC/O9,Zapato ZP-PAT-CO-C-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_pat_co_c_cassini,ZP-PAT-CO-C-CASSINI/8.5,ZPCASSPACOC/O8.5,Zapato ZP-PAT-CO-C-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_pat_co_c_cassini,ZP-PAT-CO-C-CASSINI/8,ZPCASSPACOC/O8,Zapato ZP-PAT-CO-C-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_pat_co_c_cassini,ZP-PAT-CO-C-CASSINI/7.5,ZPCASSPACOC/O7.5,Zapato ZP-PAT-CO-C-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_pat_ta_cassini,ZP-PAT-TA-CASSINI/8,ZPPATTACASS/O8,Zapato ZP-PAT-TA-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_pat_ta_cassini,ZP-PAT-TA-CASSINI/7.5,ZPPATTACASS/O7.5,Zapato ZP-PAT-TA-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_pat_ta_cassini,ZP-PAT-TA-CASSINI/9.5,ZPPATTACASS/O9.5,Zapato ZP-PAT-TA-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/32,008B120220632,Pantalon PT-008-BLACK,Talla: 32,56.43,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/30,008B120220630,Pantalon PT-008-BLACK,Talla: 30,56.43,0.00
+__import__.product_template_008_black_b_bc_2,008-BLACK-B-BC-2/70,008BB2022067052,Terno 008-BLACK-B-BC-2,Talla: 70,243.39,0.00
+__import__.product_template_008_black_b_bc_2,008-BLACK-B-BC-2/68,008BB2022066850,Terno 008-BLACK-B-BC-2,Talla: 68,243.39,0.00
+__import__.product_template_008_black_b_bc_2,008-BLACK-B-BC-2/66,008BB2022066648,Terno 008-BLACK-B-BC-2,Talla: 66,243.39,0.00
+__import__.product_template_008_black_b_bc_2,008-BLACK-B-BC-2/64,008BB2022066446,Terno 008-BLACK-B-BC-2,Talla: 64,243.39,0.00
+__import__.product_template_008_black_b_bc_2,008-BLACK-B-BC-2/62,008BB2022066244,Terno 008-BLACK-B-BC-2,Talla: 62,243.39,0.00
+__import__.product_template_008_black_b_bc_2,008-BLACK-B-BC-2/60,008BB2022066042,Terno 008-BLACK-B-BC-2,Talla: 60,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/70,3705212022067052,Terno 3705-21BC-2,Talla: 70,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/68,3705212022066850,Terno 3705-21BC-2,Talla: 68,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/66,3705212022066648,Terno 3705-21BC-2,Talla: 66,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/64,3705212022066446,Terno 3705-21BC-2,Talla: 64,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/62,3705212022066244,Terno 3705-21BC-2,Talla: 62,243.39,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/60,3705212022066042,Terno 3705-21BC-2,Talla: 60,243.39,0.00
+__import__.product_template_008_black_3_bc_2,008-BLACK-3-BC-2/8,008B320220608,Terno 008-BLACK-3-BC-2,Talla: 8,133.84,0.00
+__import__.product_template_008_black_3_bc_2,008-BLACK-3-BC-2/10,008B320220610,Terno 008-BLACK-3-BC-2,Talla: 10,133.84,0.00
+__import__.product_template_008_black_3_bc_2,008-BLACK-3-BC-2/12,008B320220612,Terno 008-BLACK-3-BC-2,Talla: 12,133.84,0.00
+__import__.product_template_008_black_3_bc_2,008-BLACK-3-BC-2/14,008B320220614,Terno 008-BLACK-3-BC-2,Talla: 14,133.84,0.00
+__import__.product_template_008_black_3_bc_2,008-BLACK-3-BC-2/16,008B320220616,Terno 008-BLACK-3-BC-2,Talla: 16,133.84,0.00
+__import__.product_template_008_black_3_bc_2,008-BLACK-3-BC-2/18,008B320220618,Terno 008-BLACK-3-BC-2,Talla: 18,223.12,0.00
+__import__.product_template_008_black_3_bc_2,008-BLACK-3-BC-2/20,008B320220620,Terno 008-BLACK-3-BC-2,Talla: 20,223.12,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/8,37052520220608,Terno 3705-25BC-2,Talla: 8,133.84,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/10,37052520220610,Terno 3705-25BC-2,Talla: 10,133.84,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/12,37052520220612,Terno 3705-25BC-2,Talla: 12,133.84,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/14,37052520220614,Terno 3705-25BC-2,Talla: 14,133.84,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/16,37052520220616,Terno 3705-25BC-2,Talla: 16,133.84,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/18,37052520220618,Terno 3705-25BC-2,Talla: 18,223.12,0.00
+__import__.product_template_3705_25bc_2,3705-25BC-2/20,37052520220620,Terno 3705-25BC-2,Talla: 20,223.12,0.00
+__import__.product_template_18102_445bc_2,18102-445BC-2/58,181024452022065840,Terno 18102-445BC-2,Talla: 58,217.30,0.00
+__import__.product_template_18102_445bc_2,18102-445BC-2/56,181024452022065638,Terno 18102-445BC-2,Talla: 56,217.30,0.00
+__import__.product_template_18102_445bc_2,18102-445BC-2/54,181024452022065436,Terno 18102-445BC-2,Talla: 54,217.30,0.00
+__import__.product_template_18102_445bc_2,18102-445BC-2/52,181024452022065234,Terno 18102-445BC-2,Talla: 52,217.30,0.00
+__import__.product_template_18102_445bc_2,18102-445BC-2/50,181024452022065032,Terno 18102-445BC-2,Talla: 50,217.30,0.00
+__import__.product_template_18102_445bc_2,18102-445BC-2/48,181024452022064830,Terno 18102-445BC-2,Talla: 48,217.30,0.00
+__import__.product_template_18102_445bc_2,18102-445BC-2/46,181024452022064628,Terno 18102-445BC-2,Talla: 46,217.30,0.00
+__import__.product_template_008_black_2_bc_2,008-BLACK-2-BC-2/58,008B22022065840,Terno 008-BLACK-2-BC-2,Talla: 58,260.78,0.00
+__import__.product_template_008_black_2_bc_2,008-BLACK-2-BC-2/56,008B22022065638,Terno 008-BLACK-2-BC-2,Talla: 56,260.78,0.00
+__import__.product_template_008_black_2_bc_2,008-BLACK-2-BC-2/54,008B22022065436,Terno 008-BLACK-2-BC-2,Talla: 54,260.78,0.00
+__import__.product_template_008_black_2_bc_2,008-BLACK-2-BC-2/52,008B22022065234,Terno 008-BLACK-2-BC-2,Talla: 52,260.78,0.00
+__import__.product_template_008_black_2_bc_2,008-BLACK-2-BC-2/50,008B22022065032,Terno 008-BLACK-2-BC-2,Talla: 50,260.78,0.00
+__import__.product_template_008_black_2_bc_2,008-BLACK-2-BC-2/48,008B22022064830,Terno 008-BLACK-2-BC-2,Talla: 48,260.78,0.00
+__import__.product_template_008_black_2_bc_2,008-BLACK-2-BC-2/46,008B22022064628,Terno 008-BLACK-2-BC-2,Talla: 46,260.78,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/20,3742120220620,Terno 3742-1BC-2,Talla: 20,217.30,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/18,3742120220618,Terno 3742-1BC-2,Talla: 18,223.12,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/16,3742120220616,Terno 3742-1BC-2,Talla: 16,133.84,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/14,3742120220614,Terno 3742-1BC-2,Talla: 14,133.84,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/12,3742120220612,Terno 3742-1BC-2,Talla: 12,133.84,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/10,3742120220610,Terno 3742-1BC-2,Talla: 10,133.84,0.00
+__import__.product_template_3742_1bc_2,3742-1BC-2/8,3742120220608,Terno 3742-1BC-2,Talla: 8,133.84,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/20,37052120220620,Terno 3705-21BC-2,Talla: 20,223.12,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/18,37052120220618,Terno 3705-21BC-2,Talla: 18,223.12,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/16,37052120220616,Terno 3705-21BC-2,Talla: 16,133.84,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/14,37052120220614,Terno 3705-21BC-2,Talla: 14,130.34,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/12,37052120220612,Terno 3705-21BC-2,Talla: 12,133.84,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/10,37052120220610,Terno 3705-21BC-2,Talla: 10,133.84,0.00
+__import__.product_template_3705_21bc_2,3705-21BC-2/8,37052120220608,Terno 3705-21BC-2,Talla: 8,133.84,0.00
+__import__.product_template_008_black_1_bg_1,008-BLACK-1-BG-1/70,008B12022067052,Terno 008-BLACK-1-BG-1,Talla: 70,278.17,0.00
+__import__.product_template_008_black_1_bg_1,008-BLACK-1-BG-1/68,008B12022066850,Terno 008-BLACK-1-BG-1,Talla: 68,278.17,0.00
+__import__.product_template_008_black_1_bg_1,008-BLACK-1-BG-1/66,008B12022066648,Terno 008-BLACK-1-BG-1,Talla: 66,278.17,0.00
+__import__.product_template_008_black_1_bg_1,008-BLACK-1-BG-1/64,008B12022066446,Terno 008-BLACK-1-BG-1,Talla: 64,278.17,0.00
+__import__.product_template_008_black_1_bg_1,008-BLACK-1-BG-1/62,008B12022066244,Terno 008-BLACK-1-BG-1,Talla: 62,278.17,0.00
+__import__.product_template_008_black_1_bg_1,008-BLACK-1-BG-1/60,008B12022066042,Terno 008-BLACK-1-BG-1,Talla: 60,278.17,0.00
+__import__.product_template_330_21bg_1,330-21BG-1/70,330212022067052,Terno 330-21BG-1,Talla: 70,252.09,0.00
+__import__.product_template_330_21bg_1,330-21BG-1/68,330212022066850,Terno 330-21BG-1,Talla: 68,252.09,0.00
+__import__.product_template_330_21bg_1,330-21BG-1/64,330212022066446,Terno 330-21BG-1,Talla: 64,252.09,0.00
+__import__.product_template_330_21bg_1,330-21BG-1/66,330212022066648,Terno 330-21BG-1,Talla: 66,252.09,0.00
+__import__.product_template_330_21bg_1,330-21BG-1/62,330212022066244,Terno 330-21BG-1,Talla: 62,252.09,0.00
+__import__.product_template_330_21bg_1,330-21BG-1/60,330212022066042,Terno 330-21BG-1,Talla: 60,252.09,0.00
+__import__.product_template_008_black_1,008-BLACK-1/46,008B12022064628,Terno 008-BLACK-1,Talla: 46,260.78,0.00
+__import__.product_template_330_21bc_1,330-21BC-1/46,330212022064628,Terno 330-21BC-1,Talla: 46,260.78,0.00
+__import__.product_template_330_21bc_1,330-21BC-1/48,330212022064830,Terno 330-21BC-1,Talla: 48,260.78,0.00
+__import__.product_template_330_21bc_1,330-21BC-1/50,330212022065032,Terno 330-21BC-1,Talla: 50,260.78,0.00
+__import__.product_template_330_21bc_1,330-21BC-1/52,330212022065234,Terno 330-21BC-1,Talla: 52,260.78,0.00
+__import__.product_template_330_21bc_1,330-21BC-1/54,330212022065436,Terno 330-21BC-1,Talla: 54,260.78,0.00
+__import__.product_template_330_21bc_1,330-21BC-1/56,330212022065638,Terno 330-21BC-1,Talla: 56,260.78,0.00
+__import__.product_template_330_21bc_1,330-21BC-1/58,330212022065840,Terno 330-21BC-1,Talla: 58,260.78,0.00
+__import__.product_template_008_black_1,008-BLACK-1/48,008B12022064830,Terno 008-BLACK-1,Talla: 48,260.78,0.00
+__import__.product_template_008_black_1,008-BLACK-1/50,008B12022065032,Terno 008-BLACK-1,Talla: 50,260.78,0.00
+__import__.product_template_008_black_1,008-BLACK-1/52,008B12022065234,Terno 008-BLACK-1,Talla: 52,260.78,0.00
+__import__.product_template_008_black_1,008-BLACK-1/54,008B12022065436,Terno 008-BLACK-1,Talla: 54,260.78,0.00
+__import__.product_template_008_black_1,008-BLACK-1/56,008B12022065638,Terno 008-BLACK-1,Talla: 56,260.78,0.00
+__import__.product_template_008_black_1,008-BLACK-1/58,008B12022065840,Terno 008-BLACK-1,Talla: 58,260.78,0.00
+__import__.product_template_bfl_j40_101_b,BFL-J40-101.B/30,BFL-J40-101.B/O30,Terno BFL-J40-101.B,Talla: 30,39.04,0.00
+__import__.product_template_bfl_j40_101_b,BFL-J40-101.B/32,BFL-J40-101.B/O32,Terno BFL-J40-101.B,Talla: 32,39.04,0.00
+__import__.product_template_bfl_j40_101_b,BFL-J40-101.B/34,BFL-J40-101.B/O34,Terno BFL-J40-101.B,Talla: 34,39.04,0.00
+__import__.product_template_bfl_j40_101_b,BFL-J40-101.B/36,BFL-J40-101.B/O36,Terno BFL-J40-101.B,Talla: 36,39.04,0.00
+__import__.product_template_bfl_j40_101_b,BFL-J40-101.B/38,BFL-J40-101.B/O38,Terno BFL-J40-101.B,Talla: 38,39.04,0.00
+__import__.product_template_bfl_j40_101_b,BFL-J40-101.B/40,BFL-J40-101.B/O40,Terno BFL-J40-101.B,Talla: 40,39.04,0.00
+__import__.product_template_bfl_j40_108_b,BFL-J40-108.B/30,BFL-J40-108.B/O30,Terno BFL-J40-108.B,Talla: 30,39.04,0.00
+__import__.product_template_bfl_j40_108_b,BFL-J40-108.B/32,BFL-J40-108.B/O32,Terno BFL-J40-108.B,Talla: 32,39.04,0.00
+__import__.product_template_bfl_j40_108_b,BFL-J40-108.B/34,BFL-J40-108.B/O34,Terno BFL-J40-108.B,Talla: 34,39.04,0.00
+__import__.product_template_bfl_j40_108_b,BFL-J40-108.B/36,BFL-J40-108.B/O36,Terno BFL-J40-108.B,Talla: 36,39.04,0.00
+__import__.product_template_bfl_j40_108_b,BFL-J40-108.B/38,BFL-J40-108.B/O38,Terno BFL-J40-108.B,Talla: 38,39.04,0.00
+__import__.product_template_bfl_j40_108_b,BFL-J40-108.B/40,BFL-J40-108.B/O40,Terno BFL-J40-108.B,Talla: 40,39.04,0.00
+__import__.product_template_bfl_j40_205_a,BFL-J40-205.A/30,BFL-J40-205.A/O30,Terno BFL-J40-205.A,Talla: 30,39.04,0.00
+__import__.product_template_bfl_j40_205_a,BFL-J40-205.A/32,BFL-J40-205.A/O32,Terno BFL-J40-205.A,Talla: 32,39.04,0.00
+__import__.product_template_bfl_j40_205_a,BFL-J40-205.A/34,BFL-J40-205.A/O34,Terno BFL-J40-205.A,Talla: 34,39.04,0.00
+__import__.product_template_bfl_j40_205_a,BFL-J40-205.A/36,BFL-J40-205.A/O36,Terno BFL-J40-205.A,Talla: 36,39.04,0.00
+__import__.product_template_bfl_j40_205_a,BFL-J40-205.A/38,BFL-J40-205.A/O38,Terno BFL-J40-205.A,Talla: 38,39.04,0.00
+__import__.product_template_bfl_j40_205_a,BFL-J40-205.A/40,BFL-J40-205.A/O40,Terno BFL-J40-205.A,Talla: 40,39.04,0.00
+__import__.product_template_bfl_j40_210_b,BFL-J40-210.B/30,BFL-J40-210.B/O30,Terno BFL-J40-210.B,Talla: 30,39.04,0.00
+__import__.product_template_bfl_j40_210_b,BFL-J40-210.B/32,BFL-J40-210.B/O32,Terno BFL-J40-210.B,Talla: 32,39.04,0.00
+__import__.product_template_bfl_j40_210_b,BFL-J40-210.B/34,BFL-J40-210.B/O34,Terno BFL-J40-210.B,Talla: 34,39.04,0.00
+__import__.product_template_bfl_j40_210_b,BFL-J40-210.B/36,BFL-J40-210.B/O36,Terno BFL-J40-210.B,Talla: 36,39.04,0.00
+__import__.product_template_bfl_j40_210_b,BFL-J40-210.B/38,BFL-J40-210.B/O38,Terno BFL-J40-210.B,Talla: 38,39.04,0.00
+__import__.product_template_bfl_j40_210_b,BFL-J40-210.B/40,BFL-J40-210.B/O40,Terno BFL-J40-210.B,Talla: 40,39.04,0.00
+__import__.product_template_bfl_j40_208_b,BFL-J40-208.B/30,BFL-J40-208.B/O30,Terno BFL-J40-208.B,Talla: 30,39.04,0.00
+__import__.product_template_bfl_j40_208_b,BFL-J40-208.B/32,BFL-J40-208.B/O32,Terno BFL-J40-208.B,Talla: 32,39.04,0.00
+__import__.product_template_bfl_j40_208_b,BFL-J40-208.B/34,BFL-J40-208.B/O34,Terno BFL-J40-208.B,Talla: 34,39.04,0.00
+__import__.product_template_bfl_j40_208_b,BFL-J40-208.B/36,BFL-J40-208.B/O36,Terno BFL-J40-208.B,Talla: 36,39.04,0.00
+__import__.product_template_bfl_j40_208_b,BFL-J40-208.B/38,BFL-J40-208.B/O38,Terno BFL-J40-208.B,Talla: 38,39.04,0.00
+__import__.product_template_bfl_j40_208_b,BFL-J40-208.B/40,BFL-J40-208.B/O40,Terno BFL-J40-208.B,Talla: 40,39.04,0.00
+__import__.product_template_lbpc_m21_101f_ka,LBPC-M21-101F-KA/38,7448341253236,Terno LBPC-M21-101F-KA,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ka,LBPC-M21-101F-KA/36,7448332941951,Terno LBPC-M21-101F-KA,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ka,LBPC-M21-101F-KA/34,7448329387311,Terno LBPC-M21-101F-KA,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ka,LBPC-M21-101F-KA/32,7448348946964,Terno LBPC-M21-101F-KA,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ka,LBPC-M21-101F-KA/30,7448339353368,Terno LBPC-M21-101F-KA,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltge,LBPC-M21-101F-LTGE/38,7448330340343,Terno LBPC-M21-101F-LTGE,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltge,LBPC-M21-101F-LTGE/36,7448343563500,Terno LBPC-M21-101F-LTGE,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltge,LBPC-M21-101F-LTGE/34,7448337971922,Terno LBPC-M21-101F-LTGE,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltge,LBPC-M21-101F-LTGE/32,7448350918973,Terno LBPC-M21-101F-LTGE,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltge,LBPC-M21-101F-LTGE/30,7448332634600,Terno LBPC-M21-101F-LTGE,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ta,LBPC-M21-101F-TA/38,7448352876868,Terno LBPC-M21-101F-TA,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ta,LBPC-M21-101F-TA/36,7448331491419,Terno LBPC-M21-101F-TA,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ta,LBPC-M21-101F-TA/34,7448330066014,Terno LBPC-M21-101F-TA,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ta,LBPC-M21-101F-TA/32,7448337160142,Terno LBPC-M21-101F-TA,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ta,LBPC-M21-101F-TA/30,7448335339380,Terno LBPC-M21-101F-TA,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_m21_101f_sd,LBPC-M21-101F-SD/38,7448337264222,Terno LBPC-M21-101F-SD,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_sd,LBPC-M21-101F-SD/36,7448338272219,Terno LBPC-M21-101F-SD,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_sd,LBPC-M21-101F-SD/34,7448328788799,Terno LBPC-M21-101F-SD,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_sd,LBPC-M21-101F-SD/32,7448340368344,Terno LBPC-M21-101F-SD,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_sd,LBPC-M21-101F-SD/30,7448338121159,Terno LBPC-M21-101F-SD,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltbu,LBPC-M21-101F-LTBU/38,7448347866850,Terno LBPC-M21-101F-LTBU,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltbu,LBPC-M21-101F-LTBU/36,7448338710773,Terno LBPC-M21-101F-LTBU,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltbu,LBPC-M21-101F-LTBU/34,7448330485488,Terno LBPC-M21-101F-LTBU,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltbu,LBPC-M21-101F-LTBU/32,7448346642646,Terno LBPC-M21-101F-LTBU,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ltbu,LBPC-M21-101F-LTBU/30,7448334840825,Terno LBPC-M21-101F-LTBU,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_m21_101f_dknv,LBPC-M21-101F-DKNV/38,7448343221257,Terno LBPC-M21-101F-DKNV,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_dknv,LBPC-M21-101F-DKNV/36,7448333034034,Terno LBPC-M21-101F-DKNV,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_dknv,LBPC-M21-101F-DKNV/34,7448333575506,Terno LBPC-M21-101F-DKNV,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_dknv,LBPC-M21-101F-DKNV/32,7448337093075,Terno LBPC-M21-101F-DKNV,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_dknv,LBPC-M21-101F-DKNV/30,7448338983931,Terno LBPC-M21-101F-DKNV,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ca,LBPC-M21-101F-CA/38,7448337290269,Terno LBPC-M21-101F-CA,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ca,LBPC-M21-101F-CA/36,7448338991974,Terno LBPC-M21-101F-CA,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ca,LBPC-M21-101F-CA/34,7448329224227,Terno LBPC-M21-101F-CA,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ca,LBPC-M21-101F-CA/32,7448329460410,Terno LBPC-M21-101F-CA,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_ca,LBPC-M21-101F-CA/30,7448332840841,Terno LBPC-M21-101F-CA,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_m21_101f_bl,LBPC-M21-101F-BL/38,7448328482406,Terno LBPC-M21-101F-BL,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_m21_101f_bl,LBPC-M21-101F-BL/36,7448336268283,Terno LBPC-M21-101F-BL,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_m21_101f_bl,LBPC-M21-101F-BL/34,7448336814893,Terno LBPC-M21-101F-BL,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_m21_101f_bl,LBPC-M21-101F-BL/32,7448332288216,Terno LBPC-M21-101F-BL,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_m21_101f_bl,LBPC-M21-101F-BL/30,7448345623646,Terno LBPC-M21-101F-BL,Talla: 30,43.39,0.00
+__import__.product_template_opksb005_744,OPKSB005-744/XL,799016291143,POLO P/H M/C 100% ALGODÓN ORGANICO MISTED YELLOW,Talla: XL,56.43,0.00
+__import__.product_template_opksb005_744,OPKSB005-744/L,799016291136,POLO P/H M/C 100% ALGODÓN ORGANICO MISTED YELLOW,Talla: L,56.43,0.00
+__import__.product_template_opksb005_744,OPKSB005-744/M,799016291129,POLO P/H M/C 100% ALGODÓN ORGANICO MISTED YELLOW,Talla: M,56.43,0.00
+__import__.product_template_opksb005_744,OPKSB005-744/S,799016291112,POLO P/H M/C 100% ALGODÓN ORGANICO MISTED YELLOW,Talla: S,56.43,0.00
+__import__.product_template_opwb1204_413,OPWB1204-413/XL,7448331284271,H. CAMISA P/CABALLERO M/L PENGUIN DARK SAPHIRE,Talla: XL,86.87,0.00
+__import__.product_template_opwb1204_413,OPWB1204-413/L,7448338413452,H. CAMISA P/CABALLERO M/L PENGUIN DARK SAPHIRE,Talla: L,86.87,0.00
+__import__.product_template_opwb1204_413,OPWB1204-413/M,7448331367394,H. CAMISA P/CABALLERO M/L PENGUIN DARK SAPHIRE,Talla: M,86.87,0.00
+__import__.product_template_opwb1204_413,OPWB1204-413/S,7448342622628,H. CAMISA P/CABALLERO M/L PENGUIN DARK SAPHIRE,Talla: S,86.87,0.00
+__import__.product_template_opwb1204_673,OPWB1204-673/XL,7448333696621,H. CAMISA P/CABALLERO M/L PENGUIN PARFAIT PINK,Talla: XL,86.87,0.00
+__import__.product_template_opwb1204_673,OPWB1204-673/L,7448329372386,H. CAMISA P/CABALLERO M/L PENGUIN PARFAIT PINK,Talla: L,86.87,0.00
+__import__.product_template_opwb1204_673,OPWB1204-673/M,7448332728743,H. CAMISA P/CABALLERO M/L PENGUIN PARFAIT PINK,Talla: M,86.87,0.00
+__import__.product_template_opwb1204_673,OPWB1204-673/S,7448337447458,H. CAMISA P/CABALLERO M/L PENGUIN PARFAIT PINK,Talla: S,86.87,0.00
+__import__.product_template_opwb1204_601,OPWB1204-601/XL,7448339755773,H. CAMISA P/CABALLERO M/L PENGUIN RIO RED,Talla: XL,76.43,0.00
+__import__.product_template_opwb1204_601,OPWB1204-601/L,7448346241214,H. CAMISA P/CABALLERO M/L PENGUIN RIO RED,Talla: L,76.43,0.00
+__import__.product_template_opwb1204_601,OPWB1204-601/M,7448339093066,H. CAMISA P/CABALLERO M/L PENGUIN RIO RED,Talla: M,76.43,0.00
+__import__.product_template_opwb1204_601,OPWB1204-601/S,7448329456475,H. CAMISA P/CABALLERO M/L PENGUIN RIO RED,Talla: S,76.43,0.00
+__import__.product_template_opwb1204_118,OPWB1204-118/XL,7448330118102,H. CAMISA P/CABALLERO M/L PENGUIN BRIGHT WHITE,Talla: XL,76.43,0.00
+__import__.product_template_opwb1204_118,OPWB1204-118/L,7448328385301,H. CAMISA P/CABALLERO M/L PENGUIN BRIGHT WHITE,Talla: L,76.43,0.00
+__import__.product_template_opwb1204_118,OPWB1204-118/M,7448340665610,H. CAMISA P/CABALLERO M/L PENGUIN BRIGHT WHITE,Talla: M,76.43,0.00
+__import__.product_template_opwb1204_118,OPWB1204-118/S,7448329058068,H. CAMISA P/CABALLERO M/L PENGUIN BRIGHT WHITE,Talla: S,76.43,0.00
+__import__.product_template_lbpc_u31_203f_mt,LBPC-U31-203F-MT/XL,7448334112199,H. SUETER POLO M/C P/H LONG BEACH MINT,Talla: XL,21.65,0.00
+__import__.product_template_lbpc_u31_203f_mt,LBPC-U31-203F-MT/L,7448330518551,H. SUETER POLO M/C P/H LONG BEACH MINT,Talla: L,21.65,0.00
+__import__.product_template_lbpc_u31_203f_mt,LBPC-U31-203F-MT/M,7448331322386,H. SUETER POLO M/C P/H LONG BEACH MINT,Talla: M,21.65,0.00
+__import__.product_template_lbpc_u31_203f_mt,LBPC-U31-203F-MT/S,7448332320374,H. SUETER POLO M/C P/H LONG BEACH MINT,Talla: S,21.65,0.00
+__import__.product_template_lbpc_u31_203f_ltbu,LBPC-U31-203F-LTBU/XL,7448330246294,H. SUETER POLO M/C P/H LONG BEACH LIGHT BLUE,Talla: XL,21.65,0.00
+__import__.product_template_lbpc_u31_203f_ltbu,LBPC-U31-203F-LTBU/L,7448333620602,H. SUETER POLO M/C P/H LONG BEACH LIGHT BLUE,Talla: L,21.65,0.00
+__import__.product_template_lbpc_u31_203f_ltbu,LBPC-U31-203F-LTBU/M,7448332823844,H. SUETER POLO M/C P/H LONG BEACH LIGHT BLUE,Talla: M,21.65,0.00
+__import__.product_template_lbpc_u31_203f_ltbu,LBPC-U31-203F-LTBU/S,7448333384320,H. SUETER POLO M/C P/H LONG BEACH LIGHT BLUE,Talla: S,21.65,0.00
+__import__.product_template_lbpc_l23_011k_olbu,LBPC-L23-011K-OLBU/38,7448349247251,Terno LBPC-L23-011K-OLBU,Talla: 38,39.04,0.00
+__import__.product_template_lbpc_l23_011k_olbu,LBPC-L23-011K-OLBU/36,7448330073067,Terno LBPC-L23-011K-OLBU,Talla: 36,39.04,0.00
+__import__.product_template_lbpc_l23_011k_olbu,LBPC-L23-011K-OLBU/34,7448337496449,Terno LBPC-L23-011K-OLBU,Talla: 34,39.04,0.00
+__import__.product_template_lbpc_l23_011k_olbu,LBPC-L23-011K-OLBU/32,7448346632685,Terno LBPC-L23-011K-OLBU,Talla: 32,39.04,0.00
+__import__.product_template_lbpc_l23_011k_olbu,LBPC-L23-011K-OLBU/30,7448334693636,Terno LBPC-L23-011K-OLBU,Talla: 30,39.04,0.00
+__import__.product_template_lbpc_l23_018k_hbu,LBPC-L23-018K-HBU/38,7448340224237,Terno LBPC-L23-018K-HBU,Talla: 38,39.04,0.00
+__import__.product_template_lbpc_l23_018k_hbu,LBPC-L23-018K-HBU/36,7448335585589,Terno LBPC-L23-018K-HBU,Talla: 36,39.04,0.00
+__import__.product_template_lbpc_l23_018k_hbu,LBPC-L23-018K-HBU/34,7448349721737,Terno LBPC-L23-018K-HBU,Talla: 34,39.04,0.00
+__import__.product_template_lbpc_l23_018k_hbu,LBPC-L23-018K-HBU/32,7448329966912,Terno LBPC-L23-018K-HBU,Talla: 32,39.04,0.00
+__import__.product_template_lbpc_l23_018k_hbu,LBPC-L23-018K-HBU/30,7448330030060,Terno LBPC-L23-018K-HBU,Talla: 30,39.04,0.00
+__import__.product_template_lbpc_l23_016s_bl,LBPC-L23-016S-BL/38,7448342453444,Terno LBPC-L23-016S-BL,Talla: 38,39.04,0.00
+__import__.product_template_lbpc_l23_016s_bl,LBPC-L23-016S-BL/36,7448332734706,Terno LBPC-L23-016S-BL,Talla: 36,39.04,0.00
+__import__.product_template_lbpc_l23_016s_bl,LBPC-L23-016S-BL/34,7448344433406,Terno LBPC-L23-016S-BL,Talla: 34,39.04,0.00
+__import__.product_template_lbpc_l23_016s_bl,LBPC-L23-016S-BL/32,7448332263282,Terno LBPC-L23-016S-BL,Talla: 32,39.04,0.00
+__import__.product_template_lbpc_l23_016s_bl,LBPC-L23-016S-BL/30,7448330747791,Terno LBPC-L23-016S-BL,Talla: 30,39.04,0.00
+__import__.product_template_lbpc_l23_001k_bl,LBPC-L23-001K-BL/30,7448334999905,Terno LBPC-L23-001K-BL,Talla: 30,39.04,0.00
+__import__.product_template_lbpc_l23_001k_bl,LBPC-L23-001K-BL/32,7448333231259,Terno LBPC-L23-001K-BL,Talla: 32,39.04,0.00
+__import__.product_template_lbpc_l23_001k_bl,LBPC-L23-001K-BL/34,7448342225287,Terno LBPC-L23-001K-BL,Talla: 34,39.04,0.00
+__import__.product_template_lbpc_l23_001k_bl,LBPC-L23-001K-BL/36,7448331728782,Terno LBPC-L23-001K-BL,Talla: 36,39.04,0.00
+__import__.product_template_lbpc_l23_001k_bl,LBPC-L23-001K-BL/38,7448332649611,Terno LBPC-L23-001K-BL,Talla: 38,39.04,0.00
+__import__.product_template_lbpc_l23_005s_nv,LBPC-L23-005S-NV/30,7448334328354,Terno LBPC-L23-005S-NV,Talla: 30,39.04,0.00
+__import__.product_template_lbpc_l23_005s_nv,LBPC-L23-005S-NV/32,7448331632638,Terno LBPC-L23-005S-NV,Talla: 32,39.04,0.00
+__import__.product_template_lbpc_l23_005s_nv,LBPC-L23-005S-NV/34,7448350095032,Terno LBPC-L23-005S-NV,Talla: 34,39.04,0.00
+__import__.product_template_lbpc_l23_005s_nv,LBPC-L23-005S-NV/36,7448337342319,Terno LBPC-L23-005S-NV,Talla: 36,39.04,0.00
+__import__.product_template_lbpc_l23_005s_nv,LBPC-L23-005S-NV/38,7448334476406,Terno LBPC-L23-005S-NV,Talla: 38,39.04,0.00
+__import__.product_template_lbpc_l23_016k_bl,LBPC-L23-016K-BL/30,7448333340395,Terno LBPC-L23-016K-BL,Talla: 30,39.04,0.00
+__import__.product_template_lbpc_l23_016k_bl,LBPC-L23-016K-BL/32,7448332125139,Terno LBPC-L23-016K-BL,Talla: 32,39.04,0.00
+__import__.product_template_lbpc_l23_016k_bl,LBPC-L23-016K-BL/34,7448342958994,Terno LBPC-L23-016K-BL,Talla: 34,39.04,0.00
+__import__.product_template_lbpc_l23_016k_bl,LBPC-L23-016K-BL/36,7448339364357,Terno LBPC-L23-016K-BL,Talla: 36,39.04,0.00
+__import__.product_template_lbpc_l23_016k_bl,LBPC-L23-016K-BL/38,7448344673680,Terno LBPC-L23-016K-BL,Talla: 38,39.04,0.00
+__import__.product_template_zp_ml_h_cassini,ZP-ML-H-CASSINI/10,ZPMLHCASS/O10,Zapato ZP-ML-H-CASSINI,Talla: 10,152.09,0.00
+__import__.product_template_zp_ml_h_cassini,ZP-ML-H-CASSINI/9.5,ZPMLHCASS/O9.5,Zapato ZP-ML-H-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_ml_h_cassini,ZP-ML-H-CASSINI/9,ZPMLHCASS/O9,Zapato ZP-ML-H-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_ml_h_cassini,ZP-ML-H-CASSINI/8.5,ZPMLHCASS/O8.5,Zapato ZP-ML-H-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_ml_h_cassini,ZP-ML-H-CASSINI/8,ZPMLHCASS/O8,Zapato ZP-ML-H-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_ml_h_cassini,ZP-ML-H-CASSINI/7.5,ZPMLHCASS/O7.5,Zapato ZP-ML-H-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_pt_22e2712_1a,PT-22E2712-1A/28,PT-22E2712-1A/O28,Pantalon PT-22E2712-1A,Talla: 28,56.43,0.00
+__import__.product_template_pt_22e2712_1a,PT-22E2712-1A/30,PT-22E2712-1A/O30,Pantalon PT-22E2712-1A,Talla: 30,56.43,0.00
+__import__.product_template_pt_22e2712_1a,PT-22E2712-1A/32,PT-22E2712-1A/O32,Pantalon PT-22E2712-1A,Talla: 32,56.43,0.00
+__import__.product_template_pt_22e2712_1a,PT-22E2712-1A/34,PT-22E2712-1A/O34,Pantalon PT-22E2712-1A,Talla: 34,56.43,0.00
+__import__.product_template_pt_22e2712_1a,PT-22E2712-1A/36,PT-22E2712-1A/O36,Pantalon PT-22E2712-1A,Talla: 36,56.43,0.00
+__import__.product_template_pt_22e2712_1a,PT-22E2712-1A/38,PT-22E2712-1A/O38,Pantalon PT-22E2712-1A,Talla: 38,56.43,0.00
+__import__.product_template_pt_22e2712_1a,PT-22E2712-1A/40,PT-22E2712-1A/O40,Pantalon PT-22E2712-1A,Talla: 40,56.43,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/10,ZPCASSPSPTCOF/O10,Zapato ZP-CASSINI-PS-PT-COF,Talla: 10,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/9.5,ZPCASSPSPTCOF/O9.5,Zapato ZP-CASSINI-PS-PT-COF,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/9,ZPCASSPSPTCOF/O9,Zapato ZP-CASSINI-PS-PT-COF,Talla: 9,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/8.5,ZPCASSPSPTCOF/O8.5,Zapato ZP-CASSINI-PS-PT-COF,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/8,ZPCASSPSPTCOF/O8,Zapato ZP-CASSINI-PS-PT-COF,Talla: 8,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_cof,ZP-CASSINI-PS-PT-COF/7.5,ZPCASSPSPTCOF/O7.5,Zapato ZP-CASSINI-PS-PT-COF,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/7.5,ZPCASSPSPTBRW/O7.5,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/10,ZPCASSPSPTBRW/O10,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 10,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/9.5,ZPCASSPSPTBRW/O9.5,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/9,ZPCASSPSPTBRW/O9,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 9,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/8.5,ZPCASSPSPTBRW/O8.5,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/7.5,ZPCASSPSPTBLK/O7.5,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/8,ZPCASSPSPTBLK/O8,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 8,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/8.5,ZPCASSPSPTBLK/O8.5,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/9,ZPCASSPSPTBLK/O9,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 9,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/9.5,ZPCASSPSPTBLK/O9.5,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_blk,ZP-CASSINI-PS-PT-BLK/10,ZPCASSPSPTBLK/O10,Zapato ZP-CASSINI-PS-PT-BLK,Talla: 10,152.09,0.00
+__import__.product_template_zp_cassini_ps_pt_brw,ZP-CASSINI-PS-PT-BRW/8,ZPCASSPSPTBRW/O8,Zapato ZP-CASSINI-PS-PT-BRW,Talla: 8,152.09,0.00
+__import__.product_template_bfl_f30_205_rd,BFL-F30-205-RD/S,BFL-F30-205-RD/OS,H. CAMISETA P/CABALLERO BFL RED,Talla: S,30.35,0.00
+__import__.product_template_bfl_f30_205_rd,BFL-F30-205-RD/M,BFL-F30-205-RD/OM,H. CAMISETA P/CABALLERO BFL RED,Talla: M,30.35,0.00
+__import__.product_template_bfl_f30_205_rd,BFL-F30-205-RD/L,BFL-F30-205-RD/OL,H. CAMISETA P/CABALLERO BFL RED,Talla: L,30.35,0.00
+__import__.product_template_bfl_f30_205_rd,BFL-F30-205-RD/XL,BFL-F30-205-RD/OXL,H. CAMISETA P/CABALLERO BFL RED,Talla: XL,30.35,0.00
+__import__.product_template_bfl_f30_205_bk,BFL-F30-205-BK/S,BFL-F30-205-BK/OS,H. CAMISETA P/CABALLERO BFL BLACK,Talla: S,30.35,0.00
+__import__.product_template_bfl_f30_205_bk,BFL-F30-205-BK/M,BFL-F30-205-BK/OM,H. CAMISETA P/CABALLERO BFL BLACK,Talla: M,30.35,0.00
+__import__.product_template_bfl_f30_205_bk,BFL-F30-205-BK/L,BFL-F30-205-BK/OL,H. CAMISETA P/CABALLERO BFL BLACK,Talla: L,30.35,0.00
+__import__.product_template_bfl_f30_205_bk,BFL-F30-205-BK/XL,BFL-F30-205-BK/OXL,H. CAMISETA P/CABALLERO BFL BLACK,Talla: XL,30.35,0.00
+__import__.product_template_bfl_f30_205_ry,BFL-F30-205-RY/S,BFL-F30-205-RY/OS,H. CAMISETA P/CABALLERO BFL ROYAL,Talla: S,30.35,0.00
+__import__.product_template_bfl_f30_205_ry,BFL-F30-205-RY/M,BFL-F30-205-RY/OM,H. CAMISETA P/CABALLERO BFL ROYAL,Talla: M,30.35,0.00
+__import__.product_template_bfl_f30_205_ry,BFL-F30-205-RY/L,BFL-F30-205-RY/OL,H. CAMISETA P/CABALLERO BFL ROYAL,Talla: L,30.35,0.00
+__import__.product_template_bfl_f30_205_ry,BFL-F30-205-RY/XL,BFL-F30-205-RY/OXL,H. CAMISETA P/CABALLERO BFL ROYAL,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702c_cor,BFL-30-702C-COR/M,BFL-30-702C-COR/OM,H. CAMISETA P/CABALLERO BFL CORAL,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702c_aq,BFL-30-702C-AQ/XL,BFL-30-702C-AQ/OXL,H. CAMISETA P/CABALLERO BFL AQUA,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702c_aq,BFL-30-702C-AQ/L,BFL-30-702C-AQ/OL,H. CAMISETA P/CABALLERO BFL AQUA,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702c_aq,BFL-30-702C-AQ/M,BFL-30-702C-AQ/OM,H. CAMISETA P/CABALLERO BFL AQUA,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702c_aq,BFL-30-702C-AQ/S,BFL-30-702C-AQ/OS,H. CAMISETA P/CABALLERO BFL AQUA,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702c_cor,BFL-30-702C-COR/XL,BFL-30-702C-COR/OXL,H. CAMISETA P/CABALLERO BFL CORAL,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702c_cor,BFL-30-702C-COR/L,BFL-30-702C-COR/OL,H. CAMISETA P/CABALLERO BFL CORAL,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702c_cor,BFL-30-702C-COR/S,BFL-30-702C-COR/OS,H. CAMISETA P/CABALLERO BFL CORAL,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702c_es,BFL-30-702C-ES/XL,BFL-30-702C-ES/OXL,H. CAMISETA P/CABALLERO BFL ESMERALD,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702c_es,BFL-30-702C-ES/L,BFL-30-702C-ES/OL,H. CAMISETA P/CABALLERO BFL ESMERALD,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702c_es,BFL-30-702C-ES/M,BFL-30-702C-ES/OM,H. CAMISETA P/CABALLERO BFL ESMERALD,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702c_es,BFL-30-702C-ES/S,BFL-30-702C-ES/OS,H. CAMISETA P/CABALLERO BFL ESMERALD,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702c_co,BFL-30-702C-CO/XL,BFL-30-702C-CO/OXL,H. CAMISETA P/CABALLERO BFL CORN,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702c_co,BFL-30-702C-CO/L,BFL-30-702C-CO/OL,H. CAMISETA P/CABALLERO BFL CORN,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702c_co,BFL-30-702C-CO/M,BFL-30-702C-CO/OM,H. CAMISETA P/CABALLERO BFL CORN,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702c_co,BFL-30-702C-CO/S,BFL-30-702C-CO/OS,H. CAMISETA P/CABALLERO BFL CORN,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702c_ry,BFL-30-702C-RY/XL,BFL-30-702C-RY/OXL,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702c_ry),Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702c_ry,BFL-30-702C-RY/L,BFL-30-702C-RY/OL,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702c_ry),Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702c_ry,BFL-30-702C-RY/M,BFL-30-702C-RY/OM,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702c_ry),Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702c_ry,BFL-30-702C-RY/S,BFL-30-702C-RY/OS,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702c_ry),Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702c_wh,BFL-30-702C-WH/XL,BFL-30-702C-WH/OXL,H. CAMISETA P/CABALLERO BFL WHITE,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702c_wh,BFL-30-702C-WH/L,BFL-30-702C-WH/OL,H. CAMISETA P/CABALLERO BFL WHITE,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702c_wh,BFL-30-702C-WH/M,BFL-30-702C-WH/OM,H. CAMISETA P/CABALLERO BFL WHITE,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702c_wh,BFL-30-702C-WH/S,BFL-30-702C-WH/OS,H. CAMISETA P/CABALLERO BFL WHITE,Talla: S,30.35,0.00
+__import__.product_template_tl_u23_102c_a_na,TL-U23-102C.A-NA/40,TL-U23-102C.A-NA/O40,Terno TL-U23-102C.A-NA,Talla: 40,43.39,0.00
+__import__.product_template_tl_u23_102c_a_na,TL-U23-102C.A-NA/38,TL-U23-102C.A-NA/O38,Terno TL-U23-102C.A-NA,Talla: 38,43.39,0.00
+__import__.product_template_tl_u23_102c_a_na,TL-U23-102C.A-NA/36,TL-U23-102C.A-NA/O36,Terno TL-U23-102C.A-NA,Talla: 36,43.39,0.00
+__import__.product_template_tl_u23_102c_a_na,TL-U23-102C.A-NA/34,TL-U23-102C.A-NA/O34,Terno TL-U23-102C.A-NA,Talla: 34,43.39,0.00
+__import__.product_template_tl_u23_102c_a_na,TL-U23-102C.A-NA/32,TL-U23-102C.A-NA/O32,Terno TL-U23-102C.A-NA,Talla: 32,43.39,0.00
+__import__.product_template_tl_u23_102c_a_na,TL-U23-102C.A-NA/30,TL-U23-102C.A-NA/O30,Terno TL-U23-102C.A-NA,Talla: 30,43.39,0.00
+__import__.product_template_tl_u23_102b_a_kh,TL-U23-102B.A-KH/40,TL-U23-102B.A-KH/O40,Terno TL-U23-102B.A-KH,Talla: 40,43.39,0.00
+__import__.product_template_tl_u23_102b_a_kh,TL-U23-102B.A-KH/38,TL-U23-102B.A-KH/O38,Terno TL-U23-102B.A-KH,Talla: 38,43.39,0.00
+__import__.product_template_tl_u23_102b_a_kh,TL-U23-102B.A-KH/36,TL-U23-102B.A-KH/O36,Terno TL-U23-102B.A-KH,Talla: 36,43.39,0.00
+__import__.product_template_tl_u23_102b_a_kh,TL-U23-102B.A-KH/34,TL-U23-102B.A-KH/O34,Terno TL-U23-102B.A-KH,Talla: 34,43.39,0.00
+__import__.product_template_tl_u23_102b_a_kh,TL-U23-102B.A-KH/32,TL-U23-102B.A-KH/O32,Terno TL-U23-102B.A-KH,Talla: 32,43.39,0.00
+__import__.product_template_tl_u23_102b_a_kh,TL-U23-102B.A-KH/30,TL-U23-102B.A-KH/O30,Terno TL-U23-102B.A-KH,Talla: 30,43.39,0.00
+__import__.product_template_tl_u23_102a_a_sa,TL-U23-102A.A-SA/40,TL-U23-102A.A-SA/O40,Terno TL-U23-102A.A-SA,Talla: 40,43.39,0.00
+__import__.product_template_tl_u23_102a_a_sa,TL-U23-102A.A-SA/38,TL-U23-102A.A-SA/O38,Terno TL-U23-102A.A-SA,Talla: 38,43.39,0.00
+__import__.product_template_tl_u23_102a_a_sa,TL-U23-102A.A-SA/36,TL-U23-102A.A-SA/O36,Terno TL-U23-102A.A-SA,Talla: 36,43.39,0.00
+__import__.product_template_tl_u23_102a_a_sa,TL-U23-102A.A-SA/34,TL-U23-102A.A-SA/O34,Terno TL-U23-102A.A-SA,Talla: 34,43.39,0.00
+__import__.product_template_tl_u23_102a_a_sa,TL-U23-102A.A-SA/32,TL-U23-102A.A-SA/O32,Terno TL-U23-102A.A-SA,Talla: 32,43.39,0.00
+__import__.product_template_tl_u23_102a_a_sa,TL-U23-102A.A-SA/30,TL-U23-102A.A-SA/O30,Terno TL-U23-102A.A-SA,Talla: 30,43.39,0.00
+__import__.product_template_tl_t25_501e_a_lt,TL-T25-501E.A-LT/40,TL-T25-501E.A-LT/O40,Terno TL-T25-501E.A-LT,Talla: 40,34.70,0.00
+__import__.product_template_tl_t25_501e_a_lt,TL-T25-501E.A-LT/38,TL-T25-501E.A-LT/O38,Terno TL-T25-501E.A-LT,Talla: 38,34.70,0.00
+__import__.product_template_tl_t25_501e_a_lt,TL-T25-501E.A-LT/36,TL-T25-501E.A-LT/O36,Terno TL-T25-501E.A-LT,Talla: 36,34.70,0.00
+__import__.product_template_tl_t25_501e_a_lt,TL-T25-501E.A-LT/34,TL-T25-501E.A-LT/O34,Terno TL-T25-501E.A-LT,Talla: 34,34.70,0.00
+__import__.product_template_tl_t25_501e_a_lt,TL-T25-501E.A-LT/32,TL-T25-501E.A-LT/O32,Terno TL-T25-501E.A-LT,Talla: 32,34.70,0.00
+__import__.product_template_tl_t25_501e_a_lt,TL-T25-501E.A-LT/30,TL-T25-501E.A-LT/O30,Terno TL-T25-501E.A-LT,Talla: 30,34.70,0.00
+__import__.product_template_tl_t25_501c_a_na,TL-T25-501C.A-NA/40,TL-T25-501C.A-NA/O40,Terno TL-T25-501C.A-NA,Talla: 40,34.70,0.00
+__import__.product_template_tl_t25_501c_a_na,TL-T25-501C.A-NA/38,TL-T25-501C.A-NA/O38,Terno TL-T25-501C.A-NA,Talla: 38,34.70,0.00
+__import__.product_template_tl_t25_501c_a_na,TL-T25-501C.A-NA/36,TL-T25-501C.A-NA/O36,Terno TL-T25-501C.A-NA,Talla: 36,34.70,0.00
+__import__.product_template_tl_t25_501c_a_na,TL-T25-501C.A-NA/34,TL-T25-501C.A-NA/O34,Terno TL-T25-501C.A-NA,Talla: 34,34.70,0.00
+__import__.product_template_tl_t25_501c_a_na,TL-T25-501C.A-NA/32,TL-T25-501C.A-NA/O32,Terno TL-T25-501C.A-NA,Talla: 32,34.70,0.00
+__import__.product_template_tl_t25_501c_a_na,TL-T25-501C.A-NA/30,TL-T25-501C.A-NA/O30,Terno TL-T25-501C.A-NA,Talla: 30,34.70,0.00
+__import__.product_template_tl_t25_507c_a_wh,TL-T25-507C.A-WH/40,TL-T25-507C.A-WH/O40,Terno TL-T25-507C.A-WH,Talla: 40,34.70,0.00
+__import__.product_template_tl_t25_507c_a_wh,TL-T25-507C.A-WH/38,TL-T25-507C.A-WH/O38,Terno TL-T25-507C.A-WH,Talla: 38,34.70,0.00
+__import__.product_template_tl_t25_507c_a_wh,TL-T25-507C.A-WH/36,TL-T25-507C.A-WH/O36,Terno TL-T25-507C.A-WH,Talla: 36,34.70,0.00
+__import__.product_template_tl_t25_507c_a_wh,TL-T25-507C.A-WH/34,TL-T25-507C.A-WH/O34,Terno TL-T25-507C.A-WH,Talla: 34,34.70,0.00
+__import__.product_template_tl_t25_507c_a_wh,TL-T25-507C.A-WH/32,TL-T25-507C.A-WH/O32,Terno TL-T25-507C.A-WH,Talla: 32,34.70,0.00
+__import__.product_template_tl_t25_507c_a_wh,TL-T25-507C.A-WH/30,TL-T25-507C.A-WH/O30,Terno TL-T25-507C.A-WH,Talla: 30,34.70,0.00
+__import__.product_template_tl_t25_501a_a_sa,TL-T25-501A.A-SA/30,TL-T25-501A.A-SA/O30,Terno TL-T25-501A.A-SA,Talla: 30,34.70,0.00
+__import__.product_template_tl_t25_501a_a_sa,TL-T25-501A.A-SA/32,TL-T25-501A.A-SA/O32,Terno TL-T25-501A.A-SA,Talla: 32,34.70,0.00
+__import__.product_template_tl_t25_501a_a_sa,TL-T25-501A.A-SA/34,TL-T25-501A.A-SA/O34,Terno TL-T25-501A.A-SA,Talla: 34,34.70,0.00
+__import__.product_template_tl_t25_501a_a_sa,TL-T25-501A.A-SA/36,TL-T25-501A.A-SA/O36,Terno TL-T25-501A.A-SA,Talla: 36,34.70,0.00
+__import__.product_template_tl_t25_501a_a_sa,TL-T25-501A.A-SA/38,TL-T25-501A.A-SA/O38,Terno TL-T25-501A.A-SA,Talla: 38,34.70,0.00
+__import__.product_template_tl_t25_501a_a_sa,TL-T25-501A.A-SA/40,TL-T25-501A.A-SA/O40,Terno TL-T25-501A.A-SA,Talla: 40,34.70,0.00
+__import__.product_template_tl_t25_507b_a_na,TL-T25-507B.A-NA/30,TL-T25-507B.A-NA/O30,Terno TL-T25-507B.A-NA,Talla: 30,34.70,0.00
+__import__.product_template_tl_t25_507b_a_na,TL-T25-507B.A-NA/32,TL-T25-507B.A-NA/O32,Terno TL-T25-507B.A-NA,Talla: 32,34.70,0.00
+__import__.product_template_tl_t25_507b_a_na,TL-T25-507B.A-NA/34,TL-T25-507B.A-NA/O34,Terno TL-T25-507B.A-NA,Talla: 34,34.70,0.00
+__import__.product_template_tl_t25_507b_a_na,TL-T25-507B.A-NA/36,TL-T25-507B.A-NA/O36,Terno TL-T25-507B.A-NA,Talla: 36,34.70,0.00
+__import__.product_template_tl_t25_507b_a_na,TL-T25-507B.A-NA/38,TL-T25-507B.A-NA/O38,Terno TL-T25-507B.A-NA,Talla: 38,34.70,0.00
+__import__.product_template_tl_t25_507b_a_na,TL-T25-507B.A-NA/40,TL-T25-507B.A-NA/O40,Terno TL-T25-507B.A-NA,Talla: 40,34.70,0.00
+__import__.product_template_tl_t30_206a_a_lt,TL-T30-206A.A-LT/S,TL-T30-206A.A-LT/OS,H. POLO P/CABALLERO TED LAPIDUS LT. BLUE,Talla: S,21.65,0.00
+__import__.product_template_tl_t30_206a_a_lt,TL-T30-206A.A-LT/M,TL-T30-206A.A-LT/OM,H. POLO P/CABALLERO TED LAPIDUS LT. BLUE,Talla: M,21.65,0.00
+__import__.product_template_tl_t30_206a_a_lt,TL-T30-206A.A-LT/L,TL-T30-206A.A-LT/OL,H. POLO P/CABALLERO TED LAPIDUS LT. BLUE,Talla: L,21.65,0.00
+__import__.product_template_tl_t30_206a_a_lt,TL-T30-206A.A-LT/XL,TL-T30-206A.A-LT/OXL,H. POLO P/CABALLERO TED LAPIDUS LT. BLUE,Talla: XL,21.65,0.00
+__import__.product_template_tl_t30_208b_a_na,TL-T30-208B.A-NA/S,TL-T30-208B.A-NA/OS,H. POLO P/CABALLERO TED LAPIDUS NAVY,Talla: S,21.65,0.00
+__import__.product_template_tl_t30_208b_a_na,TL-T30-208B.A-NA/M,TL-T30-208B.A-NA/OM,H. POLO P/CABALLERO TED LAPIDUS NAVY,Talla: M,21.65,0.00
+__import__.product_template_tl_t30_208b_a_na,TL-T30-208B.A-NA/L,TL-T30-208B.A-NA/OL,H. POLO P/CABALLERO TED LAPIDUS NAVY,Talla: L,21.65,0.00
+__import__.product_template_tl_t30_208b_a_na,TL-T30-208B.A-NA/XL,TL-T30-208B.A-NA/OXL,H. POLO P/CABALLERO TED LAPIDUS NAVY,Talla: XL,21.65,0.00
+__import__.product_template_tl_u03_226a_a_wh,TL-U03-226A.A-WH/S,TL-U03-226A.A-WH/OS,H. CAMISA P/CABALLERO M/L TED LAPIDUS NAVY,Talla: S,39.91,0.00
+__import__.product_template_tl_u03_418c_a_bk,TL-U03-418C.A-BK/XL,TL-U03-418C.A-BK/OXL,H. CAMISA P/CABALLERO M/L TED LAPIDUS BLACK,Talla: XL,39.91,0.00
+__import__.product_template_tl_u03_418c_a_bk,TL-U03-418C.A-BK/L,TL-U03-418C.A-BK/OL,H. CAMISA P/CABALLERO M/L TED LAPIDUS BLACK,Talla: L,39.91,0.00
+__import__.product_template_tl_u03_418c_a_bk,TL-U03-418C.A-BK/M,TL-U03-418C.A-BK/OM,H. CAMISA P/CABALLERO M/L TED LAPIDUS BLACK,Talla: M,39.91,0.00
+__import__.product_template_tl_u03_418c_a_bk,TL-U03-418C.A-BK/S,TL-U03-418C.A-BK/OS,H. CAMISA P/CABALLERO M/L TED LAPIDUS BLACK,Talla: S,39.91,0.00
+__import__.product_template_tl_u03_418a_a_wh,TL-U03-418A.A-WH/XL,TL-U03-418A.A-WH/OXL,H. CAMISA P/CABALLERO M/L TED LAPIDUS WHITE,Talla: XL,39.91,0.00
+__import__.product_template_tl_u03_418a_a_wh,TL-U03-418A.A-WH/L,TL-U03-418A.A-WH/OL,H. CAMISA P/CABALLERO M/L TED LAPIDUS WHITE,Talla: L,39.91,0.00
+__import__.product_template_tl_u03_418a_a_wh,TL-U03-418A.A-WH/M,TL-U03-418A.A-WH/OM,H. CAMISA P/CABALLERO M/L TED LAPIDUS WHITE,Talla: M,39.91,0.00
+__import__.product_template_tl_u03_418a_a_wh,TL-U03-418A.A-WH/S,TL-U03-418A.A-WH/OS,H. CAMISA P/CABALLERO M/L TED LAPIDUS WHITE,Talla: S,39.91,0.00
+__import__.product_template_tl_u03_226a_a_wh,TL-U03-226A.A-WH/XL,TL-U03-226A.A-WH/OXL,H. CAMISA P/CABALLERO M/L TED LAPIDUS NAVY,Talla: XL,39.91,0.00
+__import__.product_template_tl_u03_226a_a_wh,TL-U03-226A.A-WH/L,TL-U03-226A.A-WH/OL,H. CAMISA P/CABALLERO M/L TED LAPIDUS NAVY,Talla: L,39.91,0.00
+__import__.product_template_tl_u03_226a_a_wh,TL-U03-226A.A-WH/M,TL-U03-226A.A-WH/OM,H. CAMISA P/CABALLERO M/L TED LAPIDUS NAVY,Talla: M,39.91,0.00
+__import__.product_template_tl_u04_202_a_bu,TL-U04-202.A-BU/XL,TL-U04-202.A-BU/OXL,H. CAMISA P/CABALLERO M/C TED LAPIDUS BLUE,Talla: XL,37.30,0.00
+__import__.product_template_tl_u04_202_a_bu,TL-U04-202.A-BU/L,TL-U04-202.A-BU/OL,H. CAMISA P/CABALLERO M/C TED LAPIDUS BLUE,Talla: L,37.30,0.00
+__import__.product_template_tl_u04_202_a_bu,TL-U04-202.A-BU/M,TL-U04-202.A-BU/OM,H. CAMISA P/CABALLERO M/C TED LAPIDUS BLUE,Talla: M,37.30,0.00
+__import__.product_template_tl_u04_202_a_bu,TL-U04-202.A-BU/S,TL-U04-202.A-BU/OS,H. CAMISA P/CABALLERO M/C TED LAPIDUS BLUE,Talla: S,37.30,0.00
+__import__.product_template_tl_t04_201a_a_rd,TL-T04-201A.A-RD/XL,TL-T04-201A.A-RD/OXL,H. CAMISA P/CABALLERO M/C TED LAPIDUS RED,Talla: XL,37.30,0.00
+__import__.product_template_tl_t04_201a_a_rd,TL-T04-201A.A-RD/L,TL-T04-201A.A-RD/OL,H. CAMISA P/CABALLERO M/C TED LAPIDUS RED,Talla: L,37.30,0.00
+__import__.product_template_tl_t04_201a_a_rd,TL-T04-201A.A-RD/M,TL-T04-201A.A-RD/OM,H. CAMISA P/CABALLERO M/C TED LAPIDUS RED,Talla: M,37.30,0.00
+__import__.product_template_tl_t04_201a_a_rd,TL-T04-201A.A-RD/S,TL-T04-201A.A-RD/OS,H. CAMISA P/CABALLERO M/C TED LAPIDUS RED,Talla: S,37.30,0.00
+__import__.product_template_bfl_30_702b_wh,BFL-30-702B-WH/S,BFL-30-702B-WH/OS,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702b_wh),Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702b_wh,BFL-30-702B-WH/M,BFL-30-702B-WH/OM,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702b_wh),Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702b_wh,BFL-30-702B-WH/L,BFL-30-702B-WH/OL,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702b_wh),Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702b_wh,BFL-30-702B-WH/XL,BFL-30-702B-WH/OXL,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702b_wh),Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702b_bk,BFL-30-702B-BK/S,BFL-30-702B-BK/OS,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702b_bk),Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702b_bk,BFL-30-702B-BK/M,BFL-30-702B-BK/OM,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702b_bk),Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702b_bk,BFL-30-702B-BK/L,BFL-30-702B-BK/OL,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702b_bk),Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702b_bk,BFL-30-702B-BK/XL,BFL-30-702B-BK/OXL,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702b_bk),Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702b_co,BFL-30-702B-CO/S,BFL-30-702B-CO/OS,H. CAMISETA P/CABALLERO BFL COLONY,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702b_co,BFL-30-702B-CO/M,BFL-30-702B-CO/OM,H. CAMISETA P/CABALLERO BFL COLONY,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702b_co,BFL-30-702B-CO/L,BFL-30-702B-CO/OL,H. CAMISETA P/CABALLERO BFL COLONY,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702b_co,BFL-30-702B-CO/XL,BFL-30-702B-CO/OXL,H. CAMISETA P/CABALLERO BFL COLONY,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702b_bu,BFL-30-702B-BU/S,BFL-30-702B-BU/OS,H. CAMISETA P/CABALLERO BFL BURGUNDY,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702b_bu,BFL-30-702B-BU/M,BFL-30-702B-BU/OM,H. CAMISETA P/CABALLERO BFL BURGUNDY,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702b_bu,BFL-30-702B-BU/L,BFL-30-702B-BU/OL,H. CAMISETA P/CABALLERO BFL BURGUNDY,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702b_bu,BFL-30-702B-BU/XL,BFL-30-702B-BU/OXL,H. CAMISETA P/CABALLERO BFL BURGUNDY,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702b_mu,BFL-30-702B-MU/S,BFL-30-702B-MU/OS,H. CAMISETA P/CABALLERO BFL MUSTARD,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702b_mu,BFL-30-702B-MU/M,BFL-30-702B-MU/OM,H. CAMISETA P/CABALLERO BFL MUSTARD,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702b_mu,BFL-30-702B-MU/L,BFL-30-702B-MU/OL,H. CAMISETA P/CABALLERO BFL MUSTARD,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702b_mu,BFL-30-702B-MU/XL,BFL-30-702B-MU/OXL,H. CAMISETA P/CABALLERO BFL MUSTARD,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702_wh,BFL-30-702-WH/S,BFL-30-702-WH/OS,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702_wh),Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702_wh,BFL-30-702-WH/M,BFL-30-702-WH/OM,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702_wh),Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702_wh,BFL-30-702-WH/L,BFL-30-702-WH/OL,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702_wh),Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702_wh,BFL-30-702-WH/XL,BFL-30-702-WH/OXL,H. CAMISETA P/CABALLERO BFL WHITE (bfl_30_702_wh),Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702_bk,BFL-30-702-BK/S,BFL-30-702-BK/OS,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702_bk),Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702_bk,BFL-30-702-BK/M,BFL-30-702-BK/OM,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702_bk),Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702_bk,BFL-30-702-BK/L,BFL-30-702-BK/OL,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702_bk),Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702_bk,BFL-30-702-BK/XL,BFL-30-702-BK/OXL,H. CAMISETA P/CABALLERO BFL BLACK (bfl_30_702_bk),Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702_nv,BFL-30-702-NV/S,BFL-30-702-NV/OS,H. CAMISETA P/CABALLERO BFL NAVY,Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702_nv,BFL-30-702-NV/M,BFL-30-702-NV/OM,H. CAMISETA P/CABALLERO BFL NAVY,Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702_nv,BFL-30-702-NV/L,BFL-30-702-NV/OL,H. CAMISETA P/CABALLERO BFL NAVY,Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702_nv,BFL-30-702-NV/XL,BFL-30-702-NV/OXL,H. CAMISETA P/CABALLERO BFL NAVY,Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702_rd,BFL-30-702-RD/S,BFL-30-702-RD/OS,H. CAMISETA P/CABALLERO BFL RED (bfl_30_702_rd),Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702_rd,BFL-30-702-RD/M,BFL-30-702-RD/OM,H. CAMISETA P/CABALLERO BFL RED (bfl_30_702_rd),Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702_rd,BFL-30-702-RD/L,BFL-30-702-RD/OL,H. CAMISETA P/CABALLERO BFL RED (bfl_30_702_rd),Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702_rd,BFL-30-702-RD/XL,BFL-30-702-RD/OXL,H. CAMISETA P/CABALLERO BFL RED (bfl_30_702_rd),Talla: XL,30.35,0.00
+__import__.product_template_bfl_30_702_ry,BFL-30-702-RY/S,BFL-30-702-RY/OS,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702_ry),Talla: S,30.35,0.00
+__import__.product_template_bfl_30_702_ry,BFL-30-702-RY/M,BFL-30-702-RY/OM,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702_ry),Talla: M,30.35,0.00
+__import__.product_template_bfl_30_702_ry,BFL-30-702-RY/L,BFL-30-702-RY/OL,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702_ry),Talla: L,30.35,0.00
+__import__.product_template_bfl_30_702_ry,BFL-30-702-RY/XL,BFL-30-702-RY/OXL,H. CAMISETA P/CABALLERO BFL ROYAL (bfl_30_702_ry),Talla: XL,30.35,0.00
+__import__.product_template_bfl_h40_205_b_md,BFL-H40-205.B-MD/40,BFL-H40-205.B-MD/O40,Terno BFL-H40-205.B-MD,Talla: 40,39.04,0.00
+__import__.product_template_bfl_h40_205_b_md,BFL-H40-205.B-MD/38,BFL-H40-205.B-MD/O38,Terno BFL-H40-205.B-MD,Talla: 38,39.04,0.00
+__import__.product_template_bfl_h40_205_b_md,BFL-H40-205.B-MD/36,BFL-H40-205.B-MD/O36,Terno BFL-H40-205.B-MD,Talla: 36,39.04,0.00
+__import__.product_template_bfl_h40_205_b_md,BFL-H40-205.B-MD/34,BFL-H40-205.B-MD/O34,Terno BFL-H40-205.B-MD,Talla: 34,39.04,0.00
+__import__.product_template_bfl_h40_205_b_md,BFL-H40-205.B-MD/32,BFL-H40-205.B-MD/O32,Terno BFL-H40-205.B-MD,Talla: 32,39.04,0.00
+__import__.product_template_bfl_h40_205_b_md,BFL-H40-205.B-MD/30,BFL-H40-205.B-MD/O30,Terno BFL-H40-205.B-MD,Talla: 30,39.04,0.00
+__import__.product_template_bfl_h40_204_a_dk,BFL-H40-204.A-DK/30,BFL-H40-204.A-DK/O30,Terno BFL-H40-204.A-DK,Talla: 30,39.04,0.00
+__import__.product_template_bfl_h40_204_a_dk,BFL-H40-204.A-DK/32,BFL-H40-204.A-DK/O32,Terno BFL-H40-204.A-DK,Talla: 32,39.04,0.00
+__import__.product_template_bfl_h40_204_a_dk,BFL-H40-204.A-DK/34,BFL-H40-204.A-DK/O34,Terno BFL-H40-204.A-DK,Talla: 34,39.04,0.00
+__import__.product_template_bfl_h40_204_a_dk,BFL-H40-204.A-DK/36,BFL-H40-204.A-DK/O36,Terno BFL-H40-204.A-DK,Talla: 36,39.04,0.00
+__import__.product_template_bfl_h40_204_a_dk,BFL-H40-204.A-DK/38,BFL-H40-204.A-DK/O38,Terno BFL-H40-204.A-DK,Talla: 38,39.04,0.00
+__import__.product_template_bfl_h40_204_a_dk,BFL-H40-204.A-DK/40,BFL-H40-204.A-DK/O40,Terno BFL-H40-204.A-DK,Talla: 40,39.04,0.00
+__import__.product_template_bfl_h40_106_b_dk,BFL-H40-106.B-DK/30,BFL-H40-106.B-DK/O30,Terno BFL-H40-106.B-DK,Talla: 30,39.04,0.00
+__import__.product_template_bfl_h40_106_b_dk,BFL-H40-106.B-DK/32,BFL-H40-106.B-DK/O32,Terno BFL-H40-106.B-DK,Talla: 32,39.04,0.00
+__import__.product_template_bfl_h40_106_b_dk,BFL-H40-106.B-DK/34,BFL-H40-106.B-DK/O34,Terno BFL-H40-106.B-DK,Talla: 34,39.04,0.00
+__import__.product_template_bfl_h40_106_b_dk,BFL-H40-106.B-DK/36,BFL-H40-106.B-DK/O36,Terno BFL-H40-106.B-DK,Talla: 36,39.04,0.00
+__import__.product_template_bfl_h40_106_b_dk,BFL-H40-106.B-DK/38,BFL-H40-106.B-DK/O38,Terno BFL-H40-106.B-DK,Talla: 38,39.04,0.00
+__import__.product_template_bfl_h40_106_b_dk,BFL-H40-106.B-DK/40,BFL-H40-106.B-DK/O40,Terno BFL-H40-106.B-DK,Talla: 40,39.04,0.00
+__import__.product_template_dk2011_22,DK2011-22/60,DK2011222022660,Leva DK2011-22,Talla: 60,165.13,0.00
+__import__.product_template_dk2011_22,DK2011-22/58,DK2011222022658,Leva DK2011-22,Talla: 58,165.13,0.00
+__import__.product_template_dk2011_22,DK2011-22/56,DK2011222022656,Leva DK2011-22,Talla: 56,165.13,0.00
+__import__.product_template_dk2011_22,DK2011-22/54,DK2011222022654,Leva DK2011-22,Talla: 54,165.13,0.00
+__import__.product_template_dk2011_22,DK2011-22/52,DK2011222022652,Leva DK2011-22,Talla: 52,165.13,0.00
+__import__.product_template_dk2011_22,DK2011-22/50,DK2011222022650,Leva DK2011-22,Talla: 50,165.13,0.00
+__import__.product_template_dk2011_22,DK2011-22/48,DK2011222022648,Leva DK2011-22,Talla: 48,165.13,0.00
+__import__.product_template_dk2011_22,DK2011-22/46,DK2011222022646,Leva DK2011-22,Talla: 46,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/60,DK201182022660,Leva DK2011-8,Talla: 60,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/46,DK201182022646,Leva DK2011-8,Talla: 46,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/48,DK201182022648,Leva DK2011-8,Talla: 48,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/50,DK201182022650,Leva DK2011-8,Talla: 50,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/52,DK201182022652,Leva DK2011-8,Talla: 52,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/54,DK201182022654,Leva DK2011-8,Talla: 54,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/56,DK201182022656,Leva DK2011-8,Talla: 56,165.13,0.00
+__import__.product_template_dk2011_8,DK2011-8/58,DK201182022658,Leva DK2011-8,Talla: 58,165.13,0.00
+__import__.product_template_22e2712_3a_bc_2,22E2712-3A-BC-2/56,2227123202265638,Terno 22E2712-3A-BC-2,Talla: 56,217.30,0.00
+__import__.product_template_22e2712_3a_bc_2,22E2712-3A-BC-2/46,2227123202264628,Terno 22E2712-3A-BC-2,Talla: 46,217.30,0.00
+__import__.product_template_22e2712_3a_bc_2,22E2712-3A-BC-2/48,2227123202264830,Terno 22E2712-3A-BC-2,Talla: 48,217.30,0.00
+__import__.product_template_22e2712_3a_bc_2,22E2712-3A-BC-2/50,2227123202265032,Terno 22E2712-3A-BC-2,Talla: 50,217.30,0.00
+__import__.product_template_22e2712_3a_bc_2,22E2712-3A-BC-2/52,2227123202265234,Terno 22E2712-3A-BC-2,Talla: 52,217.30,0.00
+__import__.product_template_22e2712_3a_bc_2,22E2712-3A-BC-2/54,2227123202265436,Terno 22E2712-3A-BC-2,Talla: 54,217.30,0.00
+__import__.product_template_22e2712_3a_bc_2,22E2712-3A-BC-2/58,2227123202265840,Terno 22E2712-3A-BC-2,Talla: 58,217.30,0.00
+__import__.product_template_zp_pat_na_cassini,ZP-PAT-NA-CASSINI/10,ZPPATNACASS/O10,Zapato ZP-PAT-NA-CASSINI,Talla: 10,152.09,0.00
+__import__.product_template_zp_pat_na_cassini,ZP-PAT-NA-CASSINI/9.5,ZPPATNACASS/O9.5,Zapato ZP-PAT-NA-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_pat_ta_cassini,ZP-PAT-TA-CASSINI/9,ZPPATTACASS/O9,Zapato ZP-PAT-TA-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_pat_ta_cassini,ZP-PAT-TA-CASSINI/10,ZPPATTACASS/O10,Zapato ZP-PAT-TA-CASSINI,Talla: 10,152.09,0.00
+__import__.product_template_dk2011_4bc_2,DK2011-4BC-2/58,DK20114202265840,Terno DK2011-4BC-2,Talla: 58,304.26,0.00
+__import__.product_template_dk2011_4bc_2,DK2011-4BC-2/56,DK20114202265638,Terno DK2011-4BC-2,Talla: 56,304.26,0.00
+__import__.product_template_dk2011_4bc_2,DK2011-4BC-2/54,DK20114202265436,Terno DK2011-4BC-2,Talla: 54,304.26,0.00
+__import__.product_template_dk2011_4bc_2,DK2011-4BC-2/50,DK20114202265032,Terno DK2011-4BC-2,Talla: 50,304.26,0.00
+__import__.product_template_dk2011_4bc_2,DK2011-4BC-2/48,DK20114202264830,Terno DK2011-4BC-2,Talla: 48,304.26,0.00
+__import__.product_template_dk2011_4bc_2,DK2011-4BC-2/46,DK20114202264628,Terno DK2011-4BC-2,Talla: 46,565.13,0.00
+__import__.product_template_22c0905_4c_bc_2,22C0905-4C-BC-2/46,22C0954C202264628,Terno 22C0905-4C-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22c0905_4c_bc_2,22C0905-4C-BC-2/48,22C0954C202264830,Terno 22C0905-4C-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22c0905_4c_bc_2,22C0905-4C-BC-2/50,22C0954C202265032,Terno 22C0905-4C-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22c0905_4c_bc_2,22C0905-4C-BC-2/52,22C0954C202265234,Terno 22C0905-4C-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22c0905_4c_bc_2,22C0905-4C-BC-2/54,22C0954C202265436,Terno 22C0905-4C-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22c0905_4c_bc_2,22C0905-4C-BC-2/56,22C0954C202265638,Terno 22C0905-4C-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22c0905_4c_bc_2,22C0905-4C-BC-2/58,22C0954C2022665840,Terno 22C0905-4C-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_22e2712_1a_bc_2,22E2712-1A-BC-2/46,22E27121A24094628,Terno 22E2712-1A-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22e2712_1a_bc_2,22E2712-1A-BC-2/48,22E27121A24094830,Terno 22E2712-1A-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22e2712_1a_bc_2,22E2712-1A-BC-2/50,22E27121A24095032,Terno 22E2712-1A-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22e2712_1a_bc_2,22E2712-1A-BC-2/52,22E27121A24095234,Terno 22E2712-1A-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22e2712_1a_bc_2,22E2712-1A-BC-2/54,22E27121A24095436,Terno 22E2712-1A-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22e2712_1a_bc_2,22E2712-1A-BC-2/56,22E27121A24095638,Terno 22E2712-1A-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22e2712_1a_bc_2,22E2712-1A-BC-2/58,22E27121A24095840,Terno 22E2712-1A-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_22e2712_6bc_2,22E2712-6BC-2/46,22E27126202264628,Terno 22E2712-6BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22e2712_6bc_2,22E2712-6BC-2/48,22E27126202264830,Terno 22E2712-6BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22e2712_6bc_2,22E2712-6BC-2/50,22E27126202265032,Terno 22E2712-6BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22e2712_6bc_2,22E2712-6BC-2/52,22E27126202265234,Terno 22E2712-6BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22e2712_6bc_2,22E2712-6BC-2/54,22E27126202265436,Terno 22E2712-6BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22e2712_6bc_2,22E2712-6BC-2/56,22E27126202265638,Terno 22E2712-6BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22e2712_6bc_2,22E2712-6BC-2/58,22E27126202265840,Terno 22E2712-6BC-2,Talla: 58,243.39,0.00
+__import__.product_template_22e2712_9bc_2,22E2712-9BC-2/46,22E27129202264628,Terno 22E2712-9BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22e2712_9bc_2,22E2712-9BC-2/48,22E27129202264830,Terno 22E2712-9BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22e2712_9bc_2,22E2712-9BC-2/50,22E27129202265032,Terno 22E2712-9BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22e2712_9bc_2,22E2712-9BC-2/52,22E27129202265234,Terno 22E2712-9BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22e2712_9bc_2,22E2712-9BC-2/54,22E27129202265436,Terno 22E2712-9BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22e2712_9bc_2,22E2712-9BC-2/56,22E27129202265638,Terno 22E2712-9BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22e2712_9bc_2,22E2712-9BC-2/58,22E27129202265840,Terno 22E2712-9BC-2,Talla: 58,243.39,0.00
+__import__.product_template_22e2731_8bc_2,22E2731-8BC-2/46,22E27318202264628,Terno 22E2731-8BC-2,Talla: 46,243.39,0.00
+__import__.product_template_22e2731_8bc_2,22E2731-8BC-2/48,22E27318202264830,Terno 22E2731-8BC-2,Talla: 48,243.39,0.00
+__import__.product_template_22e2731_8bc_2,22E2731-8BC-2/50,22E27318202265032,Terno 22E2731-8BC-2,Talla: 50,243.39,0.00
+__import__.product_template_22e2731_8bc_2,22E2731-8BC-2/52,22E27318202265234,Terno 22E2731-8BC-2,Talla: 52,243.39,0.00
+__import__.product_template_22e2731_8bc_2,22E2731-8BC-2/54,22E27318202265436,Terno 22E2731-8BC-2,Talla: 54,243.39,0.00
+__import__.product_template_22e2731_8bc_2,22E2731-8BC-2/56,22E27318202265638,Terno 22E2731-8BC-2,Talla: 56,243.39,0.00
+__import__.product_template_22e2731_8bc_2,22E2731-8BC-2/58,22E27318202265840,Terno 22E2731-8BC-2,Talla: 58,243.39,0.00
+__import__.product_template_zp_pat_ta_cassini,ZP-PAT-TA-CASSINI/8.5,ZPPATTACASS/O8.5,Zapato ZP-PAT-TA-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_pat_vn_cassini,ZP-PAT-VN-CASSINI/10,ZPPATVNCASS/O10,Zapato ZP-PAT-VN-CASSINI,Talla: 10,152.09,0.00
+__import__.product_template_zp_pat_vn_cassini,ZP-PAT-VN-CASSINI/9.5,ZPPATVNCASS/O9.5,Zapato ZP-PAT-VN-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_cr,CR-10,CR-10,M. COLLARES P/DAMA VARIOS MODELOS,Talla: 10,12.96,0.00
+__import__.product_template_cr,CR-28,CR-28,M. COLLARES P/DAMA VARIOS MODELOS,Talla: 28,28.62,0.00
+__import__.product_template_cr,CR-15,CR-15,M. COLLARES P/DAMA VARIOS MODELOS,Talla: 15,17.30,0.00
+__import__.product_template_an,AN-12,AN-12,M. ANILLOS P/DAMA VARIOS MODELOS,Talla: 12,14.70,0.00
+__import__.product_template_an,AN-10,AN-10,M. ANILLOS P/DAMA VARIOS MODELOS,Talla: 10,12.96,0.00
+__import__.product_template_ar,AR-10,AR-10,ARETES P/DAMA V. MODELOS,Talla: 10,12.96,0.00
+__import__.product_template_jy,JY-10,JY-10,M. JOYERO P/DAMA VARIOS MODELOS,Talla: 10,12.96,0.00
+__import__.product_template_cr,CR-20,CR-20,M. COLLARES P/DAMA VARIOS MODELOS,Talla: 20,21.65,0.00
+__import__.product_template_t9158_tp,T9158-TP/L,T9158-TP/OL,M. BLUSA P/DAMA VARIOS MODELOS TAUPE,Talla: L,47.74,0.00
+__import__.product_template_t9158_tp,T9158-TP/M,T9158-TP/OM,M. BLUSA P/DAMA VARIOS MODELOS TAUPE,Talla: M,47.74,0.00
+__import__.product_template_t9158_tp,T9158-TP/S,T9158-TP/OS,M. BLUSA P/DAMA VARIOS MODELOS TAUPE,Talla: S,47.74,0.00
+__import__.product_template_swt7467_ru,SWT7467-RU/M,SWT7467-RU/OM,M. TOP P/DAMA RIBBED MONK NECK SLEEVELESS TOP RUST,Talla: M,45.13,0.00
+__import__.product_template_swt7459_mo,SWT7459-MO/L,SWT7459-MO/OL,M. TOP P/DAMA RIBBED CAMI TANK TOP MOCHA,Talla: L,46.00,0.00
+__import__.product_template_swt7459_mo,SWT7459-MO/M,SWT7459-MO/OM,M. TOP P/DAMA RIBBED CAMI TANK TOP MOCHA,Talla: M,46.00,0.00
+__import__.product_template_swt7459_mo,SWT7459-MO/S,SWT7459-MO/OS,M. TOP P/DAMA RIBBED CAMI TANK TOP MOCHA,Talla: S,46.00,0.00
+__import__.product_template_swt7467_ru,SWT7467-RU/L,SWT7467-RU/OL,M. TOP P/DAMA RIBBED MONK NECK SLEEVELESS TOP RUST,Talla: L,45.13,0.00
+__import__.product_template_swt7467_ru,SWT7467-RU/S,SWT7467-RU/OS,M. TOP P/DAMA RIBBED MONK NECK SLEEVELESS TOP RUST,Talla: S,45.13,0.00
+__import__.product_template_swt7459_bg,SWT7459-BG/L,SWT7459-BG/OL,M. TOP P/DAMA RIBBED CAMI TANK TOP BEIGE,Talla: L,46.34,0.00
+__import__.product_template_swt7459_bg,SWT7459-BG/M,SWT7459-BG/OM,M. TOP P/DAMA RIBBED CAMI TANK TOP BEIGE,Talla: M,46.34,0.00
+__import__.product_template_swt7569_wh,SWT7569-WH/S,SWT7569-WH/S,M. TOP P/DAMA SWEATER KNIT TANK TOP WHITE,Talla: S,43.66,0.00
+__import__.product_template_swt7569_bl,SWT7569-BL/L,SWT7569-BL/OL,M. TOP P/DAMA SWEATER KNIT TANK TOP BLACK,Talla: L,43.66,0.00
+__import__.product_template_swt7569_bl,SWT7569-BL/M,SWT7569-BL/OM,M. TOP P/DAMA SWEATER KNIT TANK TOP BLACK,Talla: M,43.66,0.00
+__import__.product_template_swt7569_bl,SWT7569-BL/S,SWT7569-BL/OS,M. TOP P/DAMA SWEATER KNIT TANK TOP BLACK,Talla: S,43.66,0.00
+__import__.product_template_swt7459_bg,SWT7459-BG/S,SWT7459-BG/OS,M. TOP P/DAMA RIBBED CAMI TANK TOP BEIGE,Talla: S,46.34,0.00
+__import__.product_template_swt7569_wh,SWT7569-WH/L,SWT7569-WH/OL,M. TOP P/DAMA SWEATER KNIT TANK TOP WHITE,Talla: L,43.66,0.00
+__import__.product_template_swt7569_wh,SWT7569-WH/M,SWT7569-WH/OM,M. TOP P/DAMA SWEATER KNIT TANK TOP WHITE,Talla: M,43.66,0.00
+__import__.product_template_r723_bg,R723-BG/L,R723-BG/OL,M. SHORT PARA DAMA SUBLIME BEIGE,Talla: L,46.34,0.00
+__import__.product_template_r723_bg,R723-BG/M,R723-BG/OM,M. SHORT PARA DAMA SUBLIME BEIGE,Talla: M,46.34,0.00
+__import__.product_template_r723_bg,R723-BG/S,R723-BG/OS,M. SHORT PARA DAMA SUBLIME BEIGE,Talla: S,46.34,0.00
+__import__.product_template_r723_bl,R723-BL/L,R723-BL/OL,M. SHORT PARA DAMA SUBLIME BLACK,Talla: L,46.34,0.00
+__import__.product_template_r723_bl,R723-BL/M,R723-BL/OM,M. SHORT PARA DAMA SUBLIME BLACK,Talla: M,46.34,0.00
+__import__.product_template_r723_bl,R723-BL/S,R723-BL/OS,M. SHORT PARA DAMA SUBLIME BLACK,Talla: S,46.34,0.00
+__import__.product_template_5000_bg,5000-BG/M,5000-BG/OM,M. TOP P/DAMA BIEGE,Talla: M,16.88,0.00
+__import__.product_template_5000_wh,5000-WH/M,5000-WH/OM,M. TOP P/DAMA WHITE,Talla: M,16.88,0.00
+__import__.product_template_1100_bg,1100-BG/M,1100-BG/OM,M. TOP P/DAMA BEIGE,Talla: M,16.88,0.00
+__import__.product_template_1100_bl,1100-BL/M,1100-BL/OM,M. TOP P/DAMA BLACK,Talla: M,16.88,0.00
+__import__.product_template_2007_bl,2007-BL/M,2007-BL/OM,M. TOP P/DAMA BLACK (2007_bl),Talla: M,16.88,0.00
+__import__.product_template_2007_bg,2007-BG/M,2007-BG/OM,M. TOP P/DAMA BEIGE (2007_bg),Talla: M,16.88,0.00
+__import__.product_template_2007_wh,2007-WH/M,2007-WH/OM,M. TOP P/DAMA WHITE (2007_wh),Talla: M,16.88,0.00
+__import__.product_template_tp_9560_6_gr,TP-9560-6-GR/L,TP-9560-6-GR/OL,M. TAILOR PANTS WITH NON FUCTIONAL FRONT POCKET GREEN,Talla: L,80.27,0.00
+__import__.product_template_tp_9560_6_gr,TP-9560-6-GR/M,TP-9560-6-GR/OM,M. TAILOR PANTS WITH NON FUCTIONAL FRONT POCKET GREEN,Talla: M,80.27,0.00
+__import__.product_template_tp_9560_6_gr,TP-9560-6-GR/S,TP-9560-6-GR/OS,M. TAILOR PANTS WITH NON FUCTIONAL FRONT POCKET GREEN,Talla: S,80.27,0.00
+__import__.product_template_tj_9465_6_or,TJ-9465-6-OR/M,TJ-9465-6-OR/OM,M. OVERSIZED BLAZER ORANGE,Talla: M,82.95,0.00
+__import__.product_template_rt_3107_6_ro,RT-3107-6-RO/M,RT-3107-6-RO/OM,M. V-NECK SLEEVELESS TOP ROYAL,Talla: M,54.38,0.00
+__import__.product_template_rt_3107_6_ro,RT-3107-6-RO/S,RT-3107-6-RO/OS,M. V-NECK SLEEVELESS TOP ROYAL,Talla: S,54.38,0.00
+__import__.product_template_rt_3107_6_fuc,RT-3107-6-FUC/M,RT-3107-6-FUC/OM,M. V-NECK SLEEVELESS TOP FUCHSIA,Talla: M,54.38,0.00
+__import__.product_template_rt_3107_6_fuc,RT-3107-6-FUC/S,RT-3107-6-FUC/OS,M. V-NECK SLEEVELESS TOP FUCHSIA,Talla: S,54.38,0.00
+__import__.product_template_rd_3343_6_fuc,RD-3343-6-FUC/L,RD-3343-6-FUC/OL,M. SIDE SLIT SATIN SLIP MAXI FUCHSIA,Talla: L,74.91,0.00
+__import__.product_template_rd_3343_6_fuc,RD-3343-6-FUC/M,RD-3343-6-FUC/OM,M. SIDE SLIT SATIN SLIP MAXI FUCHSIA,Talla: M,74.91,0.00
+__import__.product_template_rd_3343_6_fuc,RD-3343-6-FUC/S,RD-3343-6-FUC/OS,M. SIDE SLIT SATIN SLIP MAXI FUCHSIA,Talla: S,74.91,0.00
+__import__.product_template_tj_9465_6_or,TJ-9465-6-OR/L,TJ-9465-6-OR/OL,M. OVERSIZED BLAZER ORANGE,Talla: L,82.95,0.00
+__import__.product_template_tj_9465_6_or,TJ-9465-6-OR/S,TJ-9465-6-OR/OS,M. OVERSIZED BLAZER ORANGE,Talla: S,82.95,0.00
+__import__.product_template_rt_3107_6_ro,RT-3107-6-RO/L,RT-3107-6-RO/OL,M. V-NECK SLEEVELESS TOP ROYAL,Talla: L,54.38,0.00
+__import__.product_template_rt_3107_6_fuc,RT-3107-6-FUC/L,RT-3107-6-FUC/OL,M. V-NECK SLEEVELESS TOP FUCHSIA,Talla: L,54.38,0.00
+__import__.product_template_kp_1245_6_mu,KP-1245-6-MU/M,KP-1245-6-MU/OM,M. PAISLEY PRINT JOGGERS MULTI,Talla: M,43.39,0.00
+__import__.product_template_kp_1245_6_mu,KP-1245-6-MU/L,KP-1245-6-MU/OL,M. PAISLEY PRINT JOGGERS MULTI,Talla: L,66.88,0.00
+__import__.product_template_kp_1245_6_mu,KP-1245-6-MU/S,KP-1245-6-MU/OS,M. PAISLEY PRINT JOGGERS MULTI,Talla: S,43.39,0.00
+__import__.product_template_fd1089_wh,FD1089-WH/L,FD1089-WH/OL,M. LACE TRIM DETAILED WITH BACK ELASTI WHITE,Talla: L,68.66,0.00
+__import__.product_template_fd1089_wh,FD1089-WH/M,FD1089-WH/OM,M. LACE TRIM DETAILED WITH BACK ELASTI WHITE,Talla: M,68.66,0.00
+__import__.product_template_fd1089_wh,FD1089-WH/S,FD1089-WH/OS,M. LACE TRIM DETAILED WITH BACK ELASTI WHITE,Talla: S,68.66,0.00
+__import__.product_template_ekw7077_cam,EKW7077-CAM/L,EKW7077-CAM/OL,M. BLAZER P/DAMAS VARIOS MODELOS CAMO,Talla: L,75.80,0.00
+__import__.product_template_ekw7077_cam,EKW7077-CAM/M,EKW7077-CAM/OM,M. BLAZER P/DAMAS VARIOS MODELOS CAMO,Talla: M,75.80,0.00
+__import__.product_template_ekw7077_cam,EKW7077-CAM/S,EKW7077-CAM/OS,M. BLAZER P/DAMAS VARIOS MODELOS CAMO,Talla: S,75.80,0.00
+__import__.product_template_ekp4109_cam,EKP4109-CAM/L,EKP4109-CAM/OL,"OTTOM, WOVEN HIGH WAIST SHORTS WITH PLEATS DETAIL SELF CAMO",Talla: L,54.38,0.00
+__import__.product_template_ekp4109_cam,EKP4109-CAM/M,EKP4109-CAM/OS,"OTTOM, WOVEN HIGH WAIST SHORTS WITH PLEATS DETAIL SELF CAMO",Talla: M,54.38,0.00
+__import__.product_template_ekp4109_cam,EKP4109-CAM/S,EKP4109-CAM/,"OTTOM, WOVEN HIGH WAIST SHORTS WITH PLEATS DETAIL SELF CAMO",Talla: S,54.38,0.00
+__import__.product_template_zp_pat_vn_cassini,ZP-PAT-VN-CASSINI/7.5,ZPPATVNCASS/O7.5,Zapato ZP-PAT-VN-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_pat_vn_cassini,ZP-PAT-VN-CASSINI/8.5,ZPPATVNCASS/O8.5,Zapato ZP-PAT-VN-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_pat_vn_cassini,ZP-PAT-VN-CASSINI/9,ZPPATVNCASS/O9,Zapato ZP-PAT-VN-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_pat_na_cassini,ZP-PAT-NA-CASSINI/7.5,ZPPATNACASS/O7.5,Zapato ZP-PAT-NA-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_pat_na_cassini,ZP-PAT-NA-CASSINI/9,ZPPATNACASS/O9,Zapato ZP-PAT-NA-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_pat_na_cassini,ZP-PAT-NA-CASSINI/8.5,ZPPATNACASS/O8.5,Zapato ZP-PAT-NA-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_ekp4109_dk,EKP4109-DK/L,EKP4109-DK/OL,"BOTTOM, WOVEN HIGH WAIST SHORTS WITH PLEATS DETAIL SELF DK ROSE",Talla: L,54.38,0.00
+__import__.product_template_ekp4109_dk,EKP4109-DK/M,EKP4109-DK/OM,"BOTTOM, WOVEN HIGH WAIST SHORTS WITH PLEATS DETAIL SELF DK ROSE",Talla: M,54.38,0.00
+__import__.product_template_ekp4109_dk,EKP4109-DK/S,EKP4109-DK/OS,"BOTTOM, WOVEN HIGH WAIST SHORTS WITH PLEATS DETAIL SELF DK ROSE",Talla: S,54.38,0.00
+__import__.product_template_ekd2542_off,EKD2542-OFF/M,EKD2542-OFF/OM,DRESS WOVEN HALF SLEEVE LOOSE-FIT MINI DRESS WITH COTTON OFF WHITE,Talla: M,72.23,0.00
+__import__.product_template_ekd2542_off,EKD2542-OFF/S,EKD2542-OFF/OS,DRESS WOVEN HALF SLEEVE LOOSE-FIT MINI DRESS WITH COTTON OFF WHITE,Talla: S,72.23,0.00
+__import__.product_template_ekd2542_la,EKD2542-LA/L,EKD2542-LA/OL,DRESS WOVEN HALF SLEEVE LOOSE-FIT MINI DRESS WITH COTTON LATTE,Talla: L,55.57,0.00
+__import__.product_template_ekd2542_la,EKD2542-LA/M,EKD2542-LA/OM,DRESS WOVEN HALF SLEEVE LOOSE-FIT MINI DRESS WITH COTTON LATTE,Talla: M,55.57,0.00
+__import__.product_template_ekd2542_la,EKD2542-LA/S,EKD2542-LA/OS,DRESS WOVEN HALF SLEEVE LOOSE-FIT MINI DRESS WITH COTTON LATTE,Talla: S,55.57,0.00
+__import__.product_template_ekd2542_off,EKD2542-OFF/L,EKD2542-OFF/OL,DRESS WOVEN HALF SLEEVE LOOSE-FIT MINI DRESS WITH COTTON OFF WHITE,Talla: L,72.23,0.00
+__import__.product_template_fw50239_hg,FW50239-HG/S,FW50239-HG/OS,M. RIBBED V NECK BODYSUIT HEATHER GREY,Talla: S,47.23,0.00
+__import__.product_template_fw50239_hg,FW50239-HG/L,FW50239-HG/OL,M. RIBBED V NECK BODYSUIT HEATHER GREY,Talla: L,47.23,0.00
+__import__.product_template_fw50239_hg,FW50239-HG/M,FW50239-HG/OM,M. RIBBED V NECK BODYSUIT HEATHER GREY,Talla: M,47.23,0.00
+__import__.product_template_fs7538_eb,FS7538-EB/M,FS7538-EB/OM,M. FALDA P/DAMA ECRU/BLACK,Talla: M,62.41,0.00
+__import__.product_template_fs7427_ma,FS7427-MA/L,FS7427-MA/OL,M. FALDA P/DAMA MAUVE,Talla: L,66.88,0.00
+__import__.product_template_fs7427_ma,FS7427-MA/M,FS7427-MA/OM,M. FALDA P/DAMA MAUVE,Talla: M,66.88,0.00
+__import__.product_template_fs7427_ma,FS7427-MA/S,FS7427-MA/OS,M. FALDA P/DAMA MAUVE,Talla: S,66.88,0.00
+__import__.product_template_fs7538_eb,FS7538-EB/L,FS7538-EB/OL,M. FALDA P/DAMA ECRU/BLACK,Talla: L,62.41,0.00
+__import__.product_template_fs7538_eb,FS7538-EB/S,FS7538-EB/OS,M. FALDA P/DAMA ECRU/BLACK,Talla: S,62.41,0.00
+__import__.product_template_fs6832x_ls,FS6832X-LS/XL,FS6832X-LS/OXL,M. FALDA P/DAMA MODELO LT SAGE,Talla: XL,30.35,0.00
+__import__.product_template_fs6834x_bk,FS6834X-BK/XL,FS6834X-BK/OXL,M. FALDA P/DAMA MODELO BLACK,Talla: XL,52.59,0.00
+__import__.product_template_fs6834x_bk,FS6834X-BK/L,FS6834X-BK/OL,M. FALDA P/DAMA MODELO BLACK,Talla: L,52.59,0.00
+__import__.product_template_fs6834x_bk,FS6834X-BK/M,FS6834X-BK/OM,M. FALDA P/DAMA MODELO BLACK,Talla: M,30.35,0.00
+__import__.product_template_fs6834x_bk,FS6834X-BK/S,FS6834X-BK/OS,M. FALDA P/DAMA MODELO BLACK,Talla: S,52.59,0.00
+__import__.product_template_fs6833x_db,FS6833X-DB/XL,FS6833X-DB/OXL,M. FALDA P/DAMA MODELO DUSTY BLUE,Talla: XL,30.35,0.00
+__import__.product_template_fs6833x_db,FS6833X-DB/L,FS6833X-DB/OL,M. FALDA P/DAMA MODELO DUSTY BLUE,Talla: L,52.59,0.00
+__import__.product_template_fs6833x_db,FS6833X-DB/S,FS6833X-DB/OS,M. FALDA P/DAMA MODELO DUSTY BLUE,Talla: S,30.35,0.00
+__import__.product_template_fs6833x_db,FS6833X-DB/XS,FS6833X-DB/OXS,M. FALDA P/DAMA MODELO DUSTY BLUE,Talla: XS,52.59,0.00
+__import__.product_template_fs6832x_ls,FS6832X-LS/L,FS6832X-LS/OL,M. FALDA P/DAMA MODELO LT SAGE,Talla: L,30.35,0.00
+__import__.product_template_fs6832x_ls,FS6832X-LS/M,FS6832X-LS/OM,M. FALDA P/DAMA MODELO LT SAGE,Talla: M,52.59,0.00
+__import__.product_template_fs6832x_ls,FS6832X-LS/XS,FS6832X-LS/OXS,M. FALDA P/DAMA MODELO LT SAGE,Talla: XS,52.59,0.00
+__import__.product_template_fs6834x_bk,FS6834X-BK/XS,FS6834X-BK/OXS,M. FALDA P/DAMA MODELO BLACK,Talla: XS,52.59,0.00
+__import__.product_template_fs6833x_db,FS6833X-DB/M,FS6833X-DB/OM,M. FALDA P/DAMA MODELO DUSTY BLUE,Talla: M,30.35,0.00
+__import__.product_template_fd9266_en,FD9266-EN/L,FD9266-EN/OL,M. VESTIDO P/DAMA MODELO EMERALD,Talla: L,67.77,0.00
+__import__.product_template_fd9266_en,FD9266-EN/S,FD9266-EN/OS,M. VESTIDO P/DAMA MODELO EMERALD,Talla: S,67.77,0.00
+__import__.product_template_fs6832x_ls,FS6832X-LS/S,FS6832X-LS/OS,M. FALDA P/DAMA MODELO LT SAGE,Talla: S,30.35,0.00
+__import__.product_template_fd9266_en,FD9266-EN/M,FD9266-EN/OM,M. VESTIDO P/DAMA MODELO EMERALD,Talla: M,67.77,0.00
+__import__.product_template_fd9150_bm,FD9150-BM/L,FD9150-BM/OL,M. VESTIDO P/DAMA MODELO BLACK MULTI,Talla: L,43.39,0.00
+__import__.product_template_fd9150_bm,FD9150-BM/M,FD9150-BM/OM,M. VESTIDO P/DAMA MODELO BLACK MULTI,Talla: M,43.39,0.00
+__import__.product_template_fd9150_bm,FD9150-BM/S,FD9150-BM/OS,M. VESTIDO P/DAMA MODELO BLACK MULTI,Talla: S,43.39,0.00
+__import__.product_template_fd8129_sb,FD8129-SB/L,FD8129-SB/OL,M. VESTIDO P/DAMA MODELO SKY BLUE,Talla: L,62.41,0.00
+__import__.product_template_fd8129_sb,FD8129-SB/S,FD8129-SB/OS,M. VESTIDO P/DAMA MODELO SKY BLUE,Talla: S,62.41,0.00
+__import__.product_template_fd7636_cm,FD7636-CM/L,FD7636-CM/OL,M. VESTIDO P/DAMA MODELO CREAM/MULTI,Talla: L,62.41,0.00
+__import__.product_template_fd7636_cm,FD7636-CM/S,FD7636-CM/OS,M. VESTIDO P/DAMA MODELO CREAM/MULTI,Talla: S,62.41,0.00
+__import__.product_template_fd7550_em,FD7550-EM/L,FD7550-EM/OL,M. VESTIDO P/DAMA MODELO EMERALD (fd7550_em),Talla: L,84.73,0.00
+__import__.product_template_fd7550_em,FD7550-EM/S,FD7550-EM/OS,M. VESTIDO P/DAMA MODELO EMERALD (fd7550_em),Talla: S,84.73,0.00
+__import__.product_template_fd8129_sb,FD8129-SB/M,FD8129-SB/OM,M. VESTIDO P/DAMA MODELO SKY BLUE,Talla: M,62.41,0.00
+__import__.product_template_fd7550_bur,FD7550-BUR/L,FD7550-BUR/OL,M. VESTIDO P/DAMA MODELO BURGUNDY,Talla: L,84.73,0.00
+__import__.product_template_fd7550_bur,FD7550-BUR/M,FD7550-BUR/OM,M. VESTIDO P/DAMA MODELO BURGUNDY,Talla: M,84.73,0.00
+__import__.product_template_fd7636_cm,FD7636-CM/M,FD7636-CM/OM,M. VESTIDO P/DAMA MODELO CREAM/MULTI,Talla: M,62.41,0.00
+__import__.product_template_fd7550_em,FD7550-EM/M,FD7550-EM/OM,M. VESTIDO P/DAMA MODELO EMERALD (fd7550_em),Talla: M,84.73,0.00
+__import__.product_template_fd7550_bur,FD7550-BUR/S,FD7550-BUR/OS,M. VESTIDO P/DAMA MODELO BURGUNDY,Talla: S,84.73,0.00
+__import__.product_template_fd7442_sa,FD7442-SA/L,FD7442-SA/OL,M. VESTIDO P/DAMA MODELO SANDSTONE,Talla: L,71.34,0.00
+__import__.product_template_fd6699_im,FD6699-IM/L,FD6699-IM/OL,M. VESTIDO P/DAMA MODELO IVORY MULTI,Talla: L,74.02,0.00
+__import__.product_template_fd6699_im,FD6699-IM/M,FD6699-IM/OM,M. VESTIDO P/DAMA MODELO IVORY MULTI,Talla: M,74.02,0.00
+__import__.product_template_fd6699_im,FD6699-IM/S,FD6699-IM/OS,M. VESTIDO P/DAMA MODELO IVORY MULTI,Talla: S,74.02,0.00
+__import__.product_template_fd7442_sa,FD7442-SA/M,FD7442-SA/OM,M. VESTIDO P/DAMA MODELO SANDSTONE,Talla: M,71.34,0.00
+__import__.product_template_fd7442_sa,FD7442-SA/S,FD7442-SA/OS,M. VESTIDO P/DAMA MODELO SANDSTONE,Talla: S,71.34,0.00
+__import__.product_template_fd4571_vm,FD4571-VM/L,FD4571-VM/OL,M. VESTIDO P/DAMA MODELO VINTAGE MAUVE,Talla: L,55.57,0.00
+__import__.product_template_fd4571_vm,FD4571-VM/M,FD4571-VM/OM,M. VESTIDO P/DAMA MODELO VINTAGE MAUVE,Talla: M,75.80,0.00
+__import__.product_template_fd4571_vm,FD4571-VM/S,FD4571-VM/OS,M. VESTIDO P/DAMA MODELO VINTAGE MAUVE,Talla: S,75.80,0.00
+__import__.product_template_fd4571_dg,FD4571-DG/L,FD4571-DG/OL,M. VESTIDO P/DAMA MODELO DUSTY SAGE,Talla: L,75.80,0.00
+__import__.product_template_fd4571_dg,FD4571-DG/M,FD4571-DG/OM,M. VESTIDO P/DAMA MODELO DUSTY SAGE,Talla: M,75.80,0.00
+__import__.product_template_fd4571_dg,FD4571-DG/S,FD4571-DG/OS,M. VESTIDO P/DAMA MODELO DUSTY SAGE,Talla: S,55.57,0.00
+__import__.product_template_imc7238d,IMC7238D/L,IMC7238D/OL,M. P/DAMA SLEEVELESS MAXI DRESS WITH CUTOUT PEACH,Talla: L,75.80,0.00
+__import__.product_template_imc7238d,IMC7238D/M,IMC7238D/OM,M. P/DAMA SLEEVELESS MAXI DRESS WITH CUTOUT PEACH,Talla: M,75.80,0.00
+__import__.product_template_imc7238d,IMC7238D/S,IMC7238D/OS,M. P/DAMA SLEEVELESS MAXI DRESS WITH CUTOUT PEACH,Talla: S,75.80,0.00
+__import__.product_template_ima7899r,IMA7899R/M,IMA7899R/OM,M. P/DAMA A BANDEAU HALTER NECK JUMPSUIT COCOA,Talla: M,87.41,0.00
+__import__.product_template_ima7899r,IMA7899R/S,IMA7899R/OS,M. P/DAMA A BANDEAU HALTER NECK JUMPSUIT COCOA,Talla: S,87.41,0.00
+__import__.product_template_ima7899r,IMA7899R/L,IMA7899R/OL,M. P/DAMA A BANDEAU HALTER NECK JUMPSUIT COCOA,Talla: L,87.41,0.00
+__import__.product_template_t1528_bg,T1528-BG/S,T1528-BG/OS,M. P/DAMA CROPPED POPLIN SHIRT BEIGE,Talla: S,51.22,0.00
+__import__.product_template_t1528_bg,T1528-BG/M,T1528-BG/OM,M. P/DAMA CROPPED POPLIN SHIRT BEIGE,Talla: M,51.22,0.00
+__import__.product_template_t1528_bg,T1528-BG/L,T1528-BG/OL,M. P/DAMA CROPPED POPLIN SHIRT BEIGE,Talla: L,51.22,0.00
+__import__.product_template_t1528_bu,T1528-BU/S,T1528-BU/OS,M. P/DAMA CROPPED POPLIN SHIRT BLUE,Talla: S,51.22,0.00
+__import__.product_template_t1528_bu,T1528-BU/M,T1528-BU/OM,M. P/DAMA CROPPED POPLIN SHIRT BLUE,Talla: M,51.22,0.00
+__import__.product_template_t1528_bu,T1528-BU/L,T1528-BU/OL,M. P/DAMA CROPPED POPLIN SHIRT BLUE,Talla: L,51.22,0.00
+__import__.product_template_t1583_or,T1583-OR/S,T1583-OR/OS,M. CROP P/DAMA SHIRTS -100% POLYESTER ORANGE,Talla: S,51.22,0.00
+__import__.product_template_t1583_or,T1583-OR/M,T1583-OR/OM,M. CROP P/DAMA SHIRTS -100% POLYESTER ORANGE,Talla: M,51.22,0.00
+__import__.product_template_t1583_or,T1583-OR/L,T1583-OR/OL,M. CROP P/DAMA SHIRTS -100% POLYESTER ORANGE,Talla: L,51.22,0.00
+__import__.product_template_t1004_pi,T1004-PI/L,T1004-PI/OL,M. PUFF-SLEEVE TOP P/DAMA PINK,Talla: L,52.09,0.00
+__import__.product_template_t1004_pi,T1004-PI/M,T1004-PI/OM,M. PUFF-SLEEVE TOP P/DAMA PINK,Talla: M,52.09,0.00
+__import__.product_template_t1004_pi,T1004-PI/S,T1004-PI/OS,M. PUFF-SLEEVE TOP P/DAMA PINK,Talla: S,52.09,0.00
+__import__.product_template_t1004_la,T1004-LA/L,T1004-LA/OL,M. PUFF-SLEEVE TOP P/DAMA LAVENDER,Talla: L,52.09,0.00
+__import__.product_template_t1004_la,T1004-LA/M,T1004-LA/OM,M. PUFF-SLEEVE TOP P/DAMA LAVENDER,Talla: M,52.09,0.00
+__import__.product_template_t1004_la,T1004-LA/S,T1004-LA/OS,M. PUFF-SLEEVE TOP P/DAMA LAVENDER,Talla: S,52.09,0.00
+__import__.product_template_t1607_gr,T1607-GR/S,T1607-GR/OS,FRONT TIED SHIRTS CROP TOP- 100% POLYESTER GREEN,Talla: S,54.70,0.00
+__import__.product_template_t1607_gr,T1607-GR/L,T1607-GR/OL,FRONT TIED SHIRTS CROP TOP- 100% POLYESTER GREEN,Talla: L,54.70,0.00
+__import__.product_template_t1607_gr,T1607-GR/M,T1607-GR/OM,FRONT TIED SHIRTS CROP TOP- 100% POLYESTER GREEN,Talla: M,54.70,0.00
+__import__.product_template_p1004_wh,P1004-WH/L,P1004-WH/OL,HIGH-WAISTED PANTS -WHITE,Talla: L,62.41,0.00
+__import__.product_template_p1004_wh,P1004-WH/M,P1004-WH/OM,HIGH-WAISTED PANTS -WHITE,Talla: M,60.78,0.00
+__import__.product_template_p1004_wh,P1004-WH/S,P1004-WH/OS,HIGH-WAISTED PANTS -WHITE,Talla: S,62.41,0.00
+__import__.product_template_40094_li,40094-LI/S,40094-LI/OS,DENIM WIDE LONG PANTS -100% POLYESTER LIME,Talla: S,59.73,0.00
+__import__.product_template_40094_li,40094-LI/L,40094-LI/OL,DENIM WIDE LONG PANTS -100% POLYESTER LIME,Talla: L,58.17,0.00
+__import__.product_template_40094_li,40094-LI/M,40094-LI/OM,DENIM WIDE LONG PANTS -100% POLYESTER LIME,Talla: M,59.73,0.00
+__import__.product_template_mp2238_t7004,MP2238/T7004-38,MP2238/T7004-38,H. JEANS P/CABALLEROS VARIOS MODELOS,Talla: 38,39.04,0.00
+__import__.product_template_mp2238_t7004,MP2238/T7004-34,MP2238/T7004-34,H. JEANS P/CABALLEROS VARIOS MODELOS,Talla: 34,39.04,0.00
+__import__.product_template_mp2238_t7004,MP2238/T7004-36,MP2238/T7004-36,H. JEANS P/CABALLEROS VARIOS MODELOS,Talla: 36,39.04,0.00
+__import__.product_template_mp2238_t7004,MP2238/T7004-32,MP2238/T7004-32,H. JEANS P/CABALLEROS VARIOS MODELOS,Talla: 32,39.04,0.00
+__import__.product_template_mp2251_t7004,MP2251/T7004-32,MP2251/T7004-32,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2251_t7004),Talla: 32,107.05,0.00
+__import__.product_template_mp2251_t7004,MP2251/T7004-34,MP2251/T7004-34,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2251_t7004),Talla: 34,107.05,0.00
+__import__.product_template_mp2251_t7004,MP2251/T7004-36,MP2251/T7004-36,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2251_t7004),Talla: 36,107.05,0.00
+__import__.product_template_mp2251_t7004,MP2251/T7004-38,MP2251/T7004-38,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2251_t7004),Talla: 38,107.05,0.00
+__import__.product_template_mp2304_t7043,MP2304/T7043-38,MP2304/T7043-38,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2304_t7043),Talla: 38,39.04,0.00
+__import__.product_template_mp2304_t7043,MP2304/T7043-34,MP2304/T7043-34,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2304_t7043),Talla: 34,39.04,0.00
+__import__.product_template_mp2304_t7043,MP2304/T7043-32,MP2304/T7043-32,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2304_t7043),Talla: 32,39.04,0.00
+__import__.product_template_mp2304_t7043,MP2304/T7043-36,MP2304/T7043-36,H. JEANS P/CABALLEROS VARIOS MODELOS (mp2304_t7043),Talla: 36,39.04,0.00
+__import__.product_template_s7001_bl,S7001-BL/S,S7001-BL/OS,M. FALDA P/DAMA BLACK,Talla: S,49.02,0.00
+__import__.product_template_s7001_bl,S7001-BL/M,S7001-BL/OM,M. FALDA P/DAMA BLACK,Talla: M,49.02,0.00
+__import__.product_template_s7001_bl,S7001-BL/L,S7001-BL/OL,M. FALDA P/DAMA BLACK,Talla: L,49.02,0.00
+__import__.product_template_p7009b_fuc,P7009B-FUC/L,P7009B-FUC/OL,M. PANTALON P/DAMA FUCHSIA,Talla: L,49.02,0.00
+__import__.product_template_p7009b_fuc,P7009B-FUC/M,P7009B-FUC/OM,M. PANTALON P/DAMA FUCHSIA,Talla: M,49.02,0.00
+__import__.product_template_p7009b_fuc,P7009B-FUC/S,P7009B-FUC/OS,M. PANTALON P/DAMA FUCHSIA,Talla: S,49.02,0.00
+__import__.product_template_p7009_off,P7009-OFF/L,P7009-OFF/OL,M. PANTALON P/DAMA OFF WHITE,Talla: L,44.55,0.00
+__import__.product_template_p7009_off,P7009-OFF/M,P7009-OFF/OM,M. PANTALON P/DAMA OFF WHITE,Talla: M,44.55,0.00
+__import__.product_template_p7009_off,P7009-OFF/S,P7009-OFF/OS,M. PANTALON P/DAMA OFF WHITE,Talla: S,44.55,0.00
+__import__.product_template_sp1003_or,SP1003-OR/S,SP1003-OR/OS,M. CONJUNTO DE VESTIR P/DAMA ORANGE,Talla: S,65.13,0.00
+__import__.product_template_sp1003_or,SP1003-OR/M,SP1003-OR/OM,M. CONJUNTO DE VESTIR P/DAMA ORANGE,Talla: M,65.13,0.00
+__import__.product_template_sp1003_or,SP1003-OR/L,SP1003-OR/OL,M. CONJUNTO DE VESTIR P/DAMA ORANGE,Talla: L,117.30,0.00
+__import__.product_template_sk2103_gr,SK2103-GR/L,SK2103-GR/OL,SIDE RUCHED HIGH WEAST MINI SKIRT GREEN,Talla: L,38.30,0.00
+__import__.product_template_sk2103_gr,SK2103-GR/S,SK2103-GR/OS,SIDE RUCHED HIGH WEAST MINI SKIRT GREEN,Talla: S,38.30,0.00
+__import__.product_template_sk2103_gr,SK2103-GR/M,SK2103-GR/OM,SIDE RUCHED HIGH WEAST MINI SKIRT GREEN,Talla: M,38.30,0.00
+__import__.product_template_acd70564_wh,ACD70564-WH/S,ACD70564-WH/OS,V-NECK BLOUSON SLEEVE DRESS WHITE,Talla: S,59.73,0.00
+__import__.product_template_acd70564_wh,ACD70564-WH/M,ACD70564-WH/OM,V-NECK BLOUSON SLEEVE DRESS WHITE,Talla: M,59.73,0.00
+__import__.product_template_acd70564_wh,ACD70564-WH/L,ACD70564-WH/OL,V-NECK BLOUSON SLEEVE DRESS WHITE,Talla: L,59.73,0.00
+__import__.product_template_acd70015l_ru,ACD70015L-RU/S,ACD70015L-RU/OS,BRA CUP MIJI DRESS WITH LACEUO BACK RUST MULTI,Talla: S,66.88,0.00
+__import__.product_template_acd70015l_ru,ACD70015L-RU/M,ACD70015L-RU/OM,BRA CUP MIJI DRESS WITH LACEUO BACK RUST MULTI,Talla: M,66.88,0.00
+__import__.product_template_acd70015l_ru,ACD70015L-RU/L,ACD70015L-RU/OL,BRA CUP MIJI DRESS WITH LACEUO BACK RUST MULTI,Talla: L,66.88,0.00
+__import__.product_template_acd70105_mo,ACD70105-MO/L,ACD70105-MO/OL,RUFFLE DETAIL WITH TIE FRONT DRESS MOCCHA,Talla: L,57.95,0.00
+__import__.product_template_acd70105_mo,ACD70105-MO/M,ACD70105-MO/OM,RUFFLE DETAIL WITH TIE FRONT DRESS MOCCHA,Talla: M,57.95,0.00
+__import__.product_template_acd70105_mo,ACD70105-MO/S,ACD70105-MO/OS,RUFFLE DETAIL WITH TIE FRONT DRESS MOCCHA,Talla: S,57.95,0.00
+__import__.product_template_acd70426_gd,ACD70426-GD/L,ACD70426-GD/OL,TWIST FRONT SLEEVE MINI DRESS GOLD,Talla: L,62.41,0.00
+__import__.product_template_acd70426_gd,ACD70426-GD/M,ACD70426-GD/OM,TWIST FRONT SLEEVE MINI DRESS GOLD,Talla: M,62.41,0.00
+__import__.product_template_acd70426_gd,ACD70426-GD/S,ACD70426-GD/OS,TWIST FRONT SLEEVE MINI DRESS GOLD,Talla: S,62.41,0.00
+__import__.product_template_acd70332d_la,ACD70332D-LA/L,ACD70332D-LA/OL,COWL CAMI DRESS LAVENDER,Talla: L,53.48,0.00
+__import__.product_template_acd70332d_la,ACD70332D-LA/M,ACD70332D-LA/OM,COWL CAMI DRESS LAVENDER,Talla: M,53.48,0.00
+__import__.product_template_acd70332d_la,ACD70332D-LA/S,ACD70332D-LA/OS,COWL CAMI DRESS LAVENDER,Talla: S,53.48,0.00
+__import__.product_template_acd70332f_sl,ACD70332F-SL/S,ACD70332F-SL/OS,COWL CAMI DRESS SLATE,Talla: S,50.80,0.00
+__import__.product_template_acd70332f_sl,ACD70332F-SL/M,ACD70332F-SL/OM,COWL CAMI DRESS SLATE,Talla: M,50.80,0.00
+__import__.product_template_acd70332f_sl,ACD70332F-SL/L,ACD70332F-SL/OL,COWL CAMI DRESS SLATE,Talla: L,50.80,0.00
+__import__.product_template_it3113_wh,IT3113-WH/S,IT3113-WH/OS,TUBE FEATHER TOP WHITE,Talla: S,58.84,0.00
+__import__.product_template_it3113_wh,IT3113-WH/M,IT3113-WH/OM,TUBE FEATHER TOP WHITE,Talla: M,58.84,0.00
+__import__.product_template_it3113_wh,IT3113-WH/L,IT3113-WH/OL,TUBE FEATHER TOP WHITE,Talla: L,58.84,0.00
+__import__.product_template_ist3803b_iv,IST3803B-IV/L,IST3803B-IV/OL,SNAKE PRINT 3 PCS SET IVORY,Talla: L,78.17,0.00
+__import__.product_template_ist3803b_iv,IST3803B-IV/M,IST3803B-IV/OM,SNAKE PRINT 3 PCS SET IVORY,Talla: M,78.17,0.00
+__import__.product_template_ist3803b_iv,IST3803B-IV/S,IST3803B-IV/OS,SNAKE PRINT 3 PCS SET IVORY,Talla: S,78.17,0.00
+__import__.product_template_dk2011_4bc_2,DK2011-4BC-2/52,DK20114202265234,Terno DK2011-4BC-2,Talla: 52,304.26,0.00
+__import__.product_template_zp_ant_ca_cassini,ZP-ANT-CA-CASSINI/10,ZP-ANT-CA-CASS/O10,Zapato ZP-ANT-CA-CASSINI,Talla: 10,152.09,0.00
+__import__.product_template_zp_ant_ca_cassini,ZP-ANT-CA-CASSINI/7.5,ZP-ANT-CA-CASS/O7.5,Zapato ZP-ANT-CA-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_ant_ca_cassini,ZP-ANT-CA-CASSINI/8.5,ZP-ANT-CA-CASS/O8.5,Zapato ZP-ANT-CA-CASSINI,Talla: 8.5,152.09,0.00
+__import__.product_template_zp_ant_ca_cassini,ZP-ANT-CA-CASSINI/9,ZP-ANT-CA-CASS/O9,Zapato ZP-ANT-CA-CASSINI,Talla: 9,130.35,0.00
+__import__.product_template_zp_ant_ca_cassini,ZP-ANT-CA-CASSINI/9.5,ZP-ANT-CA-CASS/O9.5,Zapato ZP-ANT-CA-CASSINI,Talla: 9.5,152.09,0.00
+__import__.product_template_zp_ant_ca_cassini,ZP-ANT-CA-CASSINI/8,ZP-ANT-CA-CASS/O8,Zapato ZP-ANT-CA-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_pat_na_cassini,ZP-PAT-NA-CASSINI/8,ZPPATNACASS/O8,Zapato ZP-PAT-NA-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_pat_vn_cassini,ZP-PAT-VN-CASSINI/8,ZPPATVNCASS/O8,Zapato ZP-PAT-VN-CASSINI,Talla: 8,152.09,0.00
+__import__.product_template_zp_ant_cassini,ZP-ANT-CASSINI/10,ZP-ANT-CASSINI/O10,Zapato ZP-ANT-CASSINI,Talla: 10,130.35,0.00
+__import__.product_template_zp_ant_cassini,ZP-ANT-CASSINI/9,ZP-ANT-CASSINI/O9,Zapato ZP-ANT-CASSINI,Talla: 9,152.09,0.00
+__import__.product_template_zp_ant_cassini,ZP-ANT-CASSINI/8,ZP-ANT-CASSINI/O8,Zapato ZP-ANT-CASSINI,Talla: 8,130.35,0.00
+__import__.product_template_zp_ant_cassini,ZP-ANT-CASSINI/7.5,ZP-ANT-CASSINI/O7.5,Zapato ZP-ANT-CASSINI,Talla: 7.5,152.09,0.00
+__import__.product_template_zp_ant_cassini,ZP-ANT-CASSINI/9.5,ZP-ANT-CASSINI/O9.5,Zapato ZP-ANT-CASSINI,Talla: 9.5,130.35,0.00
+__import__.product_template_zp_ant_cassini,ZP-ANT-CASSINI/8.5,ZP-ANT-CASSINI/O8.5,Zapato ZP-ANT-CASSINI,Talla: 8.5,130.35,0.00
+__import__.product_template_he005_2bc_2,HE005-2BC-2/46,HE00522022024628,Terno HE005-2BC-2,Talla: 46,217.30,0.00
+__import__.product_template_he005_2bc_2,HE005-2BC-2/48,HE00522022024830,Terno HE005-2BC-2,Talla: 48,191.22,0.00
+__import__.product_template_he005_2bc_2,HE005-2BC-2/50,HE00522022025032,Terno HE005-2BC-2,Talla: 50,217.30,0.00
+__import__.product_template_he005_2bc_2,HE005-2BC-2/52,HE00522022025234,Terno HE005-2BC-2,Talla: 52,217.30,0.00
+__import__.product_template_he005_2bc_2,HE005-2BC-2/56,HE00522022025638,Terno HE005-2BC-2,Talla: 56,217.30,0.00
+__import__.product_template_he005_2bc_2,HE005-2BC-2/58,HE00522022025840,Terno HE005-2BC-2,Talla: 58,191.22,0.00
+__import__.product_template_he005_2bc_2,HE005-2BC-2/54,HE00522022025436,Terno HE005-2BC-2,Talla: 54,191.22,0.00
+__import__.product_template_9c29118_15bc_2,9C29118-15BC-2/46,92911815202224628,Terno 9C29118-15BC-2,Talla: 46,243.39,0.00
+__import__.product_template_9c29118_15bc_2,9C29118-15BC-2/48,92911815202224830,Terno 9C29118-15BC-2,Talla: 48,243.39,0.00
+__import__.product_template_9c29118_15bc_2,9C29118-15BC-2/50,92911815202225032,Terno 9C29118-15BC-2,Talla: 50,243.39,0.00
+__import__.product_template_9c29118_15bc_2,9C29118-15BC-2/52,92911815202225234,Terno 9C29118-15BC-2,Talla: 52,243.39,0.00
+__import__.product_template_9c29118_15bc_2,9C29118-15BC-2/56,92911815202225638,Terno 9C29118-15BC-2,Talla: 56,243.39,0.00
+__import__.product_template_9c29118_15bc_2,9C29118-15BC-2/58,92911815202225840,Terno 9C29118-15BC-2,Talla: 58,243.39,0.00
+__import__.product_template_9c29118_15bc_2,9C29118-15BC-2/54,92911815202225436,Terno 9C29118-15BC-2,Talla: 54,243.39,0.00
+__import__.product_template_9a700112_3bc_2,9A700112-3BC-2/46,97001123202224628,Terno 9A700112-3BC-2,Talla: 46,243.39,0.00
+__import__.product_template_9a700112_3bc_2,9A700112-3BC-2/48,97001123202224830,Terno 9A700112-3BC-2,Talla: 48,243.39,0.00
+__import__.product_template_9a700112_3bc_2,9A700112-3BC-2/50,97001123202225032,Terno 9A700112-3BC-2,Talla: 50,243.39,0.00
+__import__.product_template_9a700112_3bc_2,9A700112-3BC-2/52,97001123202225234,Terno 9A700112-3BC-2,Talla: 52,243.39,0.00
+__import__.product_template_9a700112_3bc_2,9A700112-3BC-2/54,97001123202225436,Terno 9A700112-3BC-2,Talla: 54,243.39,0.00
+__import__.product_template_9a700112_3bc_2,9A700112-3BC-2/56,97001123202225638,Terno 9A700112-3BC-2,Talla: 56,243.39,0.00
+__import__.product_template_9a700112_3bc_2,9A700112-3BC-2/58,97001123202225840,Terno 9A700112-3BC-2,Talla: 58,243.39,0.00
+__import__.product_template_9c29386_81bc_2,9C29386-81BC-2/46,9C2938681202224628,Terno 9C29386-81BC-2,Talla: 46,217.30,0.00
+__import__.product_template_9c29386_81bc_2,9C29386-81BC-2/52,9C2938681202225234,Terno 9C29386-81BC-2,Talla: 52,217.30,0.00
+__import__.product_template_9c29386_81bc_2,9C29386-81BC-2/54,9C2938681202225436,Terno 9C29386-81BC-2,Talla: 54,191.22,0.00
+__import__.product_template_9c29386_81bc_2,9C29386-81BC-2/56,9C2938681202225638,Terno 9C29386-81BC-2,Talla: 56,217.30,0.00
+__import__.product_template_9c29386_81bc_2,9C29386-81BC-2/58,9C2938681202225840,Terno 9C29386-81BC-2,Talla: 58,217.30,0.00
+__import__.product_template_9c29386_81bc_2,9C29386-81BC-2/48,9C2938681202224830,Terno 9C29386-81BC-2,Talla: 48,191.22,0.00
+__import__.product_template_9c29386_81bc_2,9C29386-81BC-2/50,9C2938681202225032,Terno 9C29386-81BC-2,Talla: 50,191.22,0.00
+__import__.product_template_9c29386_80bc_2,9C29386-80BC-2/48,9C2938680202224830,Terno 9C29386-80BC-2,Talla: 48,243.39,0.00
+__import__.product_template_9c29386_80bc_2,9C29386-80BC-2/50,9C2938680202225032,Terno 9C29386-80BC-2,Talla: 50,243.39,0.00
+__import__.product_template_9c29386_80bc_2,9C29386-80BC-2/52,9C2938680202225234,Terno 9C29386-80BC-2,Talla: 52,243.39,0.00
+__import__.product_template_9c29386_80bc_2,9C29386-80BC-2/54,9C2938680202225436,Terno 9C29386-80BC-2,Talla: 54,243.39,0.00
+__import__.product_template_9c29386_80bc_2,9C29386-80BC-2/56,9C2938680202225638,Terno 9C29386-80BC-2,Talla: 56,243.39,0.00
+__import__.product_template_9c29386_80bc_2,9C29386-80BC-2/58,9C2938680202225840,Terno 9C29386-80BC-2,Talla: 58,243.39,0.00
+__import__.product_template_9c29386_80bc_2,9C29386-80BC-2/46,9C2938680202224628,Terno 9C29386-80BC-2,Talla: 46,243.39,0.00
+__import__.product_template_9e2712_9bc_2,9E2712-9BC-2/46,9E271292022024628,Terno 9E2712-9BC-2,Talla: 46,217.30,0.00
+__import__.product_template_9e2712_9bc_2,9E2712-9BC-2/48,9E271292022024830,Terno 9E2712-9BC-2,Talla: 48,191.22,0.00
+__import__.product_template_9e2712_9bc_2,9E2712-9BC-2/50,9E271292022025032,Terno 9E2712-9BC-2,Talla: 50,191.22,0.00
+__import__.product_template_9e2712_9bc_2,9E2712-9BC-2/52,9E271292022025234,Terno 9E2712-9BC-2,Talla: 52,191.22,0.00
+__import__.product_template_9e2712_9bc_2,9E2712-9BC-2/54,9E271292022025436,Terno 9E2712-9BC-2,Talla: 54,191.22,0.00
+__import__.product_template_9e2712_9bc_2,9E2712-9BC-2/56,9E271292022025638,Terno 9E2712-9BC-2,Talla: 56,243.39,0.00
+__import__.product_template_9e2712_9bc_2,9E2712-9BC-2/58,9E271292022025840,Terno 9E2712-9BC-2,Talla: 58,243.39,0.00
+__import__.product_template_9a0343_1bc_2,9A0343-1BC-2/58,9A034312022025840,Terno 9A0343-1BC-2,Talla: 58,243.39,0.00
+__import__.product_template_9a0343_1bc_2,9A0343-1BC-2/56,9A034312022025638,Terno 9A0343-1BC-2,Talla: 56,243.39,0.00
+__import__.product_template_9a0343_1bc_2,9A0343-1BC-2/54,9A034312022025436,Terno 9A0343-1BC-2,Talla: 54,243.39,0.00
+__import__.product_template_9a0343_1bc_2,9A0343-1BC-2/52,9A034312022025234,Terno 9A0343-1BC-2,Talla: 52,243.39,0.00
+__import__.product_template_9a0343_1bc_2,9A0343-1BC-2/50,9A034312022025032,Terno 9A0343-1BC-2,Talla: 50,243.39,0.00
+__import__.product_template_9a0343_1bc_2,9A0343-1BC-2/48,9A034312022024830,Terno 9A0343-1BC-2,Talla: 48,243.39,0.00
+__import__.product_template_9a0343_1bc_2,9A0343-1BC-2/46,9A034312022024628,Terno 9A0343-1BC-2,Talla: 46,243.39,0.00
+__import__.product_template_kan_anhoa,KAN-ANHOA/28,KAN-ANHOA/O28,Terno KAN-ANHOA,Talla: 28,40.09,0.00
+__import__.product_template_h_6_119,H-6-119-17-S2,H6119202211702,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 34-35,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_h_6_119,H-6-119-17-S1,H6119202211701,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 34-35,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_h_6_119,H-6-119-15.5-S2,H6119202211552,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_h_6_119,H-6-119-15.5-S1,H6119202211551,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_h_6_119,H-6-119-14.5-S2,H6119202211452,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 34-35,"Talla: 14.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_h_6_119,H-6-119-14.5-S1,H6119202211451,H. CAMISA P/S BRUNO CASSINI CUADRO BLUE 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_hd42_b122bg,HD42-B122BG-19-S2,42B122B20221902,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35 (hd42_b122bg),"Talla: 19, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_hd42_b122bg,HD42-B122BG-19-S1,42B122B20221901,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35 (hd42_b122bg),"Talla: 19, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_hd42_b122bu,HD42-B122BU-16.5-S2,42B122BU20221652,H. CAMISA P/S BRUNO CASSINI BLUE 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_hd42_b122bu,HD42-B122BU-16.5-S1,42B122BU20221651,H. CAMISA P/S BRUNO CASSINI BLUE 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_hd42_b122bu,HD42-B122BU-15.5-S2,42B122BU20221552,H. CAMISA P/S BRUNO CASSINI BLUE 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_hd42_b122bu,HD42-B122BU-15.5-S1,42B122BU20221551,H. CAMISA P/S BRUNO CASSINI BLUE 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_8150_34,8150-34-14.5-S2,81503420221452,H. CAMISA P/S BRUNO CASSINI NAVY 34-35,"Talla: 14.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_8150_34,8150-34-15.5-S2,81503420221552,H. CAMISA P/S BRUNO CASSINI NAVY 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_8150_34,8150-34-14.5-S1,81503420221451,H. CAMISA P/S BRUNO CASSINI NAVY 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_8150_34,8150-34-15.5-S1,81503420221551,H. CAMISA P/S BRUNO CASSINI NAVY 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_150bg_3,150BG-3-18.5-S2,15032022011852,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35 (150bg_3),"Talla: 18.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_150bg_3,150BG-3-18.5-S1,15032022011851,H. CAMISA P/S BIG SIZE BRUNO CASSINI WHITE 34-35 (150bg_3),"Talla: 18.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_16306,16306-17-S2,163062022011702,Camisa 16306,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_16306,16306-17-S1,163062022011701,Camisa 16306,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_16306,16306-16.5-S2,163062022011652,Camisa 16306,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_z_1759siuk_az,Z-1759SIUK-AZ/38,Z-1759SIUK-AZ/O38,Terno Z-1759SIUK-AZ,Talla: 38,99.05,0.00
+__import__.product_template_16306,16306-16.5-S1,163062022011651,Camisa 16306,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_16306,16306-14.5-S2,163062022011452,Camisa 16306,"Talla: 14.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_16306,16306-14.5-S1,163062022011451,Camisa 16306,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_17605bg,17605BG-20-S2,176052022012002,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 20, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605bg,17605BG-20-S1,170652022012001,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 20, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605bg,17605BG-19.5-S2,176052022011952,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 19.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605bg,17605BG-19.5-S1,170652022011951,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 19.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605bg,17605BG-19-S2,176052022011902,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 19, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605bg,17605BG-19-S1,176052022011901,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 19, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605bg,17605BG-18.5-S2,176052022011852,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 18.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605bg,17605BG-18.5-S1,176052022011851,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 18.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605bg,17605BG-18-S2,176052022011802,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 18, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605bg,17605BG-18-S1,176052022011801,H. CAMISA P/S BIG SIZE BRUNO CASSINI BLACK 34-35 (17605bg),"Talla: 18, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_11901,11901-16.5-S2,119012022011652,Camisa 11901,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_11901,11901-16.5-S1,119012022011651,Camisa 11901,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_12001,12001-17-S2,120012022011702,Camisa 12001,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_12001,12001-17-S1,120012022011701,Camisa 12001,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_11701,11701-17-S2,117012022011702,Camisa 11701,"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_12001,12001-16.5-S2,120012022011652,Camisa 12001,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_11701,11701-17-S1,117012022011701,Camisa 11701,"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_12001,12001-16.5-S1,120012022011651,Camisa 12001,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_11701,11701-16.5-S2,117012022011652,Camisa 11701,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_11701,11701-16.5-S1,117012022011651,Camisa 11701,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_12001,12001-15.5-S2,120012022011552,Camisa 12001,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_11701,11701-15.5-S2,117012022011552,Camisa 11701,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_11701,11701-15.5-S1,117012022011551,Camisa 11701,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_12001,12001-15.5-S1,120012022011551,Camisa 12001,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-17.5-S2,42B10820221752,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-17.5-S1,42B10820221751,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 17.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-17-S2,42B10820221702,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-17-S1,42B10820221701,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-16.5-S2,42B10820221652,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-16.5-S1,42B10820221651,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-15.5-S2,42B10820221552,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_hd42b_108,HD42B-108-15.5-S1,42B10820221551,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (hd42b_108),"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_150_3,150-3-17.5-S2,15032022011752,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (150_3),"Talla: 17.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_150_3,150-3-17.5-S1,15032022011751,H. CAMISA P/S BRUNO CASSINI WHITE 34-35 (150_3),"Talla: 17.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_17605,17605-17.5-S2,176052022011752,Camisa 17605,"Talla: 17.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605,17605-17.5-S1,176052022011751,Camisa 17605,"Talla: 17.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_17605,17605-17-S2,176052022011702,Camisa 17605,"Talla: 17, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605,17605-17-S1,176052022011701,Camisa 17605,"Talla: 17, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605,17605-16.5-S2,176052022011652,Camisa 17605,"Talla: 16.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605,17605-16.5-S1,176052022011651,Camisa 17605,"Talla: 16.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605,17605-16-S2,176052022011602,Camisa 17605,"Talla: 16, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605,17605-16-S1,176052022011601,Camisa 17605,"Talla: 16, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605,17605-15.5-S2,176052022011552,Camisa 17605,"Talla: 15.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605,17605-15.5-S1,176052022011551,Camisa 17605,"Talla: 15.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605,17605-15-S2,176052022011502,Camisa 17605,"Talla: 15, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605,17605-15-S1,176052022011501,Camisa 17605,"Talla: 15, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_17605,17605-14.5-S2,176052022011452,Camisa 17605,"Talla: 14.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_17605,17605-14.5-S1,176052022011451,Camisa 17605,"Talla: 14.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_562dc,562DC-16.5-S2,56DC22022011652,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_562dc,562DC-16.5-S1,56DC22022011651,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_562dc,562DC-16-S2,56DC22022011602,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 16, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_562dc,562DC-16-S1,56DC22022011601,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 16, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_562dc,562DC-15.5-S2,56DC22022011552,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_562dc,562DC-15.5-S1,56DC22022011551,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_562dc,562DC-14.5-S2,56DC22022011452,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 14.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_562dc,562DC-14.5-S1,56DC22022011451,H. CAMISA D/P BRUNO CASSINI BLUE POINT 34-35,"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_603_3,603-3-15-S1,603320221501,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (603_3),"Talla: 15, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_603_3,603-3-15-S2,603320221502,H. CAMISA P/S BRUNO CASSINI LINEN BLUE 32-33 (603_3),"Talla: 15, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_hd42_b116,HD42-B116-14.5-S1,42B116202221451,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 14.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-14.5-S2,42B116202221452,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 14.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-15-S1,42B116202221501,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 15, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-15.5-S1,42B116202221551,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-15.5-S2,42B116202221552,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-16-S2,42B116202221602,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 16, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-16.5-S1,42B116202221651,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 16.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-16.5-S2,42B116202221652,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 16.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-17-S1,42B116202221701,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 17, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-17-S2,42B116202221702,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 17, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-15-S2,42B116202221502,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 15, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-17.5-S1,42B116202221751,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 17.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-17.5-S2,42B116202221752,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 17.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_hd42_b116,HD42-B116-16-S1,42B116202221601,H. CAMISA P/S BRUNO CASSINI WHITE 32-33 (hd42_b116),"Talla: 16, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_hd42_126l,HD42-126L-17-S1,42126L20221701,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33 (hd42_126l),"Talla: 17, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_hd42_126l,HD42-126L-17-S2,42126L20221702,H. CAMISA P/S BRUNO CASSINI LIGHT BLUE 32-33 (hd42_126l),"Talla: 17, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_562,562-15.5-S2,5622022011552,Camisa 562,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_562,562-15.5-S1,5622022011551,Camisa 562,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_8504,8504-17.5-S2,85042022011752,Camisa 8504,"Talla: 17.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8504,8504-17.5-S1,85042022011751,Camisa 8504,"Talla: 17.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_8504,8504-17-S2,85042022011702,Camisa 8504,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8504,8504-17-S1,85042022011701,Camisa 8504,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8504,8504-16.5-S2,85042022011652,Camisa 8504,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8504,8504-16.5-S1,85042022011651,Camisa 8504,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8504,8504-16-S2,85042022011602,Camisa 8504,"Talla: 16, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8504,8504-16-S1,85042022011601,Camisa 8504,"Talla: 16, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8504,8504-15.5-S2,85042022011552,Camisa 8504,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8504,8504-15.5-S1,85042022011551,Camisa 8504,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8504,8504-15-S2,85042022011502,Camisa 8504,"Talla: 15, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_8504,8504-15-S1,85042022011501,Camisa 8504,"Talla: 15, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_8504,8504-14.5-S2,85042022011452,Camisa 8504,"Talla: 14.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_8504,8504-14.5-S1,85042022011451,Camisa 8504,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_19203,19203-15.5-S2,192032022011552,Camisa 19203,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_19203,19203-15.5-S1,192032022011551,Camisa 19203,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_7306,7306-14.5-S2,73062022011452,Camisa 7306,"Talla: 14.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_7306,7306-15.5-S1,73062022011551,Camisa 7306,"Talla: 15.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_7306,7306-15.5-S2,73062022011552,Camisa 7306,"Talla: 15.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_7306,7306-14.5-S1,73062022011451,Camisa 7306,"Talla: 14.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_7306,7306-16.5-S1,73062022011651,Camisa 7306,"Talla: 16.5, Manga de Camisa: S1 - 32/33",43.39,0.00
+__import__.product_template_7306,7306-16.5-S2,73062022011652,Camisa 7306,"Talla: 16.5, Manga de Camisa: S2 - 34/35",43.39,0.00
+__import__.product_template_z_3021lamo_ne,Z-3021LAMO-NE/38,Z-3021LAMO-NE/O38,Terno Z-3021LAMO-NE,Talla: 38,86.87,0.00
+__import__.product_template_z_5325clape_mo,Z-5325CLAPE-MO/38,Z-5325CLAPE-MO/O38,Terno Z-5325CLAPE-MO,Talla: 38,95.57,0.00
+__import__.product_template_z_2836_dfv_na,Z-2836-DFV-NA/38,Z-2836-DFV-NA/O38,Terno Z-2836-DFV-NA,Talla: 38,102.52,0.00
+__import__.product_template_z_2839dfv_gd,Z-2839DFV-GD/38,Z-2839DFV-GD/O38,Terno Z-2839DFV-GD,Talla: 38,105.27,0.00
+__import__.product_template_z_2839dfv_ne,Z-2839DFV-NE/38,Z-2839DFV-NE/O38,Terno Z-2839DFV-NE,Talla: 38,102.52,0.00
+__import__.product_template_pt_s100302_8,PT-S100302-8/32,PT-S100302-8/O32,Pantalon PT-S100302-8,Talla: 32,117.30,0.00
+__import__.product_template_pt_s100302_8,PT-S100302-8/34,PT-S100302-8/O34,Pantalon PT-S100302-8,Talla: 34,117.30,0.00
+__import__.product_template_pt_s100302_8,PT-S100302-8/38,PT-S100302-8/O38,Pantalon PT-S100302-8,Talla: 38,117.30,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/56,TL-10-500E.A/O56,Terno TL-10-500E.A,Talla: 56,260.78,0.00
+__import__.product_template_opbb0099_010,OPBB0099-010/30,OPBB0099-010/O30,Terno OPBB0099-010,Talla: 30,73.83,0.00
+__import__.product_template_opbb0099_010,OPBB0099-010/31,OPBB0099-010/O31,Terno OPBB0099-010,Talla: 31,73.83,0.00
+__import__.product_template_opbb0099_010,OPBB0099-010/32,OPBB0099-010/32,Terno OPBB0099-010,Talla: 32,73.83,0.00
+__import__.product_template_opbb0099_010,OPBB0099-010/33,OPBB0099-010/O33,Terno OPBB0099-010,Talla: 33,73.83,0.00
+__import__.product_template_opbb0099_010,OPBB0099-010/34,OPBB0099-010/O34,Terno OPBB0099-010,Talla: 34,73.83,0.00
+__import__.product_template_opbb0099_010,OPBB0099-010/36,OPBB0099-010/O36,Terno OPBB0099-010,Talla: 36,73.83,0.00
+__import__.product_template_opbb0099_010,OPBB0099-010/38,OPBB0099-010/O38,Terno OPBB0099-010,Talla: 38,73.83,0.00
+__import__.product_template_opksb183_118,OPKSB183-118/XL,799016091729,H. CAMISETA P/HOMBRE M/C PENGUIN BRIGHT WHITE,Talla: XL,56.43,0.00
+__import__.product_template_opksb183_118,OPKSB183-118/L,799016091712,H. CAMISETA P/HOMBRE M/C PENGUIN BRIGHT WHITE,Talla: L,56.43,0.00
+__import__.product_template_opksb183_118,OPKSB183-118/M,799016091705,H. CAMISETA P/HOMBRE M/C PENGUIN BRIGHT WHITE,Talla: M,56.43,0.00
+__import__.product_template_opksb183_118,OPKSB183-118/S,799016091699,H. CAMISETA P/HOMBRE M/C PENGUIN BRIGHT WHITE,Talla: S,56.43,0.00
+__import__.product_template_cb_g22_002nv,CB-G22-002NV/40,7453097405495,Terno CB-G22-002NV,Talla: 40,56.43,0.00
+__import__.product_template_cb_g22_002nv,CB-G22-002NV/38,7453097405488,Terno CB-G22-002NV,Talla: 38,56.43,0.00
+__import__.product_template_cb_g22_002nv,CB-G22-002NV/36,7453097405471,Terno CB-G22-002NV,Talla: 36,56.43,0.00
+__import__.product_template_cb_g22_002nv,CB-G22-002NV/34,7453097405464,Terno CB-G22-002NV,Talla: 34,56.43,0.00
+__import__.product_template_cb_g22_002nv,CB-G22-002NV/32,7453097405457,Terno CB-G22-002NV,Talla: 32,56.43,0.00
+__import__.product_template_cb_g22_002nv,CB-G22-002NV/30,CB-G22-002NV/O30,Terno CB-G22-002NV,Talla: 30,56.43,0.00
+__import__.product_template_cb_g22_002sd,CB-G22-002SD/40,7453097405440,Terno CB-G22-002SD,Talla: 40,56.43,0.00
+__import__.product_template_cb_g22_002sd,CB-G22-002SD/38,7453097405662,Terno CB-G22-002SD,Talla: 38,56.43,0.00
+__import__.product_template_cb_g22_002sd,CB-G22-002SD/36,7453097405655,Terno CB-G22-002SD,Talla: 36,56.43,0.00
+__import__.product_template_cb_g22_002sd,CB-G22-002SD/34,7453097405648,Terno CB-G22-002SD,Talla: 34,56.43,0.00
+__import__.product_template_cb_g22_002sd,CB-G22-002SD/32,7453097405631,Terno CB-G22-002SD,Talla: 32,56.43,0.00
+__import__.product_template_cb_g22_002sd,CB-G22-002SD/30,7453097405624,Terno CB-G22-002SD,Talla: 30,56.43,0.00
+__import__.product_template_cb_g22_002bw,CB-G22-002BW/40,7453097405730,Terno CB-G22-002BW,Talla: 40,56.43,0.00
+__import__.product_template_cb_g22_002bw,CB-G22-002BW/38,7453097405723,Terno CB-G22-002BW,Talla: 38,56.43,0.00
+__import__.product_template_cb_g22_002bw,CB-G22-002BW/36,7453097405716,Terno CB-G22-002BW,Talla: 36,56.43,0.00
+__import__.product_template_cb_g22_002bw,CB-G22-002BW/34,7453097405709,Terno CB-G22-002BW,Talla: 34,56.43,0.00
+__import__.product_template_cb_g22_002bw,CB-G22-002BW/32,7453097405693,Terno CB-G22-002BW,Talla: 32,56.43,0.00
+__import__.product_template_cb_g22_002bw,CB-G22-002BW/30,7453097405686,Terno CB-G22-002BW,Talla: 30,56.43,0.00
+__import__.product_template_cuwf9040_640,CUWF9040-640/XL,084971096330,H. CAMISA P/HOMBRE M/C CUBAVERA BIKING RED,Talla: XL,78.17,0.00
+__import__.product_template_cuwf9040_640,CUWF9040-640/L,084971096323,H. CAMISA P/HOMBRE M/C CUBAVERA BIKING RED,Talla: L,78.17,0.00
+__import__.product_template_cuwf9040_640,CUWF9040-640/M,084971096316,H. CAMISA P/HOMBRE M/C CUBAVERA BIKING RED,Talla: M,78.17,0.00
+__import__.product_template_cuwf9040_640,CUWF9040-640/S,084971096309,H. CAMISA P/HOMBRE M/C CUBAVERA BIKING RED,Talla: S,78.17,0.00
+__import__.product_template_cv_q11_060hgr,CV-Q11-060HGR/36,7448329461448,Terno CV-Q11-060HGR,Talla: 36,191.22,0.00
+__import__.product_template_cv_q11_060hgr,CV-Q11-060HGR/38,7448330039018,Terno CV-Q11-060HGR,Talla: 38,217.30,0.00
+__import__.product_template_cv_q11_060hgr,CV-Q11-060HGR/40,7448332969931,Terno CV-Q11-060HGR,Talla: 40,304.26,0.00
+__import__.product_template_cv_q11_060hgr,CV-Q11-060HGR/42,7448335670636,Terno CV-Q11-060HGR,Talla: 42,191.22,0.00
+__import__.product_template_cv_q11_060hgr,CV-Q11-060HGR/44,7448332632682,Terno CV-Q11-060HGR,Talla: 44,191.22,0.00
+__import__.product_template_cv_q11_060hgr,CV-Q11-060HGR/46,7448340841854,Terno CV-Q11-060HGR,Talla: 46,191.22,0.00
+__import__.product_template_b9sut124_lt_bl,B9SUT124-LT-BL/48,B9SUT124-LT-BL/O48,Terno B9SUT124-LT-BL,Talla: 48,217.30,0.00
+__import__.product_template_b9sut124_lt_bl,B9SUT124-LT-BL/46,B9SUT124-LT-BL/O46,Terno B9SUT124-LT-BL,Talla: 46,217.30,0.00
+__import__.product_template_b9sut124_lt_bl,B9SUT124-LT-BL/44,B9SUT124-LT-BL/O44,Terno B9SUT124-LT-BL,Talla: 44,217.30,0.00
+__import__.product_template_b9sut124_lt_bl,B9SUT124-LT-BL/42,B9SUT124-LT-BL/O42,Terno B9SUT124-LT-BL,Talla: 42,217.30,0.00
+__import__.product_template_b9sut124_lt_bl,B9SUT124-LT-BL/40,B9SUT124-LT-BL/O40,Terno B9SUT124-LT-BL,Talla: 40,217.30,0.00
+__import__.product_template_b9sut124_lt_bl,B9SUT124-LT-BL/38,B9SUT124-LT-BL/O38,Terno B9SUT124-LT-BL,Talla: 38,217.30,0.00
+__import__.product_template_b9sut124_lt_bl,B9SUT124-LT-BL/36,B9SUT124-LT-BL/O36,Terno B9SUT124-LT-BL,Talla: 36,217.30,0.00
+__import__.product_template_ophb0099_010_op,OPHB0099-010.OP/38,691046761699,Terno OPHB0099-010.OP,Talla: 38,65.13,0.00
+__import__.product_template_ophb0099_010_op,OPHB0099-010.OP/36,691046761682,Terno OPHB0099-010.OP,Talla: 36,65.13,0.00
+__import__.product_template_ophb0099_010_op,OPHB0099-010.OP/34,691046761675,Terno OPHB0099-010.OP,Talla: 34,65.13,0.00
+__import__.product_template_ophb0099_010_op,OPHB0099-010.OP/33,691046761668,Terno OPHB0099-010.OP,Talla: 33,65.13,0.00
+__import__.product_template_ophb0099_010_op,OPHB0099-010.OP/32,691046761651,Terno OPHB0099-010.OP,Talla: 32,65.13,0.00
+__import__.product_template_ophb0099_010_op,OPHB0099-010.OP/31,691046761644,Terno OPHB0099-010.OP,Talla: 31,65.13,0.00
+__import__.product_template_ophb0099_010_op,OPHB0099-010.OP/30,691046761637,Terno OPHB0099-010.OP,Talla: 30,65.13,0.00
+__import__.product_template_ophb0099_413_op,OPHB0099-413.OP/38,691046762054,Terno OPHB0099-413.OP,Talla: 38,65.13,0.00
+__import__.product_template_ophb0099_413_op,OPHB0099-413.OP/32,691046762016,Terno OPHB0099-413.OP,Talla: 32,65.13,0.00
+__import__.product_template_ophb0099_413_op,OPHB0099-413.OP/30,691046761996,Terno OPHB0099-413.OP,Talla: 30,65.13,0.00
+__import__.product_template_ophb0099_413_op,OPHB0099-413.OP/36,691046762047,Terno OPHB0099-413.OP,Talla: 36,65.13,0.00
+__import__.product_template_ophb0099_413_op,OPHB0099-413.OP/33,691046762023,Terno OPHB0099-413.OP,Talla: 33,65.13,0.00
+__import__.product_template_ophb0099_413_op,OPHB0099-413.OP/34,691046762030,Terno OPHB0099-413.OP,Talla: 34,65.13,0.00
+__import__.product_template_ophb0099_413_op,OPHB0099-413.OP/31,691046762009,Terno OPHB0099-413.OP,Talla: 31,65.13,0.00
+__import__.product_template_pt_025_2,PT-025-2/30,PT-025-2/O30,Pantalon PT-025-2,Talla: 30,39.04,0.00
+__import__.product_template_fund_neg,FUND-NEG-16,FUND-NEG-16,FUNDA PREMIUN NEGRA P/ACCESORIO,Talla: 16,2.00,0.00
+__import__.product_template_pt_s100302_8,PT-S100302-8/40,PT-S100302-8/O40,Pantalon PT-S100302-8,Talla: 40,117.30,0.00
+__import__.product_template_cuwsb009_112,CUWSB009-112/XL,84971664164,H. GUAYABERA CUBAVERA LINO P/CABALLERO BRILLIANT WHITE,Talla: XL,82.52,0.00
+__import__.product_template_cuwsb009_112,CUWSB009-112/S,84971664133,H. GUAYABERA CUBAVERA LINO P/CABALLERO BRILLIANT WHITE,Talla: S,82.52,0.00
+__import__.product_template_cuwsb009_112,CUWSB009-112/M,84971664140,H. GUAYABERA CUBAVERA LINO P/CABALLERO BRILLIANT WHITE,Talla: M,82.52,0.00
+__import__.product_template_cuwsb009_112,CUWSB009-112/L,84971664157,H. GUAYABERA CUBAVERA LINO P/CABALLERO BRILLIANT WHITE,Talla: L,82.52,0.00
+__import__.product_template_lbpc_j21_001_wi,LBPC-J21-001-WI/30,691046790033,Terno LBPC-J21-001-WI,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_j21_001_wi,LBPC-J21-001-WI/32,691046790040,Terno LBPC-J21-001-WI,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_001_wi,LBPC-J21-001-WI/34,691046790057,Terno LBPC-J21-001-WI,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_001_wi,LBPC-J21-001-WI/36,691046790064,Terno LBPC-J21-001-WI,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_001_wi,LBPC-J21-001-WI/38,691046790071,Terno LBPC-J21-001-WI,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_001_wi,LBPC-J21-001-WI/40,691046790088,Terno LBPC-J21-001-WI,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ta,LBPC-J21-002F-TA/40,691046691712,Terno LBPC-J21-002F-TA,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ta,LBPC-J21-002F-TA/38,691046691705,Terno LBPC-J21-002F-TA,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ta,LBPC-J21-002F-TA/36,691046691699,Terno LBPC-J21-002F-TA,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ta,LBPC-J21-002F-TA/34,691046691682,Terno LBPC-J21-002F-TA,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ta,LBPC-J21-002F-TA/32,691046691675,Terno LBPC-J21-002F-TA,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ta,LBPC-J21-002F-TA/30,691046691668,Terno LBPC-J21-002F-TA,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_j21_002f_st,LBPC-J21-002F-ST/40,691046691354,Terno LBPC-J21-002F-ST,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_002f_st,LBPC-J21-002F-ST/38,691046691347,Terno LBPC-J21-002F-ST,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_002f_st,LBPC-J21-002F-ST/36,691046691330,Terno LBPC-J21-002F-ST,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_002f_st,LBPC-J21-002F-ST/34,691046691323,Terno LBPC-J21-002F-ST,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_002f_st,LBPC-J21-002F-ST/32,691046691316,Terno LBPC-J21-002F-ST,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_002f_st,LBPC-J21-002F-ST/30,691046691309,Terno LBPC-J21-002F-ST,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sl,LBPC-J21-002F-SL/40,691046691590,Terno LBPC-J21-002F-SL,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sl,LBPC-J21-002F-SL/38,691046691583,Terno LBPC-J21-002F-SL,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sl,LBPC-J21-002F-SL/36,691046691576,Terno LBPC-J21-002F-SL,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sl,LBPC-J21-002F-SL/34,691046691569,Terno LBPC-J21-002F-SL,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sl,LBPC-J21-002F-SL/32,691046691552,Terno LBPC-J21-002F-SL,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sl,LBPC-J21-002F-SL/30,691046691545,Terno LBPC-J21-002F-SL,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sd,LBPC-J21-002F-SD/40,691046691774,Terno LBPC-J21-002F-SD,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sd,LBPC-J21-002F-SD/38,691046691767,Terno LBPC-J21-002F-SD,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sd,LBPC-J21-002F-SD/36,691046691750,Terno LBPC-J21-002F-SD,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sd,LBPC-J21-002F-SD/34,691046691743,Terno LBPC-J21-002F-SD,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sd,LBPC-J21-002F-SD/32,691046691736,Terno LBPC-J21-002F-SD,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_002f_sd,LBPC-J21-002F-SD/30,691046691728,Terno LBPC-J21-002F-SD,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_j21_002f_och,LBPC-J21-002F-OCH/40,691046691651,Terno LBPC-J21-002F-OCH,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_002f_och,LBPC-J21-002F-OCH/38,691046691644,Terno LBPC-J21-002F-OCH,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_002f_och,LBPC-J21-002F-OCH/36,691046691637,Terno LBPC-J21-002F-OCH,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_002f_och,LBPC-J21-002F-OCH/34,691046691620,Terno LBPC-J21-002F-OCH,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_002f_och,LBPC-J21-002F-OCH/32,691046691613,Terno LBPC-J21-002F-OCH,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_002f_och,LBPC-J21-002F-OCH/30,691046691606,Terno LBPC-J21-002F-OCH,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ja,LBPC-J21-002F-JA/40,691046691477,Terno LBPC-J21-002F-JA,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ja,LBPC-J21-002F-JA/38,691046691460,Terno LBPC-J21-002F-JA,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ja,LBPC-J21-002F-JA/36,691046691453,Terno LBPC-J21-002F-JA,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ja,LBPC-J21-002F-JA/34,691046691446,Terno LBPC-J21-002F-JA,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ja,LBPC-J21-002F-JA/32,691046691439,Terno LBPC-J21-002F-JA,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_002f_ja,LBPC-J21-002F-JA/30,691046691422,Terno LBPC-J21-002F-JA,Talla: 30,43.39,0.00
+__import__.product_template_z_sd913davi_rd,Z-SD913DAVI-RD/38,Z-SD913DAVI-RD/O38,Terno Z-SD913DAVI-RD,Talla: 38,98.13,0.00
+__import__.product_template_z_sd391davi_bl,Z-SD391DAVI-BL/38,Z-SD391DAVI-BL/O38,Terno Z-SD391DAVI-BL,Talla: 38,95.57,0.00
+__import__.product_template_z_sd391davi_bl,Z-SD391DAVI-BL/36,Z-SD391DAVI-BL/O36,Terno Z-SD391DAVI-BL,Talla: 36,98.13,0.00
+__import__.product_template_z_1475c_n,Z-1475C-N/38,Z-1475C-N/O38,Terno Z-1475C-N,Talla: 38,99.91,0.00
+__import__.product_template_z_1475c_n,Z-1475C-N/36,Z-1475C-N/O36,Terno Z-1475C-N,Talla: 36,99.91,0.00
+__import__.product_template_pt_k10189_7,PT-K10189-7/30,PT-K10189-7/O30,Pantalon PT-K10189-7,Talla: 30,117.30,0.00
+__import__.product_template_3_2_d_9_bu,3-2-D#9-BU-15.5-S2,32D92021BU1552,H. CAMISA P/CABALLERO P/S BLUE 34-35 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_3_2_d_9_bu,3-2-D#9-BU-14.5-S1,32D92021BU1451,H. CAMISA P/CABALLERO P/S BLUE 34-35 BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_3_2_d_9_bu,3-2-D#9-BU-15.5-S1,32D92021BU1551,H. CAMISA P/CABALLERO P/S BLUE 34-35 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_58c_29c_bu,58C#29C-BU-14.5-S1,58C292021BU1451,H. CAMISA P/CABALLERO P/S BLUE 32-33 BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_58c_29c_bu,58C#29C-BU-15.5-S1,58C292021BU1551,H. CAMISA P/CABALLERO P/S BLUE 32-33 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_58c_29c_bu,58C#29C-BU-15.5-S2,58C292021BU1552,H. CAMISA P/CABALLERO P/S BLUE 32-33 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_3_2_d_17_bu,3-2-D#17-BU-14.5-S1,32D172021BU1451,H. CAMISA P/CABALLERO P/S BLUE 32-33 BRUNO CASSINI (3_2_d_17_bu),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_enstdo_4_bu,ENSTDO#4-BU-14.5-S1,ENST42021BU1451,H. CAMISA P/CABALLERO P/S BLUE 32-33 BRUNO CASSINI (enstdo_4_bu),"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_3_2mh_or,3-2MH-OR-16.5-S2,32MH2021OR1652,H. CAMISA P/CABALLERO P/S ORANGE 34-35 BRUNO CASSINI,"Talla: 16.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_3_2mh_or,3-2MH-OR-16.5-S1,32MH2021OR1651,H. CAMISA P/CABALLERO P/S ORANGE 34-35 BRUNO CASSINI,"Talla: 16.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_3_2tc_rd,3-2TC-RD-17-S2,32TC2021RD1702,H. CAMISA P/CABALLERO P/S RED 34-35 BRUNO CASSINI,"Talla: 17, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_3_2tc_rd,3-2TC-RD-17-S1,32TC2021RD1701,H. CAMISA P/CABALLERO P/S RED 34-35 BRUNO CASSINI,"Talla: 17, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_3_2tc_rd,3-2TC-RD-14.5-S1,32TC2021RD1451,H. CAMISA P/CABALLERO P/S RED 34-35 BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_14c_cpt_bn,14C-CPT-BN-15.5-S2,14CPT2021BN1552,H. CAMISA P/CABALLERO P/S NAVY 34-35 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S2 - 34/35",56.43,0.00
+__import__.product_template_14c_cpt_bn,14C-CPT-BN-14.5-S1,14CPT2021BN1451,H. CAMISA P/CABALLERO P/S NAVY 34-35 BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_14c_cpt_bn,14C-CPT-BN-15.5-S1,14CPT2021BN1551,H. CAMISA P/CABALLERO P/S NAVY 34-35 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_esns_pk,ESNS-PK-14.5-S1,ENS2021PK1451,H. CAMISA P/CABALLERO P/S PINK 32-33 BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_l21sw_3,L21SW-3-17.5-S2,21SW202131752,H. CAMISA P/CABALLERO XL P/S WHITE 34-35 BRUNO CASSINI,"Talla: 17.5, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_l21sw_3,L21SW-3-19-S2,21SW202131902,H. CAMISA P/CABALLERO XL P/S WHITE 34-35 BRUNO CASSINI,"Talla: 19, Manga de Camisa: S2 - 34/35",73.83,0.00
+__import__.product_template_l21sw_3,L21SW-3-17.5-S1,21SW202131751,H. CAMISA P/CABALLERO XL P/S WHITE 34-35 BRUNO CASSINI,"Talla: 17.5, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_l21sw_3,L21SW-3-19-S1,21SW202131901,H. CAMISA P/CABALLERO XL P/S WHITE 34-35 BRUNO CASSINI,"Talla: 19, Manga de Camisa: S1 - 32/33",73.83,0.00
+__import__.product_template_rl_bl,RL-BL-14.5-S1,RL012021BL1451,H. CAMISA P/CABALLERO P/S LIGHT BLUE 32-33 BRUNO CASSINI,"Talla: 14.5, Manga de Camisa: S1 - 32/33",56.43,0.00
+__import__.product_template_l21sw_1,L21SW-1-17.5-S2,21SW202111752,H. CAMISA P/CABALLERO M/C WHITE 34-35 BRUNO CASSINI,"Talla: 17.5, Manga de Camisa: S2 - 34/35",69.48,0.00
+__import__.product_template_eft_dc_bu,EFT-DC-BU-15.5-S2,EFT2021DCBU1552,H. CAMISA P/CABALLERO D/P BLUE 34-35 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S2 - 34/35",65.13,0.00
+__import__.product_template_eft_dc_bu,EFT-DC-BU-15.5-S1,EFT2021DCBU1551,H. CAMISA P/CABALLERO D/P BLUE 34-35 BRUNO CASSINI,"Talla: 15.5, Manga de Camisa: S1 - 32/33",65.13,0.00
+__import__.product_template_b8dpnt05_dk_bl,B8DPNT05-DK-BL/30,B8DPNT05-DK-BL/O30,Terno B8DPNT05-DK-BL,Talla: 30,65.13,0.00
+__import__.product_template_b8dpnt05_dk_bl,B8DPNT05-DK-BL/32,B8DPNT05-DK-BL/O32,Terno B8DPNT05-DK-BL,Talla: 32,65.13,0.00
+__import__.product_template_b8dpnt05_dk_bl,B8DPNT05-DK-BL/34,B8DPNT05-DK-BL/O34,Terno B8DPNT05-DK-BL,Talla: 34,65.13,0.00
+__import__.product_template_b8dpnt05_dk_bl,B8DPNT05-DK-BL/36,B8DPNT05-DK-BL/O36,Terno B8DPNT05-DK-BL,Talla: 36,65.13,0.00
+__import__.product_template_b8dpnt05_dk_bl,B8DPNT05-DK-BL/38,B8DPNT05-DK-BL/O38,Terno B8DPNT05-DK-BL,Talla: 38,65.13,0.00
+__import__.product_template_b8dpnt05_dk_bl,B8DPNT05-DK-BL/40,B8DPNT05-DK-BL/O40,Terno B8DPNT05-DK-BL,Talla: 40,65.13,0.00
+__import__.product_template_b8dpnt05_dk_bl,B8DPNT05-DK-BL/42,B8DPNT05-DK-BL/O42,Terno B8DPNT05-DK-BL,Talla: 42,65.13,0.00
+__import__.product_template_b8dpnt05_bl,B8DPNT05-BL/30,B8DPNT05-BL/O30,Terno B8DPNT05-BL,Talla: 30,65.13,0.00
+__import__.product_template_b8dpnt05_bl,B8DPNT05-BL/32,B8DPNT05-BL/O32,Terno B8DPNT05-BL,Talla: 32,65.13,0.00
+__import__.product_template_b8dpnt05_bl,B8DPNT05-BL/34,B8DPNT05-BL/O34,Terno B8DPNT05-BL,Talla: 34,65.13,0.00
+__import__.product_template_b8dpnt05_bl,B8DPNT05-BL/36,B8DPNT05-BL/O36,Terno B8DPNT05-BL,Talla: 36,65.13,0.00
+__import__.product_template_b8dpnt05_bl,B8DPNT05-BL/38,B8DPNT05-BL/O38,Terno B8DPNT05-BL,Talla: 38,65.13,0.00
+__import__.product_template_b8dpnt05_bl,B8DPNT05-BL/40,B8DPNT05-BL/O40,Terno B8DPNT05-BL,Talla: 40,65.13,0.00
+__import__.product_template_b8dpnt05_bl,B8DPNT05-BL/42,B8DPNT05-BL/O42,Terno B8DPNT05-BL,Talla: 42,65.13,0.00
+__import__.product_template_a20drs435_pur_t_s2,A20DRS435-PUR-T-S2/18,DRS435-PURT-S2/O18,Terno A20DRS435-PUR-T-S2,Talla: 18,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s2,A20DRS435-PUR-T-S2/17.5,DRS435-PURT-S2/O17.5,Terno A20DRS435-PUR-T-S2,Talla: 17.5,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s2,A20DRS435-PUR-T-S2/17,DRS435-PURT-S2/O17,Terno A20DRS435-PUR-T-S2,Talla: 17,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s2,A20DRS435-PUR-T-S2/16.5,DRS435-PURT-S2/O16.5,Terno A20DRS435-PUR-T-S2,Talla: 16.5,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s2,A20DRS435-PUR-T-S2/16,DRS435-PURT-S2/O16,Terno A20DRS435-PUR-T-S2,Talla: 16,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s2,A20DRS435-PUR-T-S2/15.5,DRS435-PURT-S2/O15.5,Terno A20DRS435-PUR-T-S2,Talla: 15.5,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s1,A20DRS435-PUR-T-S1/16.5,DRS435-PURT-S1/O16.5,Terno A20DRS435-PUR-T-S1,Talla: 16.5,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s1,A20DRS435-PUR-T-S1/16,DRS435-PURT-S1/O16,Terno A20DRS435-PUR-T-S1,Talla: 16,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s1,A20DRS435-PUR-T-S1/15.5,DRS435-PURT-S1/O15.5,Terno A20DRS435-PUR-T-S1,Talla: 15.5,56.43,0.00
+__import__.product_template_a20drs435_pur_t_s1,A20DRS435-PUR-T-S1/15,DRS435-PURT-S1/O15,Terno A20DRS435-PUR-T-S1,Talla: 15,56.43,0.00
+__import__.product_template_b9drs51_nv_s1,B9DRS51-NV-S1/16.5,B9DRS51-NV-S1/O16.5,Terno B9DRS51-NV-S1,Talla: 16.5,56.43,0.00
+__import__.product_template_b9drs51_nv_s1,B9DRS51-NV-S1/16,B9DRS51-NV-S1/O16,Terno B9DRS51-NV-S1,Talla: 16,56.43,0.00
+__import__.product_template_b9drs51_nv_s1,B9DRS51-NV-S1/15.5,B9DRS51-NV-S1/O15.5,Terno B9DRS51-NV-S1,Talla: 15.5,56.43,0.00
+__import__.product_template_b9drs51_nv_s1,B9DRS51-NV-S1/15,B9DRS51-NV-S1/O15,Terno B9DRS51-NV-S1,Talla: 15,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s1,A9DRS06-MD-BL-S1/16,A9DRS06-MD-BL-S1/O16,Terno A9DRS06-MD-BL-S1,Talla: 16,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s1,A9DRS06-MD-BL-S1/14.5,A9DRS06-MD-BL-S1/O14.5,Terno A9DRS06-MD-BL-S1,Talla: 14.5,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s1,A9DRS06-MD-BL-S1/15,A9DRS06-MD-BL-S1/O15,Terno A9DRS06-MD-BL-S1,Talla: 15,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s1,A9DRS06-MD-BL-S1/15.5,A9DRS06-MD-BL-S1/O15.5,Terno A9DRS06-MD-BL-S1,Talla: 15.5,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s1,A9DRS06-MD-BL-S1/16.5,A9DRS06-MD-BL-S1/O16.5,Terno A9DRS06-MD-BL-S1,Talla: 16.5,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s2,A9DRS06-MD-BL-S2/15.5,A9DRS06-MD-BL-S2/O15.5,Terno A9DRS06-MD-BL-S2,Talla: 15.5,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s2,A9DRS06-MD-BL-S2/16,A9DRS06-MD-BL-S2/O16,Terno A9DRS06-MD-BL-S2,Talla: 16,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s2,A9DRS06-MD-BL-S2/16.5,A9DRS06-MD-BL-S2/O16.5,Terno A9DRS06-MD-BL-S2,Talla: 16.5,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s2,A9DRS06-MD-BL-S2/17,A9DRS06-MD-BL-S2/O17,Terno A9DRS06-MD-BL-S2,Talla: 17,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s2,A9DRS06-MD-BL-S2/17.5,A9DRS06-MD-BL-S2/O17.5,Terno A9DRS06-MD-BL-S2,Talla: 17.5,56.43,0.00
+__import__.product_template_a9drs06_md_bl_s2,A9DRS06-MD-BL-S2/18,A9DRS06-MD-BL-S2/O18,Terno A9DRS06-MD-BL-S2,Talla: 18,56.43,0.00
+__import__.product_template_b9drs35_bl_s1,B9DRS35-BL-S1/15,B9DRS35-BL-S1/O15,Terno B9DRS35-BL-S1,Talla: 15,56.43,0.00
+__import__.product_template_b9drs35_bl_s1,B9DRS35-BL-S1/15.5,B9DRS35-BL-S1/O15.5,Terno B9DRS35-BL-S1,Talla: 15.5,56.43,0.00
+__import__.product_template_b9drs35_bl_s1,B9DRS35-BL-S1/16,B9DRS35-BL-S1/O16,Terno B9DRS35-BL-S1,Talla: 16,56.43,0.00
+__import__.product_template_b9drs35_bl_s1,B9DRS35-BL-S1/16.5,B9DRS35-BL-S1/O16.5,Terno B9DRS35-BL-S1,Talla: 16.5,56.43,0.00
+__import__.product_template_b9drs35_bl_s2,B9DRS35-BL-S2/18,B9DRS35-BL-S2/O18,Terno B9DRS35-BL-S2,Talla: 18,56.43,0.00
+__import__.product_template_b9drs35_bl_s2,B9DRS35-BL-S2/15.5,B9DRS35-BL-S2/O15.5,Terno B9DRS35-BL-S2,Talla: 15.5,56.43,0.00
+__import__.product_template_b9drs35_bl_s2,B9DRS35-BL-S2/16,B9DRS35-BL-S2/O16,Terno B9DRS35-BL-S2,Talla: 16,56.43,0.00
+__import__.product_template_b9drs35_bl_s2,B9DRS35-BL-S2/16.5,B9DRS35-BL-S2/O16.5,Terno B9DRS35-BL-S2,Talla: 16.5,56.43,0.00
+__import__.product_template_b9drs35_bl_s2,B9DRS35-BL-S2/17,B9DRS35-BL-S2/O17,Terno B9DRS35-BL-S2,Talla: 17,56.43,0.00
+__import__.product_template_b9drs35_bl_s2,B9DRS35-BL-S2/17.5,B9DRS35-BL-S2/O17.5,Terno B9DRS35-BL-S2,Talla: 17.5,56.43,0.00
+__import__.product_template_a20drs407_bl_lt_s2,A20DRS407-BL-LT-S2/18,DRS407-BL-LT-S2/O18,Terno A20DRS407-BL-LT-S2,Talla: 18,56.43,0.00
+__import__.product_template_a20drs407_bl_lt_s2,A20DRS407-BL-LT-S2/17.5,DRS407-BL-LT-S2/O17.5,Terno A20DRS407-BL-LT-S2,Talla: 17.5,56.43,0.00
+__import__.product_template_a20drs407_bl_lt_s2,A20DRS407-BL-LT-S2/17,DRS407-BL-LT-S2/O17,Terno A20DRS407-BL-LT-S2,Talla: 17,56.43,0.00
+__import__.product_template_a20drs407_bl_lt_s2,A20DRS407-BL-LT-S2/16.5,DRS407-BL-LT-S2/O16.5,Terno A20DRS407-BL-LT-S2,Talla: 16.5,56.43,0.00
+__import__.product_template_a20drs407_bl_lt_s2,A20DRS407-BL-LT-S2/16,DRS407-BL-LT-S2/O16,Terno A20DRS407-BL-LT-S2,Talla: 16,56.43,0.00
+__import__.product_template_a20drs407_bl_lt_s2,A20DRS407-BL-LT-S2/15.5,DRS407-BL-LT-S2/15.5,Terno A20DRS407-BL-LT-S2,Talla: 15.5,56.43,0.00
+__import__.product_template_tl_10_400b_azn,TL-10-400B-AZN/46,TL-10-400B-AZN/O46,Terno TL-10-400B-AZN,Talla: 46,165.13,0.00
+__import__.product_template_tl_10_400b_azn,TL-10-400B-AZN/44,TL-10-400B-AZN/O44,Terno TL-10-400B-AZN,Talla: 44,165.13,0.00
+__import__.product_template_tl_10_400b_azn,TL-10-400B-AZN/42,TL-10-400B-AZN/O42,Terno TL-10-400B-AZN,Talla: 42,86.87,0.00
+__import__.product_template_tl_10_400b_azn,TL-10-400B-AZN/40,TL-10-400B-AZN/O40,Terno TL-10-400B-AZN,Talla: 40,86.87,0.00
+__import__.product_template_tl_10_400b_azn,TL-10-400B-AZN/38,TL-10-400B-AZN/O38,Terno TL-10-400B-AZN,Talla: 38,86.87,0.00
+__import__.product_template_tl_10_400b_azn,TL-10-400B-AZN/36,TL-10-400B-AZN/O36,Terno TL-10-400B-AZN,Talla: 36,86.87,0.00
+__import__.product_template_b9sut104_nv,B9SUT104-NV/36,B9SUT104-NV/O36,Terno B9SUT104-NV,Talla: 36,217.30,0.00
+__import__.product_template_b9sut104_nv,B9SUT104-NV/38,B9SUT104-NV/O38,Terno B9SUT104-NV,Talla: 38,217.30,0.00
+__import__.product_template_b9sut104_nv,B9SUT104-NV/40,B9SUT104-NV/O40,Terno B9SUT104-NV,Talla: 40,217.30,0.00
+__import__.product_template_b9sut104_nv,B9SUT104-NV/42,B9SUT104-NV/O42,Terno B9SUT104-NV,Talla: 42,217.30,0.00
+__import__.product_template_b9sut104_nv,B9SUT104-NV/44,B9SUT104-NV/O44,Terno B9SUT104-NV,Talla: 44,217.30,0.00
+__import__.product_template_b9sut104_nv,B9SUT104-NV/46,B9SUT104-NV/O46,Terno B9SUT104-NV,Talla: 46,217.30,0.00
+__import__.product_template_b9sut104_nv,B9SUT104-NV/48,B9SUT104-NV/O48,Terno B9SUT104-NV,Talla: 48,217.30,0.00
+__import__.product_template_b9sut103_md_bl,B9SUT103-MD-BL/48,B9SUT103-MD-BL/O48,Terno B9SUT103-MD-BL,Talla: 48,217.30,0.00
+__import__.product_template_b9sut103_md_bl,B9SUT103-MD-BL/46,B9SUT103-MD-BL/O46,Terno B9SUT103-MD-BL,Talla: 46,217.30,0.00
+__import__.product_template_b9sut103_md_bl,B9SUT103-MD-BL/44,B9SUT103-MD-BL/O44,Terno B9SUT103-MD-BL,Talla: 44,217.30,0.00
+__import__.product_template_b9sut103_md_bl,B9SUT103-MD-BL/42,B9SUT103-MD-BL/O42,Terno B9SUT103-MD-BL,Talla: 42,217.30,0.00
+__import__.product_template_b9sut103_md_bl,B9SUT103-MD-BL/40,B9SUT103-MD-BL/O40,Terno B9SUT103-MD-BL,Talla: 40,217.30,0.00
+__import__.product_template_b9sut103_md_bl,B9SUT103-MD-BL/38,B9SUT103-MD-BL/O38,Terno B9SUT103-MD-BL,Talla: 38,217.30,0.00
+__import__.product_template_b9sut103_md_bl,B9SUT103-MD-BL/36,B9SUT103-MD-BL/O36,Terno B9SUT103-MD-BL,Talla: 36,217.30,0.00
+__import__.product_template_tl_10_656a,TL-10-656A/56,TL-10-656A/O56,Terno TL-10-656A,Talla: 56,260.78,0.00
+__import__.product_template_tl_10_658c,TL-10-658C/58,TL-10-658C/O58,Terno TL-10-658C,Talla: 58,260.78,0.00
+__import__.product_template_tl_10_658b,TL-10-658B/58,TL-10-658B/O58,Terno TL-10-658B,Talla: 58,86.87,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/58,TL-10-500E.A/O58,Terno TL-10-500E.A,Talla: 58,260.78,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/50,TL-10-500E.A/O50,Terno TL-10-500E.A,Talla: 50,217.30,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/56,TL-10-500D.A/O56,Terno TL-10-500D.A,Talla: 56,165.13,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/54,TL-10-500D.A/O54,Terno TL-10-500D.A,Talla: 54,165.13,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/36,TL-10-500E.A/O36,Terno TL-10-500E.A,Talla: 36,191.22,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/38,TL-10-500E.A/O38,Terno TL-10-500E.A,Talla: 38,191.22,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/40,TL-10-500E.A/O40,Terno TL-10-500E.A,Talla: 40,191.22,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/42,TL-10-500E.A/O42,Terno TL-10-500E.A,Talla: 42,191.22,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/44,TL-10-500E.A/O44,Terno TL-10-500E.A,Talla: 44,191.22,0.00
+__import__.product_template_tl_10_500e_a,TL-10-500E.A/46,TL-10-500E.A/O46,Terno TL-10-500E.A,Talla: 46,191.22,0.00
+__import__.product_template_tl_10_500d,TL-10-500D/48,TL-10-500D.48,Terno TL-10-500D,Talla: 48,165.13,0.00
+__import__.product_template_rz543_black_tl,RZ543-BLACK-TL/9.5,RZ543-BLACK-TL/O9.5,Terno RZ543-BLACK-TL,Talla: 9.5,104.26,0.00
+__import__.product_template_rz543_black,RZ543-BLACK/9.5,RZ543-BLACK/O9.5,Terno RZ543-BLACK,Talla: 9.5,130.35,0.00
+__import__.product_template_cubfa016_473,CUBFA016-473/42,084971446043,Terno CUBFA016-473,Talla: 42,117.30,0.00
+__import__.product_template_cubfa016_473,CUBFA016-473/40,084971408249,Terno CUBFA016-473,Talla: 40,117.30,0.00
+__import__.product_template_cubfa016_473,CUBFA016-473/38,084971408232,Terno CUBFA016-473,Talla: 38,117.30,0.00
+__import__.product_template_cubfa016_473,CUBFA016-473/36,084971408225,Terno CUBFA016-473,Talla: 36,117.30,0.00
+__import__.product_template_cubfa016_473,CUBFA016-473/34,084971408218,Terno CUBFA016-473,Talla: 34,117.30,0.00
+__import__.product_template_cubfa016_473,CUBFA016-473/32,084971408201,Terno CUBFA016-473,Talla: 32,117.30,0.00
+__import__.product_template_cubfa020_274,CUBFA020-274/42,084971446050,Terno CUBFA020-274,Talla: 42,117.30,0.00
+__import__.product_template_cubfa020_274,CUBFA020-274/40,084971408300,Terno CUBFA020-274,Talla: 40,117.30,0.00
+__import__.product_template_cubfa020_274,CUBFA020-274/38,084971408294,Terno CUBFA020-274,Talla: 38,117.30,0.00
+__import__.product_template_cubfa020_274,CUBFA020-274/36,084971408287,Terno CUBFA020-274,Talla: 36,117.30,0.00
+__import__.product_template_cubfa020_274,CUBFA020-274/34,084971408270,Terno CUBFA020-274,Talla: 34,117.30,0.00
+__import__.product_template_cubfa020_274,CUBFA020-274/32,084971408263,Terno CUBFA020-274,Talla: 32,117.30,0.00
+__import__.product_template_akd0100,AKD0100/L,AKD0100/OL,DRESS WHITE 70% RAYON 30%NYLON,Talla: L,70.45,0.00
+__import__.product_template_akd0100,AKD0100/M,AKD0100/OM,DRESS WHITE 70% RAYON 30%NYLON,Talla: M,70.45,0.00
+__import__.product_template_akd0100,AKD0100/S,AKD0100/OS,DRESS WHITE 70% RAYON 30%NYLON,Talla: S,70.45,0.00
+__import__.product_template_swt7042_la,SWT7042-LA/S,SWT7042-LA/OS,SWEETHEART LINE SPAGEHTTI STRAPS RIBBED TOP LAVENDER,Talla: S,30.36,0.00
+__import__.product_template_swt7042_la,SWT7042-LA/M,SWT7042-LA/OM,SWEETHEART LINE SPAGEHTTI STRAPS RIBBED TOP LAVENDER,Talla: M,30.36,0.00
+__import__.product_template_swt7042_la,SWT7042-LA/L,SWT7042-LA/OL,SWEETHEART LINE SPAGEHTTI STRAPS RIBBED TOP LAVENDER,Talla: L,30.35,0.00
+__import__.product_template_dfb3011_blanco,DFB3011-BLANCO/S,DFB3011-BLANCO/OS,M. CONJUNTO PANT+ TOP P/DAMA BLANCO DANFIVE,Talla: S,60.00,0.00
+__import__.product_template_2536_kan_tally,2536-KAN-TALLY/28,2536-KAN-TALLY/O28,Terno 2536-KAN-TALLY,Talla: 28,40.09,0.00
+__import__.product_template_tl_10_500d,TL-10-500D/46,TL-10-500D/O46,Terno TL-10-500D,Talla: 46,165.13,0.00
+__import__.product_template_tl_10_500d,TL-10-500D/44,TL-10-500D/O44,Terno TL-10-500D,Talla: 44,165.13,0.00
+__import__.product_template_tl_10_500d,TL-10-500D/42,TL-10-500D/O42,Terno TL-10-500D,Talla: 42,165.13,0.00
+__import__.product_template_tl_10_500d,TL-10-500D/40,TL-10-500D/O40,Terno TL-10-500D,Talla: 40,165.13,0.00
+__import__.product_template_tl_10_500d,TL-10-500D/38,TL-10-500D/O38,Terno TL-10-500D,Talla: 38,165.13,0.00
+__import__.product_template_tl_10_500d,TL-10-500D/36,TL-10-500D/O36,Terno TL-10-500D,Talla: 36,165.13,0.00
+__import__.product_template_lino_ramy_s2,LINO-RAMY-S2/15,LINO-RAMY-S2/O15,Terno LINO-RAMY-S2,Talla: 15,17.30,0.00
+__import__.product_template_lino_ramy_s2,LINO-RAMY-S2/15.5,LINO-RAMY-S2/O15.5,Terno LINO-RAMY-S2,Talla: 15.5,47.74,0.00
+__import__.product_template_lino_ramy_s2,LINO-RAMY-S2/16,LINO-RAMY-S2/O16,Terno LINO-RAMY-S2,Talla: 16,17.30,0.00
+__import__.product_template_lino_ramy_s2,LINO-RAMY-S2/16.5,LINO-RAMY-S2/O16.5,Terno LINO-RAMY-S2,Talla: 16.5,47.74,0.00
+__import__.product_template_lino_ramy_s2,LINO-RAMY-S2/17,LINO-RAMY-S2/O17,Terno LINO-RAMY-S2,Talla: 17,47.74,0.00
+__import__.product_template_lino_ramy_s2,LINO-RAMY-S2/17.5,LINO-RAMY-S2/O17.5,Terno LINO-RAMY-S2,Talla: 17.5,47.74,0.00
+__import__.product_template_lino_ramy_s2,LINO-RAMY-S2/18,LINO-RAMY-S2/O18,Terno LINO-RAMY-S2,Talla: 18,47.74,0.00
+__import__.product_template_lino_ramy_s1,LINO-RAMY-S1/16.5,LINO-RAMY-S1/O16.5,Terno LINO-RAMY-S1,Talla: 16.5,47.74,0.00
+__import__.product_template_lino_ramy_s1,LINO-RAMY-S1/16,LINO-RAMY-S1/O16,Terno LINO-RAMY-S1,Talla: 16,47.74,0.00
+__import__.product_template_lino_ramy_s1,LINO-RAMY-S1/15.5,LINO-RAMY-S1/O15.5,Terno LINO-RAMY-S1,Talla: 15.5,17.30,0.00
+__import__.product_template_lino_ramy_s1,LINO-RAMY-S1/15,LINO-RAMY-S1/O15,Terno LINO-RAMY-S1,Talla: 15,47.74,0.00
+__import__.product_template_jr0402_5_s1,JR0402-5-S1/14.5,JR0402-5-S1/O14.5,Terno JR0402-5-S1,Talla: 14.5,39.04,0.00
+__import__.product_template_jr0402_5_s1,JR0402-5-S1/15,JR0402-5-S1/O15,Terno JR0402-5-S1,Talla: 15,39.04,0.00
+__import__.product_template_jr0402_5_s1,JR0402-5-S1/15.5,JR0402-5-S1/O15.5,Terno JR0402-5-S1,Talla: 15.5,39.04,0.00
+__import__.product_template_jr0402_5_s1,JR0402-5-S1/16,JR0402-5-S1/O16,Terno JR0402-5-S1,Talla: 16,39.04,0.00
+__import__.product_template_jr0402_5_s1,JR0402-5-S1/16.5,JR0402-5-S1/O16.5,Terno JR0402-5-S1,Talla: 16.5,39.04,0.00
+__import__.product_template_jr0402_5_s1,JR0402-5-S1/17,JR0402-5-S1/O17,Terno JR0402-5-S1,Talla: 17,39.04,0.00
+__import__.product_template_jr0402_5_s1,JR0402-5-S1/17.5,JR0402-5-S1/O17.5,Terno JR0402-5-S1,Talla: 17.5,39.04,0.00
+__import__.product_template_jr0221_7_s1,JR0221-7-S1/14.5,JR0221-7-S1/O14.5,Terno JR0221-7-S1,Talla: 14.5,39.04,0.00
+__import__.product_template_jr0221_7_s1,JR0221-7-S1/15,JR0221-7-S1/O15,Terno JR0221-7-S1,Talla: 15,39.04,0.00
+__import__.product_template_jr0221_7_s1,JR0221-7-S1/15.5,JR0221-7-S1/O15.5,Terno JR0221-7-S1,Talla: 15.5,39.04,0.00
+__import__.product_template_jr0221_7_s1,JR0221-7-S1/16,JR0221-7-S1/O16,Terno JR0221-7-S1,Talla: 16,39.04,0.00
+__import__.product_template_jr0221_7_s1,JR0221-7-S1/16.5,JR0221-7-S1/O16.5,Terno JR0221-7-S1,Talla: 16.5,39.04,0.00
+__import__.product_template_jr0221_7_s1,JR0221-7-S1/17,JR0221-7-S1/O17,Terno JR0221-7-S1,Talla: 17,39.04,0.00
+__import__.product_template_jr0221_7_s1,JR0221-7-S1/17.5,JR0221-7-S1/O17.5,Terno JR0221-7-S1,Talla: 17.5,39.04,0.00
+__import__.product_template_9c28646_111bc_2,9C28646-111BC-2/46,9286462021044628,Terno 9C28646-111BC-2,Talla: 46,217.30,0.00
+__import__.product_template_9c28646_111bc_2,9C28646-111BC-2/48,9286462021044830,Terno 9C28646-111BC-2,Talla: 48,191.22,0.00
+__import__.product_template_9c28646_111bc_2,9C28646-111BC-2/50,9286462021045032,Terno 9C28646-111BC-2,Talla: 50,191.22,0.00
+__import__.product_template_9c28646_111bc_2,9C28646-111BC-2/52,9286462021045234,Terno 9C28646-111BC-2,Talla: 52,191.22,0.00
+__import__.product_template_9c28646_111bc_2,9C28646-111BC-2/54,9286462021045436,Terno 9C28646-111BC-2,Talla: 54,191.22,0.00
+__import__.product_template_9c28646_111bc_2,9C28646-111BC-2/56,9286462021045638,Terno 9C28646-111BC-2,Talla: 56,217.30,0.00
+__import__.product_template_9c28646_111bc_2,9C28646-111BC-2/58,9286462021045840,Terno 9C28646-111BC-2,Talla: 58,217.30,0.00
+__import__.product_template_a0356t,A0356T/S,A0356T/OS,M. BLUSA NECJ CROP TOP LADIES BONE,Talla: S,41.65,0.00
+__import__.product_template_a0356t,A0356T/M,A0356T/OM,M. BLUSA NECJ CROP TOP LADIES BONE,Talla: M,41.65,0.00
+__import__.product_template_a0356t,A0356T/L,A0356T/OL,M. BLUSA NECJ CROP TOP LADIES BONE,Talla: L,41.65,0.00
+__import__.product_template_a2019t_of,A2019T-OF/L,A2019T-OF/OL,"M, BLUSA DOWN TOP LADIES SQUARE OFF WHITE",Talla: L,41.65,0.00
+__import__.product_template_a2019t_of,A2019T-OF/M,A2019T-OF/OM,"M, BLUSA DOWN TOP LADIES SQUARE OFF WHITE",Talla: M,41.65,0.00
+__import__.product_template_a2019t_of,A2019T-OF/S,A2019T-OF/OS,"M, BLUSA DOWN TOP LADIES SQUARE OFF WHITE",Talla: S,41.65,0.00
+__import__.product_template_a2019t_le,A2019T-LE/L,A2019T-LE/OL,"M, BLUSA DOWN TOP LADIES SQUARE LEMON",Talla: L,41.65,0.00
+__import__.product_template_a2019t_le,A2019T-LE/M,A2019T-LE/OM,"M, BLUSA DOWN TOP LADIES SQUARE LEMON",Talla: M,41.65,0.00
+__import__.product_template_a2019t_le,A2019T-LE/S,A2019T-LE/OS,"M, BLUSA DOWN TOP LADIES SQUARE LEMON",Talla: S,41.65,0.00
+__import__.product_template_a0241p_4,A0241P-4/S,A0241P-4/OS,M. JEANS PDAMA LADIES BOTTOM,Talla: S,62.41,0.00
+__import__.product_template_a0241p_4,A0241P-4/M,A0241P-4/OM,M. JEANS PDAMA LADIES BOTTOM,Talla: M,62.41,0.00
+__import__.product_template_a0241p_4,A0241P-4/L,A0241P-4/OL,M. JEANS PDAMA LADIES BOTTOM,Talla: L,62.41,0.00
+__import__.product_template_tl_20_500d_a,TL-20-500D.A/40,7453040450459,Terno TL-20-500D.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_20_500d_a,TL-20-500D.A/38,7453040450343,Terno TL-20-500D.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_20_500d_a,TL-20-500D.A/36,7453040450237,Terno TL-20-500D.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_20_500d_a,TL-20-500D.A/34,7453040450121,Terno TL-20-500D.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_20_500d_a,TL-20-500D.A/32,7453040450015,Terno TL-20-500D.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_20_500d_a,TL-20-500D.A/30,7453040449903,Terno TL-20-500D.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_m26_527_a,TL-M26-527.A/XL,7453040553112,H. TRAJE DE BAÑO P/CABALLERO TED LAPIDUS AQUA,Talla: XL,31.16,0.00
+__import__.product_template_tl_m26_527_a,TL-M26-527.A/L,7453040553105,H. TRAJE DE BAÑO P/CABALLERO TED LAPIDUS AQUA,Talla: L,31.16,0.00
+__import__.product_template_tl_m26_527_a,TL-M26-527.A/M,7453040553099,H. TRAJE DE BAÑO P/CABALLERO TED LAPIDUS AQUA,Talla: M,31.16,0.00
+__import__.product_template_tl_m26_527_a,TL-M26-527.A/S,7453040553082,H. TRAJE DE BAÑO P/CABALLERO TED LAPIDUS AQUA,Talla: S,31.16,0.00
+__import__.product_template_tl_m04_114_a,TL-M04-114.A/S,7453040553846,H. CAMISA P/CABALLERO TED LAPIDUS NAVY,Talla: S,39.04,0.00
+__import__.product_template_tl_m04_114_a,TL-M04-114.A/M,7453040553853,H. CAMISA P/CABALLERO TED LAPIDUS NAVY,Talla: M,39.04,0.00
+__import__.product_template_tl_m04_114_a,TL-M04-114.A/L,7453040553860,H. CAMISA P/CABALLERO TED LAPIDUS NAVY,Talla: L,39.04,0.00
+__import__.product_template_tl_m04_114_a,TL-M04-114.A/XL,7453040553877,H. CAMISA P/CABALLERO TED LAPIDUS NAVY,Talla: XL,39.04,0.00
+__import__.product_template_tl_p25_501f_a,TL-P25-501F.A/30,7453040588749,Terno TL-P25-501F.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_p25_501f_a,TL-P25-501F.A/32,7453040588893,Terno TL-P25-501F.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_p25_501f_a,TL-P25-501F.A/34,7453040589043,Terno TL-P25-501F.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_p25_501f_a,TL-P25-501F.A/36,7453040589197,Terno TL-P25-501F.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_p25_501f_a,TL-P25-501F.A/38,7453040589340,Terno TL-P25-501F.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_p25_501f_a,TL-P25-501F.A/40,7453040589494,Terno TL-P25-501F.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_p25_501c_a,TL-P25-501C.A/30,7453040588718,Terno TL-P25-501C.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_p25_501c_a,TL-P25-501C.A/32,7453040588862,Terno TL-P25-501C.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_p25_501c_a,TL-P25-501C.A/34,7453040589012,Terno TL-P25-501C.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_p25_501c_a,TL-P25-501C.A/36,7453040589166,Terno TL-P25-501C.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_p25_501c_a,TL-P25-501C.A/38,7453040589319,Terno TL-P25-501C.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_p25_501c_a,TL-P25-501C.A/40,7453040589463,Terno TL-P25-501C.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_p25_501a_a,TL-P25-501A.A/30,7453040588695,Terno TL-P25-501A.A,Talla: 30,34.70,0.00
+__import__.product_template_tl_p25_501a_a,TL-P25-501A.A/32,7453040588848,Terno TL-P25-501A.A,Talla: 32,34.70,0.00
+__import__.product_template_tl_p25_501a_a,TL-P25-501A.A/34,7453040588992,Terno TL-P25-501A.A,Talla: 34,34.70,0.00
+__import__.product_template_tl_p25_501a_a,TL-P25-501A.A/36,7453040589142,Terno TL-P25-501A.A,Talla: 36,34.70,0.00
+__import__.product_template_tl_p25_501a_a,TL-P25-501A.A/38,7453040589296,Terno TL-P25-501A.A,Talla: 38,34.70,0.00
+__import__.product_template_tl_p25_501a_a,TL-P25-501A.A/40,7453040589449,Terno TL-P25-501A.A,Talla: 40,34.70,0.00
+__import__.product_template_tl_p23_105b_a,TL-P23-105B.A/30,7453040590810,Terno TL-P23-105B.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_p23_105b_a,TL-P23-105B.A/32,7453040590827,Terno TL-P23-105B.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_p23_105b_a,TL-P23-105B.A/34,7453040590834,Terno TL-P23-105B.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_p23_105b_a,TL-P23-105B.A/36,7453040590841,Terno TL-P23-105B.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_p23_105b_a,TL-P23-105B.A/38,7453040590858,Terno TL-P23-105B.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_p23_105b_a,TL-P23-105B.A/40,7453040590865,Terno TL-P23-105B.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_p23_105a_a,TL-P23-105A.A/30,7453040590759,Terno TL-P23-105A.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_p23_105a_a,TL-P23-105A.A/32,7453040590766,Terno TL-P23-105A.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_p23_105a_a,TL-P23-105A.A/34,7453040590773,Terno TL-P23-105A.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_p23_105a_a,TL-P23-105A.A/36,7453040590780,Terno TL-P23-105A.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_p23_105a_a,TL-P23-105A.A/38,7453040590797,Terno TL-P23-105A.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_p23_105a_a,TL-P23-105A.A/40,7453040590803,Terno TL-P23-105A.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_p23_102a_a,TL-P23-102A.A/30,7453040590193,Terno TL-P23-102A.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_p23_102a_a,TL-P23-102A.A/32,7453040590209,Terno TL-P23-102A.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_p23_102a_a,TL-P23-102A.A/34,7453040590216,Terno TL-P23-102A.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_p23_102a_a,TL-P23-102A.A/36,7453040590223,Terno TL-P23-102A.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_p23_102a_a,TL-P23-102A.A/38,7453040590230,Terno TL-P23-102A.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_p23_102a_a,TL-P23-102A.A/40,7453040590247,Terno TL-P23-102A.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_p23_105c_a,TL-P23-105C.A/34,7453040590933,Terno TL-P23-105C.A,Talla: 34,43.39,0.00
+__import__.product_template_tl_p23_105c_a,TL-P23-105C.A/36,7453040590940,Terno TL-P23-105C.A,Talla: 36,43.39,0.00
+__import__.product_template_tl_p23_105c_a,TL-P23-105C.A/38,7453040590957,Terno TL-P23-105C.A,Talla: 38,43.39,0.00
+__import__.product_template_tl_p23_105c_a,TL-P23-105C.A/40,7453040590964,Terno TL-P23-105C.A,Talla: 40,43.39,0.00
+__import__.product_template_tl_p23_105c_a,TL-P23-105C.A/32,7453040590926,Terno TL-P23-105C.A,Talla: 32,43.39,0.00
+__import__.product_template_tl_p23_105c_a,TL-P23-105C.A/30,7453040590919,Terno TL-P23-105C.A,Talla: 30,43.39,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/36,7453040447572,Terno TL-10-500D.A,Talla: 36,165.13,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/38,7453040447756,Terno TL-10-500D.A,Talla: 38,165.13,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/40,7453040447930,Terno TL-10-500D.A,Talla: 40,165.13,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/42,7453040448111,Terno TL-10-500D.A,Talla: 42,165.13,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/44,7453040448296,Terno TL-10-500D.A,Talla: 44,165.13,0.00
+__import__.product_template_tl_10_500d_a,TL-10-500D.A/46,7453040448470,Terno TL-10-500D.A,Talla: 46,165.13,0.00
+__import__.product_template_tl_10_500b_a,TL-10-500B.A/36,7453040447558,Terno TL-10-500B.A,Talla: 36,165.13,0.00
+__import__.product_template_tl_10_500b_a,TL-10-500B.A/38,7453040447732,Terno TL-10-500B.A,Talla: 38,104.26,0.00
+__import__.product_template_tl_10_500b_a,TL-10-500B.A/40,7453040447916,Terno TL-10-500B.A,Talla: 40,165.13,0.00
+__import__.product_template_tl_10_500b_a,TL-10-500B.A/42,7453040448098,Terno TL-10-500B.A,Talla: 42,165.13,0.00
+__import__.product_template_tl_10_500b_a,TL-10-500B.A/44,7453040448272,Terno TL-10-500B.A,Talla: 44,165.13,0.00
+__import__.product_template_tl_10_500b_a,TL-10-500B.A/46,7453040448456,Terno TL-10-500B.A,Talla: 46,165.13,0.00
+__import__.product_template_pt_k10189_7,PT-K10189-7/40,PT-K10189-7/O40,Pantalon PT-K10189-7,Talla: 40,117.30,0.00
+__import__.product_template_pt_s100302_8,PT-S100302-8/36,PT-S100302-8/O36,Pantalon PT-S100302-8,Talla: 36,117.30,0.00
+__import__.product_template_y17558,Y17558/S,Y17558/OS,JUMPER ENTERIZO DO+BE,Talla: S,47.23,0.00
+__import__.product_template_y17558,Y17558/M,Y17558/OM,JUMPER ENTERIZO DO+BE,Talla: M,47.23,0.00
+__import__.product_template_y17558,Y17558/L,Y17558/OL,JUMPER ENTERIZO DO+BE,Talla: L,47.23,0.00
+__import__.product_template_ire90495,IRE90495/S,IRE90495/OS,M. JUMPER ENTERIZO INA,Talla: S,42.77,0.00
+__import__.product_template_ekp4086,EKP4086/S,EKP4086/OS,M. SHORT P/DAMA,Talla: S,36.52,0.00
+__import__.product_template_ekp4086,EKP4086/M,EKP4086/OM,M. SHORT P/DAMA,Talla: M,36.52,0.00
+__import__.product_template_ekp4086,EKP4086/L,EKP4086/OL,M. SHORT P/DAMA,Talla: L,36.52,0.00
+__import__.product_template_jd40120,JD40120/L,JD40120/OL,COTTOS FLORAL EYELET DRESS VESTIDO,Talla: L,57.95,0.00
+__import__.product_template_jd40120,JD40120/S,JD40120/OS,COTTOS FLORAL EYELET DRESS VESTIDO,Talla: S,57.95,0.00
+__import__.product_template_jd40120,JD40120/M,JD40120/OM,COTTOS FLORAL EYELET DRESS VESTIDO,Talla: M,57.95,0.00
+__import__.product_template_r625_bg,R625-BG/S,R625-BG/OS,M. PANTALON P/DAMA BEIGE TALLA S,Talla: S,40.09,0.00
+__import__.product_template_r625_bg,R625-BG/M,R625-BG/OM,M. PANTALON P/DAMA BEIGE TALLA S,Talla: M,40.09,0.00
+__import__.product_template_r625_bg,R625-BG/L,R625-BG/OL,M. PANTALON P/DAMA BEIGE TALLA S,Talla: L,40.09,0.00
+__import__.product_template_r625_bg,R625-BG/XL,R625-BG/OXL,M. PANTALON P/DAMA BEIGE TALLA S,Talla: XL,40.09,0.00
+__import__.product_template_kse_5022,KSE-5022-6,KSE-5022-6,Corbata KSE-5022,Ancho Corbata: 6 cm,11.22,0.00
+__import__.product_template_ip7799_na,IP7799-NA/L,IP7799-NA/OL,M. SHORT BUTTON PLEATS SOLID,Talla: L,34.73,0.00
+__import__.product_template_ip7799_na,IP7799-NA/M,IP7799-NA/OM,M. SHORT BUTTON PLEATS SOLID,Talla: M,34.73,0.00
+__import__.product_template_ip7799_na,IP7799-NA/S,IP7799-NA/OS,M. SHORT BUTTON PLEATS SOLID,Talla: S,34.73,0.00
+__import__.product_template_pt_k10189_7,PT-K10189-7/34,PT-K10189-7/O34,Pantalon PT-K10189-7,Talla: 34,117.30,0.00
+__import__.product_template_pt_k10189_7,PT-K10189-7/32,PT-K10189-7/O32,Pantalon PT-K10189-7,Talla: 32,117.30,0.00
+__import__.product_template_pt_k10189_7,PT-K10189-7/36,PT-K10189-7/O36,Pantalon PT-K10189-7,Talla: 36,117.30,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/60,PT-008-BLACK/O60,Pantalon PT-008-BLACK,Talla: 60,47.74,0.00
+__import__.product_template_pt_k10189_7,PT-K10189-7/38,PT-K10189-7/O38,Pantalon PT-K10189-7,Talla: 38,117.30,0.00
+__import__.product_template_lbpc_celeste_az,LBPC-CELESTE-AZ/XL,LBPC-CELESTE-AZ/OXL,SUETER POLO P/H 65% POLIESTER 35% ALGODÓN CELESTE LOGO AZUL,Talla: XL,16.43,0.00
+__import__.product_template_lbpc_celeste_az,LBPC-CELESTE-AZ/L,LBPC-CELESTE-AZ/OL,SUETER POLO P/H 65% POLIESTER 35% ALGODÓN CELESTE LOGO AZUL,Talla: L,16.43,0.00
+__import__.product_template_lbpc_celeste_az,LBPC-CELESTE-AZ/M,LBPC-CELESTE-AZ/OM,SUETER POLO P/H 65% POLIESTER 35% ALGODÓN CELESTE LOGO AZUL,Talla: M,16.43,0.00
+__import__.product_template_lbpc_celeste_az,LBPC-CELESTE-AZ/S,LBPC-CELESTE-AZ/OS,SUETER POLO P/H 65% POLIESTER 35% ALGODÓN CELESTE LOGO AZUL,Talla: S,16.43,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/40,008B120220640,Pantalon PT-008-BLACK,Talla: 40,56.43,0.00
+__import__.product_template_ca_tommy_ml_nv,CA-TOMMY-ML-NV/XXL,CA-TOMMY-ML-NV/OXXL,CAMISA M/L P/CABALLERO TOMMY H. NAVY,Talla: XXL,56.43,0.00
+__import__.product_template_ca_tommy_ml_nv,CA-TOMMY-ML-NV/XL,CA-TOMMY-ML-NV/OXL,CAMISA M/L P/CABALLERO TOMMY H. NAVY,Talla: XL,56.43,0.00
+__import__.product_template_ca_tommy_ml_nv,CA-TOMMY-ML-NV/L,CA-TOMMY-ML-NV/OL,CAMISA M/L P/CABALLERO TOMMY H. NAVY,Talla: L,56.43,0.00
+__import__.product_template_ca_tommy_ml_nv,CA-TOMMY-ML-NV/M,CA-TOMMY-ML-NV/OM,CAMISA M/L P/CABALLERO TOMMY H. NAVY,Talla: M,56.43,0.00
+__import__.product_template_d5624,D5624/M,D5624/OM,VESTIDO C/CINTURON SUGAR LIPS,Talla: M,70.45,0.00
+__import__.product_template_d5624,D5624/S,D5624/OS,VESTIDO C/CINTURON SUGAR LIPS,Talla: S,70.45,0.00
+__import__.product_template_d5624,D5624/XS,D5624/OXS,VESTIDO C/CINTURON SUGAR LIPS,Talla: XS,70.45,0.00
+__import__.product_template_8358pw,8358PW/L,8358PW/OL,M. PANTALON P/DAMA JET BLACK TALLA L,Talla: L,41.88,0.00
+__import__.product_template_8358pw,8358PW/M,8358PW/OM,M. PANTALON P/DAMA JET BLACK TALLA L,Talla: M,41.88,0.00
+__import__.product_template_8358pw,8358PW/S,8358PW/OS,M. PANTALON P/DAMA JET BLACK TALLA L,Talla: S,41.88,0.00
+__import__.product_template_pi4512,PI4512/L,PI4512/OL,M. PANTALON P/DAMA CAMEL TALLA L,Talla: L,46.87,0.00
+__import__.product_template_pi4512,PI4512/M,PI4512/OM,M. PANTALON P/DAMA CAMEL TALLA L,Talla: M,46.87,0.00
+__import__.product_template_pi4512,PI4512/S,PI4512/OS,M. PANTALON P/DAMA CAMEL TALLA L,Talla: S,48.13,0.00
+__import__.product_template_ab7202,AB7202/L,AB7202/OL,M. SHORT P/DAMA COCO TALLA L,Talla: L,26.70,0.00
+__import__.product_template_ab7202,AB7202/M,AB7202/OM,M. SHORT P/DAMA COCO TALLA L,Talla: M,26.70,0.00
+__import__.product_template_ab7202,AB7202/S,AB7202/OS,M. SHORT P/DAMA COCO TALLA L,Talla: S,26.70,0.00
+__import__.product_template_r679,R679/S,R679/OS,PANTALON NEGRO - FUSHA S-M-L,Talla: S,44.55,0.00
+__import__.product_template_r679,R679/M,R679/OL,PANTALON NEGRO - FUSHA S-M-L,Talla: M,44.55,0.00
+__import__.product_template_r679,R679/L,R679/OXL,PANTALON NEGRO - FUSHA S-M-L,Talla: L,44.55,0.00
+__import__.product_template_r679,R679/XL,R679/OM,PANTALON NEGRO - FUSHA S-M-L,Talla: XL,40.09,0.00
+__import__.product_template_r319,R319/XL,R319/OXL,M. PANTALON PARA DAMA BEIGE TALLA XL,Talla: XL,40.09,0.00
+__import__.product_template_r319,R319/L,R319/OL,M. PANTALON PARA DAMA BEIGE TALLA XL,Talla: L,40.09,0.00
+__import__.product_template_r319,R319/M,R319/OM,M. PANTALON PARA DAMA BEIGE TALLA XL,Talla: M,40.09,0.00
+__import__.product_template_r319,R319/S,R319/OS,M. PANTALON PARA DAMA BEIGE TALLA XL,Talla: S,40.09,0.00
+__import__.product_template_r625_wh,R625-WH/S,R625-WH/OS,M. PANTALON P/DAMA WHITE TALLA S,Talla: S,40.09,0.00
+__import__.product_template_r625_wh,R625-WH/M,R625-WH/OM,M. PANTALON P/DAMA WHITE TALLA S,Talla: M,40.09,0.00
+__import__.product_template_r625_wh,R625-WH/L,R625-WH/OL,M. PANTALON P/DAMA WHITE TALLA S,Talla: L,40.09,0.00
+__import__.product_template_r625_wh,R625-WH/XL,R625-WH/OXL,M. PANTALON P/DAMA WHITE TALLA S,Talla: XL,40.09,0.00
+__import__.product_template_p1345,P1345/9,P1345/O9,Terno P1345,Talla: 9,56.16,0.00
+__import__.product_template_p1345,P1345/7,P1345/O7,Terno P1345,Talla: 7,56.16,0.00
+__import__.product_template_ekp4066,EKP4066/L,EKP4066/OL,M. SHORT OFF WHITE TALLA L,Talla: L,48.13,0.00
+__import__.product_template_ekp4066,EKP4066/M,EKP4066/OM,M. SHORT OFF WHITE TALLA L,Talla: M,48.13,0.00
+__import__.product_template_ekp4066,EKP4066/S,EKP4066/OS,M. SHORT OFF WHITE TALLA L,Talla: S,48.13,0.00
+__import__.product_template_ijf30458_bl,IJF30458-BL/S,IJF30458-BL/OS,M. CHAQUETA INA BLACK TALLA S,Talla: S,46.00,0.00
+__import__.product_template_ijf30458_bl,IJF30458-BL/M,IJF30458-BL/OM,M. CHAQUETA INA BLACK TALLA S,Talla: M,46.00,0.00
+__import__.product_template_ijf30458_bl,IJF30458-BL/L,IJF30458-BL/OL,M. CHAQUETA INA BLACK TALLA S,Talla: L,46.00,0.00
+__import__.product_template_z_tb_s04,Z-TB-S04/6,Z-TB-S04/O6,Terno Z-TB-S04,Talla: 6,44.55,0.00
+__import__.product_template_z_tb_s04,Z-TB-S04/7,Z-TB-S04/O7,Terno Z-TB-S04,Talla: 7,44.55,0.00
+__import__.product_template_z_tb_s04,Z-TB-S04/8,Z-TB-S04/O8,Terno Z-TB-S04,Talla: 8,43.39,0.00
+__import__.product_template_z_tb_s04,Z-TB-S04/9,Z-TB-S04/O9,Terno Z-TB-S04,Talla: 9,44.55,0.00
+__import__.product_template_mmtr00498_fa800109_w00749_7013_38,MMTR00498-FA800109-W00749-7013-38/52,8059712741550,Terno MMTR00498-FA800109-W00749-7013-38,Talla: 52,86.87,0.00
+__import__.product_template_mmtr00498_fa800109_w00749_5065_40,MMTR00498-FA800109-W00749-5065-40/54,8059712741529,Terno MMTR00498-FA800109-W00749-5065-40,Talla: 54,86.87,0.00
+__import__.product_template_mmtr00498_fa800109_w00749_5065_38,MMTR00498-FA800109-W00749-5065-38/52,8059712741536,Terno MMTR00498-FA800109-W00749-5065-38,Talla: 52,86.87,0.00
+__import__.product_template_mmtr00498_fa800109_w00749_5065_36,MMTR00498-FA800109-W00749-5065-36/50,8059712741512,Terno MMTR00498-FA800109-W00749-5065-36,Talla: 50,86.87,0.00
+__import__.product_template_mmtr00498_w00749_5065_34,MMTR00498-W00749-5065-34/48,8059712741505,Terno MMTR00498-W00749-5065-34,Talla: 48,86.87,0.00
+__import__.product_template_mmsl00529_fa430374_6002_50,MMSL00529-FA430374-6002-50/L,8059712722580,SHIRT LONG SLEEVE WITH VENT ON MORATO MULTCOLORE,Talla: L,73.83,0.00
+__import__.product_template_mmsl00529_fa430374_6002_46,MMSL00529-FA430374-6002-46/S,8059712661148,SHIRT LONG SLEEVE WITH VENT ON MORATO MULTCOLORE (mmsl00529_fa430374_6002_46),Talla: S,73.83,0.00
+__import__.product_template_mmsl00538_fa430367_7073_46,MMSL00538-FA430367-7073-46/S,8059712666075,SHIRT GOLD ON PRINTED FABRIC MORATO BLUE INK,Talla: S,73.83,0.00
+__import__.product_template_mmsl00425_fa430305_9024_46,MMSL00425-FA430305-9024-46/S,8059712439549,SHIRT PRINTED FABRIC MORATO STEEL GREY,Talla: S,73.83,0.00
+__import__.product_template_mmks01600_fa120001_1000,MMKS01600-FA120001-1000-XXL,8059712811925,POLO WITH LOGO PRINT ON CHEST MORATO WHITE,Talla: XXL,47.74,0.00
+__import__.product_template_mmks01600_fa120001_1000,MMKS01600-FA120001-1000-XL,8059712811918,POLO WITH LOGO PRINT ON CHEST MORATO WHITE,Talla: XL,47.74,0.00
+__import__.product_template_mmks01600_fa120001_1000,MMKS01600-FA120001-1000-S,8059712811901,POLO WITH LOGO PRINT ON CHEST MORATO WHITE,Talla: S,47.74,0.00
+__import__.product_template_mmks01600_fa120001_1000,MMKS01600-FA120001-1000-M,8059712775524,POLO WITH LOGO PRINT ON CHEST MORATO WHITE,Talla: M,47.74,0.00
+__import__.product_template_mmks01600_fa120001_1000,MMKS01600-FA120001-1000-L,8059712775692,POLO WITH LOGO PRINT ON CHEST MORATO WHITE,Talla: L,47.74,0.00
+__import__.product_template_bm22338_a,BM22338.A/28,BM22338.A/O28,Terno BM22338.A,Talla: 28,30.35,0.00
+__import__.product_template_bm22338_a,BM22338.A/29,BM22338.A/O29,Terno BM22338.A,Talla: 29,30.35,0.00
+__import__.product_template_b8dpnt07_bl,B8DPNT07-BL/42,B8DPNT07-BL/O42,Terno B8DPNT07-BL,Talla: 42,56.43,0.00
+__import__.product_template_b8dpnt07_bl,B8DPNT07-BL/40,B8DPNT07-BL/O40,Terno B8DPNT07-BL,Talla: 40,56.43,0.00
+__import__.product_template_b8dpnt07_bl,B8DPNT07-BL/38,B8DPNT07-BL/O38,Terno B8DPNT07-BL,Talla: 38,56.43,0.00
+__import__.product_template_b8dpnt07_bl,B8DPNT07-BL/36,B8DPNT07-BL/O36,Terno B8DPNT07-BL,Talla: 36,56.43,0.00
+__import__.product_template_b8dpnt07_bl,B8DPNT07-BL/34,B8DPNT07-BL/O34,Terno B8DPNT07-BL,Talla: 34,56.43,0.00
+__import__.product_template_b8dpnt07_bl,B8DPNT07-BL/32,B8DPNT07-BL/O32,Terno B8DPNT07-BL,Talla: 32,56.43,0.00
+__import__.product_template_b8dpnt07_bl,B8DPNT07-BL/30,B8DPNT07-BL/O30,Terno B8DPNT07-BL,Talla: 30,56.43,0.00
+__import__.product_template_lbpc_j21_001f_wi,LBPC-J21-001F-WI/40,691046690753,Terno LBPC-J21-001F-WI,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_001f_wi,LBPC-J21-001F-WI/38,691046690746,Terno LBPC-J21-001F-WI,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_001f_wi,LBPC-J21-001F-WI/36,691046690739,Terno LBPC-J21-001F-WI,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_001f_wi,LBPC-J21-001F-WI/34,691046690722,Terno LBPC-J21-001F-WI,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_001f_wi,LBPC-J21-001F-WI/32,691046690715,Terno LBPC-J21-001F-WI,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_001f_wi,LBPC-J21-001F-WI/30,691046690708,Terno LBPC-J21-001F-WI,Talla: 30,43.39,0.00
+__import__.product_template_lbpc_j21_001f_ja,LBPC-J21-001F-JA/40,691046690814,Terno LBPC-J21-001F-JA,Talla: 40,43.39,0.00
+__import__.product_template_lbpc_j21_001f_ja,LBPC-J21-001F-JA/38,691046690807,Terno LBPC-J21-001F-JA,Talla: 38,43.39,0.00
+__import__.product_template_lbpc_j21_001f_ja,LBPC-J21-001F-JA/36,691046690791,Terno LBPC-J21-001F-JA,Talla: 36,43.39,0.00
+__import__.product_template_lbpc_j21_001f_ja,LBPC-J21-001F-JA/34,691046690784,Terno LBPC-J21-001F-JA,Talla: 34,43.39,0.00
+__import__.product_template_lbpc_j21_001f_ja,LBPC-J21-001F-JA/32,691046690777,Terno LBPC-J21-001F-JA,Talla: 32,43.39,0.00
+__import__.product_template_lbpc_j21_001f_ja,LBPC-J21-001F-JA/30,691046690760,Terno LBPC-J21-001F-JA,Talla: 30,43.39,0.00
+__import__.product_template_bpmd00211c_a,BPMD00211C.A/30,BPMD00211C.A/O30,Terno BPMD00211C.A,Talla: 30,39.04,0.00
+__import__.product_template_bpmd00211c_a,BPMD00211C.A/31,BPMD00211C.A/O31,Terno BPMD00211C.A,Talla: 31,39.04,0.00
+__import__.product_template_bpmd00211c_a,BPMD00211C.A/32,BPMD00211C.A/O32,Terno BPMD00211C.A,Talla: 32,39.04,0.00
+__import__.product_template_bpmd00211c_a,BPMD00211C.A/33,BPMD00211C.A/O33,Terno BPMD00211C.A,Talla: 33,39.04,0.00
+__import__.product_template_bpmd00211c_a,BPMD00211C.A/34,BPMD00211C.A/O34,Terno BPMD00211C.A,Talla: 34,39.04,0.00
+__import__.product_template_bpmd00211c_a,BPMD00211C.A/36,BPMD00211C.A/O36,Terno BPMD00211C.A,Talla: 36,39.04,0.00
+__import__.product_template_bpmd00211c_a,BPMD00211C.A/38,BPMD00211C.A/O38,Terno BPMD00211C.A,Talla: 38,39.04,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/40,BPM11986.B/O40,Terno BPM11986.B,Talla: 40,39.04,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/38,BPM11986.B/O38,Terno BPM11986.B,Talla: 38,39.04,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/36,BPM11986.B/O36,Terno BPM11986.B,Talla: 36,120.45,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/34,BPM11986.B/O34,Terno BPM11986.B,Talla: 34,120.45,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/33,BPM11986.B/O33,Terno BPM11986.B,Talla: 33,39.04,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/32,BPM11986.B/O32,Terno BPM11986.B,Talla: 32,120.45,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/31,BPM11986.B/O31,Terno BPM11986.B,Talla: 31,120.45,0.00
+__import__.product_template_bpm11986_b,BPM11986.B/30,BPM11986.B/O30,Terno BPM11986.B,Talla: 30,120.45,0.00
+__import__.product_template_bm22338_a,BM22338.A/30,BM22338.A/O30,Terno BM22338.A,Talla: 30,30.35,0.00
+__import__.product_template_bm22338_a,BM22338.A/32,BM22338.A/O32,Terno BM22338.A,Talla: 32,39.04,0.00
+__import__.product_template_bm22338_a,BM22338.A/31,BM22338.A/O31,Terno BM22338.A,Talla: 31,30.35,0.00
+__import__.product_template_bm22338_a,BM22338.A/33,BM22338.A/O33,Terno BM22338.A,Talla: 33,30.35,0.00
+__import__.product_template_bm22338_a,BM22338.A/34,BM22338.A/O34,Terno BM22338.A,Talla: 34,30.35,0.00
+__import__.product_template_bm22338_a,BM22338.A/36,BM22338.A/O36,Terno BM22338.A,Talla: 36,39.04,0.00
+__import__.product_template_bm22338_a,BM22338.A/38,BM22338.A/O38,Terno BM22338.A,Talla: 38,30.35,0.00
+__import__.product_template_z_2526dfv,Z-2526DFV/36,Z-2526DFV/O36,Terno Z-2526DFV,Talla: 36,80.79,0.00
+__import__.product_template_z_2526dfv,Z-2526DFV/38,Z-2526DFV/O38,Terno Z-2526DFV,Talla: 38,82.95,0.00
+__import__.product_template_z_2475dfv,Z-2475DFV/38,Z-2475DFV/O38,Terno Z-2475DFV,Talla: 38,80.79,0.00
+__import__.product_template_z_2475dfv,Z-2475DFV/36,Z-2475DFV/O36,Terno Z-2475DFV,Talla: 36,80.79,0.00
+__import__.product_template_z_6729lamod,Z-6729LAMOD/36,Z-6729LAMOD/O36,Terno Z-6729LAMOD,Talla: 36,73.82,0.00
+__import__.product_template_z_6729lamod,Z-6729LAMOD/38,Z-6729LAMOD/O38,Terno Z-6729LAMOD,Talla: 38,75.80,0.00
+__import__.product_template_z_sd223davi,Z-SD223DAVI/36,Z-SD223DAVI/O36,Terno Z-SD223DAVI,Talla: 36,86.00,0.00
+__import__.product_template_z_sd223davi,Z-SD223DAVI/38,Z-SD223DAVI/O38,Terno Z-SD223DAVI,Talla: 38,86.00,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/42,008B120220642,Pantalon PT-008-BLACK,Talla: 42,47.74,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/38,008B120220638,Pantalon PT-008-BLACK,Talla: 38,56.43,0.00
+__import__.product_template_p1290_36,P1290/36-6,P1290/O36-6,Corbata P1290/36,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12137_11,MF12137/11-6,MF12137/O11-6,Corbata MF12137/11,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12137_2,MF12137/2-6,MF12137/O2-6,Corbata MF12137/2,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12162_10,MF12162/10-6,MF12162/O10-6,Corbata MF12162/10,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12162_5,MF12162/5-6,MF12162/O5-6,Corbata MF12162/5,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12162_3,MF12162/3-6,MF12162/O3-6,Corbata MF12162/3,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12160_11,MF12160/11-6,MF12160/O11-6,Corbata MF12160/11,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12160_9,MF12160/9-6,MF12160/O9-6,Corbata MF12160/9,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12160_8,MF12160/8-6,MF12160/O8-6,Corbata MF12160/8,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12160_6,MF12160/6-6,MF12160/O6-6,Corbata MF12160/6,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_47,P1290/47-6,P1290/O47-6,Corbata P1290/47,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_45,P1290/45-6,P1290/O45-6,Corbata P1290/45,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_38,P1290/38-6,P1290/O38-6,Corbata P1290/38,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_37,P1290/37-6,P1290/O37-6,Corbata P1290/37,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_35,P1290/35-6,P1290/O35-6,Corbata P1290/35,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_34,P1290/34-6,P1290/O34-6,Corbata P1290/34,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_13,P1290/13-6,P1290/O13-6,Corbata P1290/13,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_10,P1290/10-6,P1290/O10-6,Corbata P1290/10,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1290_6,P1290/6-6,P1290/O6-6,Corbata P1290/6,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_19,MF3870/19-6,MF3870/O19-6,Corbata MF3870/19,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_13,MF3870/13-6,MF3870/O13-6,Corbata MF3870/13,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_11,MF3870/11-6,MF3870/O11-6,Corbata MF3870/11,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_9,MF3870/9-6,MF3870/O9-6,Corbata MF3870/9,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_3,MF3870/3-6,MF3870/O3-6,Corbata MF3870/3,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_1,MF3870/1-6,MF3870/O1-6,Corbata MF3870/1,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_66,MF3870/66-6,MF3870/O66-6,Corbata MF3870/66,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_57,MF3870/57-6,MF3870/O57-6,Corbata MF3870/57,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_54,MF3870/54-6,MF3870/O54-6,Corbata MF3870/54,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_45,MF3870/45-6,MF3870/O45-6,Corbata MF3870/45,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_115,MF3870/115-6,MF3870/O115-6,Corbata MF3870/115,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_114,MF3870/114-6,MF3870/O114-6,Corbata MF3870/114,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_113,MF3870/113-6,MF3870/O113-6,Corbata MF3870/113,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_109,MF3870/109-6,MF3870/O109-6,Corbata MF3870/109,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_104,MF3870/104-6,MF3870/O104-6,Corbata MF3870/104,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_100,MF3870/100-6,MF3870/O100-6,Corbata MF3870/100,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_90,MF3870/90-6,MF3870/O90-6,Corbata MF3870/90,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1288_47,P1288/47-6,P1288/O47-6,Corbata P1288/47,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1288_43,P1288/43-6,P1288/O43-6,Corbata P1288/43,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1288_37,P1288/37-6,P1288/O37-6,Corbata P1288/37,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1288_36,P1288/36-6,P1288/O36-6,Corbata P1288/36,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1288_35,P1288/35-6,P1288/O35-6,Corbata P1288/35,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1288_31,P1288/31-6,P1288/O31-6,Corbata P1288/31,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p1288_15,P1288/15-6,P1288/O15-6,Corbata P1288/15,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf12162_10,MF12162/10-7,MF12162/O10-7,Corbata MF12162/10,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12162_5,MF12162/5-7,MF12162/O5-7,Corbata MF12162/5,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12162_3,MF12162/3-7,MF12162/O3-7,Corbata MF12162/3,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12160_11,MF12160/11-7,MF12160/O11-7,Corbata MF12160/11,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12160_9,MF12160/9-7,MF12160/O9-7,Corbata MF12160/9,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12160_8,MF12160/8-7,MF12160/O8-7,Corbata MF12160/8,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12160_6,MF12160/6-7,MF12160/O6-7,Corbata MF12160/6,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_47,P1290/47-7,P1290/O47-7,Corbata P1290/47,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_45,P1290/45-7,P1290/O45-7,Corbata P1290/45,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_38,P1290/38-7,P1290/O38-7,Corbata P1290/38,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_37,P1290/37-7,P1290/O37-7,Corbata P1290/37,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_36,P1290/36-7,P1290/O36-7,Corbata P1290/36,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_35,P1290/35-7,P1290/O35-7,Corbata P1290/35,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_34,P1290/34-7,P1290/O34-7,Corbata P1290/34,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_13,P1290/13-7,P1290/O13-7,Corbata P1290/13,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_10,P1290/10-7,P1290/O10-7,Corbata P1290/10,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1290_6,P1290/6-7,P1290/O6-7,Corbata P1290/6,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_19,MF3870/19-7,MF3870202319701,Corbata MF3870/19,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_13,MF3870/13-7,MF3870/O13-7,Corbata MF3870/13,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_11,MF3870/11-7,MF3870202311701,Corbata MF3870/11,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_9,MF3870/9-7,MF3870/O9-7,Corbata MF3870/9,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_3,MF3870/3-7,MF3870/O3-7,Corbata MF3870/3,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_1,MF3870/1-7,MF3870202301701,Corbata MF3870/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_66,MF3870/66-7,MF3870/O66-7,Corbata MF3870/66,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_57,MF3870/57-7,MF3870/O57-7,Corbata MF3870/57,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_54,MF3870/54-7,MF3870/O54-7,Corbata MF3870/54,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_45,MF3870/45-7,MF3870202345701,Corbata MF3870/45,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_115,MF3870/115-7,MF3870/O115-7,Corbata MF3870/115,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_114,MF3870/114-7,MF3870/O114-7,Corbata MF3870/114,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_113,MF3870/113-7,MF3870/O113-7,Corbata MF3870/113,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_109,MF3870/109-7,MF3870/O109-7,Corbata MF3870/109,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_104,MF3870/104-7,MF3870/O104-7,Corbata MF3870/104,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_100,MF3870/100-7,MF3870/O100-7,Corbata MF3870/100,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_90,MF3870/90-7,MF3870/O90-7,Corbata MF3870/90,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1288_47,P1288/47-7,P1288/O47-7,Corbata P1288/47,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1288_43,P1288/43-7,P1288/O43-7,Corbata P1288/43,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1288_37,P1288/37-7,P1288/O37-7,Corbata P1288/37,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1288_36,P1288/36-7,P1288/O36-7,Corbata P1288/36,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1288_35,P1288/35-7,P1288/O35-7,Corbata P1288/35,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1288_31,P1288/31-7,P1288/O31-7,Corbata P1288/31,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p1288_15,P1288/15-7,P1288/O15-7,Corbata P1288/15,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12137_11,MF12137/11-7,MF12137/O11-7,Corbata MF12137/11,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf12137_2,MF12137/2-7,MF12137/O2-7,Corbata MF12137/2,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_at4266,AT4266/L,AT4266/OL,BLUSA LOVE ENCOUNTER,Talla: L,38.17,0.00
+__import__.product_template_9511tw,9511TW/L,9511TW/OL,BLUSA CQ BY CQ TALLA L,Talla: L,46.87,0.00
+__import__.product_template_9511tw,9511TW/S,9511TW/OS,BLUSA CQ BY CQ TALLA L,Talla: S,46.87,0.00
+__import__.product_template_10896t,10896T/L,10896T/OL,BLUSA IDEM DITTO TALLA L,Talla: L,44.26,0.00
+__import__.product_template_10896t,10896T/M,10896T/OM,BLUSA IDEM DITTO TALLA L,Talla: M,44.26,0.00
+__import__.product_template_10896t,10896T/S,10896T/OS,BLUSA IDEM DITTO TALLA L,Talla: S,44.26,0.00
+__import__.product_template_6040124_mx,6040124-MX/XL,6040M/OXL,VESTIDO TIRAS P/DAMA MODELOS MIX TALLA XL,Talla: XL,40.09,0.00
+__import__.product_template_6040124_mx,6040124-MX/L,6040MX/OL,VESTIDO TIRAS P/DAMA MODELOS MIX TALLA XL,Talla: L,40.09,0.00
+__import__.product_template_6040124_mx,6040124-MX/M,6040MX/OM,VESTIDO TIRAS P/DAMA MODELOS MIX TALLA XL,Talla: M,40.09,0.00
+__import__.product_template_6040124_mx,6040124-MX/S,6040124-MX/OS,VESTIDO TIRAS P/DAMA MODELOS MIX TALLA XL,Talla: S,40.09,0.00
+__import__.product_template_6040124_mx,6040124-MX/XS,6040M/OXS,VESTIDO TIRAS P/DAMA MODELOS MIX TALLA XL,Talla: XS,40.09,0.00
+__import__.product_template_6040109_rj,6040109-RJ/XL,6040109-RJ/OXL,TOP S/M P/DAMAS MODELO ROJA TALLA XL,Talla: XL,21.65,0.00
+__import__.product_template_6040109_rj,6040109-RJ/L,6040109-RJ/OL,TOP S/M P/DAMAS MODELO ROJA TALLA XL,Talla: L,21.65,0.00
+__import__.product_template_6040109_rj,6040109-RJ/M,6040109-RJ/OM,TOP S/M P/DAMAS MODELO ROJA TALLA XL,Talla: M,21.65,0.00
+__import__.product_template_6040109_rj,6040109-RJ/S,6040109-RJ/OS,TOP S/M P/DAMAS MODELO ROJA TALLA XL,Talla: S,21.65,0.00
+__import__.product_template_6040109_rj,6040109-RJ/XS,6040109-RJ/OXS,TOP S/M P/DAMAS MODELO ROJA TALLA XL,Talla: XS,21.65,0.00
+__import__.product_template_6010058_bl,6010058-BL/XL,6010058-BL/OXL,BLUSA S/M P/DAMA MODELO TALLA XL,Talla: XL,24.26,0.00
+__import__.product_template_6010058_bl,6010058-BL/L,6010058-BL/OL,BLUSA S/M P/DAMA MODELO TALLA XL,Talla: L,24.26,0.00
+__import__.product_template_6010058_bl,6010058-BL/M,6010058-BL/OM,BLUSA S/M P/DAMA MODELO TALLA XL,Talla: M,24.26,0.00
+__import__.product_template_6010058_bl,6010058-BL/S,6010058-BL/OS,BLUSA S/M P/DAMA MODELO TALLA XL,Talla: S,24.26,0.00
+__import__.product_template_6010058_bl,6010058-BL/XS,6010058-BL/OXS,BLUSA S/M P/DAMA MODELO TALLA XL,Talla: XS,24.26,0.00
+__import__.product_template_1012065_rj,1012065-RJ/L,1012065-RJ/OL,BLUSA M/3/4 P/DAMA BLANCA ROJO TALLA L,Talla: L,24.26,0.00
+__import__.product_template_1012065_rj,1012065-RJ/M,1012065-RJ/OM,BLUSA M/3/4 P/DAMA BLANCA ROJO TALLA L,Talla: M,24.26,0.00
+__import__.product_template_1012065_rj,1012065-RJ/S,1012065-RJ/OS,BLUSA M/3/4 P/DAMA BLANCA ROJO TALLA L,Talla: S,24.26,0.00
+__import__.product_template_1012065_rj,1012065-RJ/XS,1012065-RJ/XS,BLUSA M/3/4 P/DAMA BLANCA ROJO TALLA L,Talla: XS,24.26,0.00
+__import__.product_template_1012065_az,1012065-AZ/M,1012065-AZ/OM,BLUSA M/3/4 P/DAMA BLANCA AZUL TALLA M,Talla: M,24.26,0.00
+__import__.product_template_1012065_az,1012065-AZ/XS,1012065-AZ/OXS,BLUSA M/3/4 P/DAMA BLANCA AZUL TALLA M,Talla: XS,24.26,0.00
+__import__.product_template_1012065_az,1012065-AZ/S,1012065-AZ/OS,BLUSA M/3/4 P/DAMA BLANCA AZUL TALLA M,Talla: S,24.26,0.00
+__import__.product_template_cv_b90_002wi,CV-B90-002WI/S,CV-B90-002WI/OS,PIJAMA P/H M/C P/C 100% ALGODON,Talla: S,30.35,0.00
+__import__.product_template_cv_b90_002wi,CV-B90-002WI/M,CV-B90-002WI/OM,PIJAMA P/H M/C P/C 100% ALGODON,Talla: M,30.35,0.00
+__import__.product_template_cv_b90_002wi,CV-B90-002WI/L,CV-B90-002WI/OL,PIJAMA P/H M/C P/C 100% ALGODON,Talla: L,30.35,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/34,008B120220634,Pantalon PT-008-BLACK,Talla: 34,56.43,0.00
+__import__.product_template_pt_008_black,PT-008-BLACK/36,008B120220636,Pantalon PT-008-BLACK,Talla: 36,56.43,0.00
+__import__.product_template_ter_bc_var,TER-BC-VAR/46,TER-BC-VAR/O46,Terno TER-BC-VAR,Talla: 46,217.30,0.00
+__import__.product_template_ter_bc_var,TER-BC-VAR/54,TER-BC-VAR/O54,Terno TER-BC-VAR,Talla: 54,104.26,0.00
+__import__.product_template_ter_bc_var,TER-BC-VAR/52,TER-BC-VAR/O52,Terno TER-BC-VAR,Talla: 52,165.13,0.00
+__import__.product_template_ter_bc_var,TER-BC-VAR/50,TER-BC-VAR/O50,Terno TER-BC-VAR,Talla: 50,165.13,0.00
+__import__.product_template_ter_bc_var,TER-BC-VAR/48,TER-BC-VAR/O48,Terno TER-BC-VAR,Talla: 48,165.13,0.00
+__import__.product_template_ter_bc_var,TER-BC-VAR/44,TER-BC-VAR/O44,Terno TER-BC-VAR,Talla: 44,165.13,0.00
+__import__.product_template_j11063_bleach_blue_sh,J11063/BLEACH BLUE-SH-28,J11063/BLEALUE-SH-28,SHORT P/DAMA OBSENA,Talla: 28,11.52,0.00
+__import__.product_template_43sw7026,43SW7026-S,43SW7026-S,CAMISA M/C CASUAL HOMBRE,Talla: S,47.74,0.00
+__import__.product_template_bmo6483,BMO6483-29,BMO6483-29,H. JEANS BUFFALO-X GARRET,Talla: 29,39.04,0.00
+__import__.product_template_omo0944,OMO0944-31,OMO0944-31,H. JEANS BUFFALO MAX,Talla: 31,39.04,0.00
+__import__.product_template_bpm7775,BPM7775-29,BPM7775-29,JEANS DE HOMBRE 100 ALGODON,Talla: 29,39.04,0.00
+__import__.product_template_bpm7770,BPM7770-28,BPM7770-28,JEANS DE HOMBRE 100 ALGODON (bpm7770),Talla: 28,120.45,0.00
+__import__.product_template_bpm7770,BPM7770-29,BPM7770-29,JEANS DE HOMBRE 100 ALGODON (bpm7770),Talla: 29,39.04,0.00
+__import__.product_template_bpm7770,BPM7770-30,BPM7770-30,JEANS DE HOMBRE 100 ALGODON (bpm7770),Talla: 30,120.45,0.00
+__import__.product_template_bpm7770,BPM7770-31,BPM7770-31,JEANS DE HOMBRE 100 ALGODON (bpm7770),Talla: 31,120.45,0.00
+__import__.product_template_bpm7682,BPM7682-29,BPM7682-29,JEANS SAX DE HOMBRE 100 ALGODON,Talla: 29,120.45,0.00
+__import__.product_template_bpm7682,BPM7682-28,BPM7682-28,JEANS SAX DE HOMBRE 100 ALGODON,Talla: 28,39.04,0.00
+__import__.product_template_bpm7473,BPM7473-28,BPM7473-28,KING PANTALON,Talla: 28,39.04,0.00
+__import__.product_template_bpm7473,BPM7473-29,BPM7473-29,KING PANTALON,Talla: 29,39.04,0.00
+__import__.product_template_bpm7473,BPM7473-31,BPM7473-31,KING PANTALON,Talla: 31,39.04,0.00
+__import__.product_template_bpm7473,BPM7473-32,BPM7473-32,KING PANTALON,Talla: 32,39.04,0.00
+__import__.product_template_bpm7120,BPM7120-34,BPM7120-34,JEANS SIMON DE HOMBRE,Talla: 34,39.04,0.00
+__import__.product_template_bmo7217,BMO7217-32,BMO7217-32,H. JEANS BUFFALO,Talla: 32,39.04,0.00
+__import__.product_template_bmo7209,BMO7209-30,BMO7209-30,H. JEANS BUFFALO GAME,Talla: 30,39.04,0.00
+__import__.product_template_bmo6604,BMO6604-30,BMO6604-30,H. JEANS BUFFALO MATHEW,Talla: 30,39.04,0.00
+__import__.product_template_bmo6234,BMO6234-28,BMO6234-28,H. JEANS MATTHEW BUFFALO,Talla: 28,30.35,0.00
+__import__.product_template_bmo6234,BMO6234-29,BMO6234-29,H. JEANS MATTHEW BUFFALO,Talla: 29,30.35,0.00
+__import__.product_template_bmo6234,BMO6234-30,BMO6234-30,H. JEANS MATTHEW BUFFALO,Talla: 30,39.04,0.00
+__import__.product_template_bmo6226,BMO6226-30,BMO6226-30,H. PANTALON BUFFALO X-PERT,Talla: 30,39.04,0.00
+__import__.product_template_bmo5961,BMO5961-29,BMO5961-29,H. PANTALON BUFFALO JECK,Talla: 29,39.04,0.00
+__import__.product_template_bm13708,BM13708-28,BM13708-28,KING PANTALON (bm13708),Talla: 28,39.04,0.00
+__import__.product_template_bm13521,BM13521-30,BM13521-30,JEANS KOBE HOMBRE 1005 ALGODON,Talla: 30,39.04,0.00
+__import__.product_template_bm13521,BM13521-29,BM13521-29,JEANS KOBE HOMBRE 1005 ALGODON,Talla: 29,39.04,0.00
+__import__.product_template_bm11131,BM11131-29,BM11131-29,JEANS DRAYANN DE HOMBRE,Talla: 29,39.04,0.00
+__import__.product_template_bm11115,BM11115-29,BM11115-29,JEANS KARSE DE HOMBRE,Talla: 29,30.35,0.00
+__import__.product_template_bm11115,BM11115-28,BM11115-28,JEANS KARSE DE HOMBRE,Talla: 28,39.04,0.00
+__import__.product_template_bm10814,BM10814-32,BM10814-32,JEANS SIX HOMBRE,Talla: 32,39.04,0.00
+__import__.product_template_opbs5148_468_sh,OPBS5148-468.SH/31,OPBS5148-468.OP/O31,Terno OPBS5148-468.SH,Talla: 31,47.74,0.00
+__import__.product_template_opbb9154_489_sh,OPBB9154-489.SH/30,OPBB9154-489.SH/O30,Terno OPBB9154-489.SH,Talla: 30,47.74,0.00
+__import__.product_template_opbb9154_489_sh,OPBB9154-489.SH/31,OPBB9154-489.SH/O31,Terno OPBB9154-489.SH,Talla: 31,47.74,0.00
+__import__.product_template_opbb9154_489_sh,OPBB9154-489.SH/32,OPBB9154-489.SH/O32,Terno OPBB9154-489.SH,Talla: 32,47.74,0.00
+__import__.product_template_opbb9154_489_sh,OPBB9154-489.SH/33,OPBB9154-489.SH/O33,Terno OPBB9154-489.SH,Talla: 33,47.74,0.00
+__import__.product_template_opbb9154_489_sh,OPBB9154-489.SH/34,OPBB9154-489.SH/O34,Terno OPBB9154-489.SH,Talla: 34,47.74,0.00
+__import__.product_template_opbb9154_489_sh,OPBB9154-489.SH/36,OPBB9154-489.SH/O36,Terno OPBB9154-489.SH,Talla: 36,47.74,0.00
+__import__.product_template_opbb9154_489_sh,OPBB9154-489.SH/38,OPBB9154-489.SH/O38,Terno OPBB9154-489.SH,Talla: 38,47.74,0.00
+__import__.product_template_opbb9154_413_sh,OPBB9154-413.SH/36,OPBB9154-413.SH/O36,Terno OPBB9154-413.SH,Talla: 36,47.74,0.00
+__import__.product_template_opbb9154_413_sh,OPBB9154-413.SH/38,OPBB9154-413.SH/O38,Terno OPBB9154-413.SH,Talla: 38,47.74,0.00
+__import__.product_template_opbb9154_413_sh,OPBB9154-413.SH/34,OPBB9154-413.SH/O34,Terno OPBB9154-413.SH,Talla: 34,47.74,0.00
+__import__.product_template_opbb9154_413_sh,OPBB9154-413.SH/33,OPBB9154-413.SH/O33,Terno OPBB9154-413.SH,Talla: 33,47.74,0.00
+__import__.product_template_opbb9154_413_sh,OPBB9154-413.SH/32,OPBB9154-413.SH/O32,Terno OPBB9154-413.SH,Talla: 32,47.74,0.00
+__import__.product_template_opbb9154_413_sh,OPBB9154-413.SH/31,OPBB9154-413.SH/O31,Terno OPBB9154-413.SH,Talla: 31,47.74,0.00
+__import__.product_template_opbb9154_413_sh,OPBB9154-413.SH/30,OPBB9154-413.SH/O30,Terno OPBB9154-413.SH,Talla: 30,47.74,0.00
+__import__.product_template_opbb9154_010_sh,OPBB9154-010.SH/38,OPBB9154-010.SH/O38,Terno OPBB9154-010.SH,Talla: 38,47.74,0.00
+__import__.product_template_opbb9154_010_sh,OPBB9154-010.SH/36,OPBB9154-010.SH/O36,Terno OPBB9154-010.SH,Talla: 36,47.74,0.00
+__import__.product_template_opbb9154_010_sh,OPBB9154-010.SH/34,OPBB9154-010.SH/O34,Terno OPBB9154-010.SH,Talla: 34,47.74,0.00
+__import__.product_template_opbb9154_010_sh,OPBB9154-010.SH/33,OPBB9154-010.SH/O33,Terno OPBB9154-010.SH,Talla: 33,47.74,0.00
+__import__.product_template_opbb9154_010_sh,OPBB9154-010.SH/32,OPBB9154-010.SH/O32,Terno OPBB9154-010.SH,Talla: 32,47.74,0.00
+__import__.product_template_opbb9154_010_sh,OPBB9154-010.SH/31,OPBB9154-010.SH/O31,Terno OPBB9154-010.SH,Talla: 31,47.74,0.00
+__import__.product_template_opbb9154_010_sh,OPBB9154-010.SH/30,OPBB9154-010.SH/O30,Terno OPBB9154-010.SH,Talla: 30,47.74,0.00
+__import__.product_template_pt_025_2,PT-025-2/29,PT-025-2/O29,Pantalon PT-025-2,Talla: 29,39.04,0.00
+__import__.product_template_pt_008_black_1,PT-008-BLACK-1/32,PT-008-BLACK-1/O32,Pantalon PT-008-BLACK-1,Talla: 32,39.04,0.00
+__import__.product_template_mb0905_4cbc_2,MB0905-4CBC-2/56,90540201925638,Terno MB0905-4CBC-2,Talla: 56,217.30,0.00
+__import__.product_template_mb0905_4cbc_2,MB0905-4CBC-2/52,90540201925234,Terno MB0905-4CBC-2,Talla: 52,191.22,0.00
+__import__.product_template_mb0905_4cbc_2,MB0905-4CBC-2/50,90540201925032,Terno MB0905-4CBC-2,Talla: 50,191.22,0.00
+__import__.product_template_mb0905_4cbc_2,MB0905-4CBC-2/54,90540201925436,Terno MB0905-4CBC-2,Talla: 54,191.22,0.00
+__import__.product_template_mb0905_4cbc_2,MB0905-4CBC-2/46,90540201924629,Terno MB0905-4CBC-2,Talla: 46,191.22,0.00
+__import__.product_template_mb0905_4cbc_2,MB0905-4CBC-2/48,90540201924830,Terno MB0905-4CBC-2,Talla: 48,191.22,0.00
+__import__.product_template_mb0905_4cbc_2,MB0905-4CBC-2/58,90540201925840,Terno MB0905-4CBC-2,Talla: 58,191.22,0.00
+__import__.product_template_mb0905_14bc_2,MB0905-14BC-2/46,90514201924629,Terno MB0905-14BC-2,Talla: 46,217.30,0.00
+__import__.product_template_mb0905_14bc_2,MB0905-14BC-2/48,90514201924830,Terno MB0905-14BC-2,Talla: 48,217.30,0.00
+__import__.product_template_mb0905_14bc_2,MB0905-14BC-2/50,90514201925032,Terno MB0905-14BC-2,Talla: 50,147.74,0.00
+__import__.product_template_mb0905_14bc_2,MB0905-14BC-2/52,90514201925234,Terno MB0905-14BC-2,Talla: 52,147.74,0.00
+__import__.product_template_mb0905_14bc_2,MB0905-14BC-2/54,90514201925436,Terno MB0905-14BC-2,Talla: 54,147.74,0.00
+__import__.product_template_mb0905_14bc_2,MB0905-14BC-2/56,90514201925638,Terno MB0905-14BC-2,Talla: 56,217.30,0.00
+__import__.product_template_mb0905_14bc_2,MB0905-14BC-2/58,90514201925840,Terno MB0905-14BC-2,Talla: 58,147.74,0.00
+__import__.product_template_mb0905_11bc_2,MB0905-11BC-2/48,90511201924830,Terno MB0905-11BC-2,Talla: 48,165.13,0.00
+__import__.product_template_mb0905_11bc_2,MB0905-11BC-2/50,90511201925032,Terno MB0905-11BC-2,Talla: 50,165.13,0.00
+__import__.product_template_mb0905_11bc_2,MB0905-11BC-2/54,90511201925436,Terno MB0905-11BC-2,Talla: 54,165.13,0.00
+__import__.product_template_mb0905_11bc_2,MB0905-11BC-2/56,90511201925638,Terno MB0905-11BC-2,Talla: 56,165.13,0.00
+__import__.product_template_mb0905_11bc_2,MB0905-11BC-2/46,90511201924629,Terno MB0905-11BC-2,Talla: 46,217.30,0.00
+__import__.product_template_mb0905_11bc_2,MB0905-11BC-2/58,90511201925840,Terno MB0905-11BC-2,Talla: 58,165.13,0.00
+__import__.product_template_mb0905_11bc_2,MB0905-11BC-2/52,90511201925234,Terno MB0905-11BC-2,Talla: 52,165.13,0.00
+__import__.product_template_fund_adams,FUND-ADAMS-18,FUND-ADAMS-18,FUNDAS ADAMS 18FLI,Talla: 18,0.02,0.00
+__import__.product_template_fund_adams,FUND-ADAMS-15,FUND-ADAMS-15,FUNDAS ADAMS 18FLI,Talla: 15,0.01,0.00
+__import__.product_template_8870_35_2,8870-35-2/17.5,8870352019091752,Terno 8870-35-2,Talla: 17.5,39.04,0.00
+__import__.product_template_8870_35_1,8870-35-1/17.5,8870352019091751,Terno 8870-35-1,Talla: 17.5,39.04,0.00
+__import__.product_template_8870_35_2,8870-35-2/17,8870352019091702,Terno 8870-35-2,Talla: 17,39.04,0.00
+__import__.product_template_8870_35_1,8870-35-1/17,8870352019091701,Terno 8870-35-1,Talla: 17,39.04,0.00
+__import__.product_template_8870_35_2,8870-35-2/16.5,8870352019091652,Terno 8870-35-2,Talla: 16.5,39.04,0.00
+__import__.product_template_8870_35_1,8870-35-1/16.5,8870352019091651,Terno 8870-35-1,Talla: 16.5,39.04,0.00
+__import__.product_template_8870_35_2,8870-35-2/16,8870352019091602,Terno 8870-35-2,Talla: 16,39.04,0.00
+__import__.product_template_8870_35_1,8870-35-1/16,8870352019091601,Terno 8870-35-1,Talla: 16,39.04,0.00
+__import__.product_template_8870_35_2,8870-35-2/15.5,8870352019091552,Terno 8870-35-2,Talla: 15.5,39.04,0.00
+__import__.product_template_8870_35_1,8870-35-1/15.5,8870352019091551,Terno 8870-35-1,Talla: 15.5,39.04,0.00
+__import__.product_template_8870_35_2,8870-35-2/15,8870352019091502,Terno 8870-35-2,Talla: 15,39.04,0.00
+__import__.product_template_8870_35_1,8870-35-1/15,8870352019091501,Terno 8870-35-1,Talla: 15,39.04,0.00
+__import__.product_template_8870_35_2,8870-35-2/14.5,8870352019091452,Terno 8870-35-2,Talla: 14.5,39.04,0.00
+__import__.product_template_8870_35_1,8870-35-1/14.5,8870352019091451,Terno 8870-35-1,Talla: 14.5,39.04,0.00
+__import__.product_template_8911_8_2,8911-8-2/17,891182019091702,Terno 8911-8-2,Talla: 17,39.04,0.00
+__import__.product_template_8911_8_2,8911-8-2/16.5,891182019091652,Terno 8911-8-2,Talla: 16.5,39.04,0.00
+__import__.product_template_8911_8_2,8911-8-2/16,891182019091602,Terno 8911-8-2,Talla: 16,39.04,0.00
+__import__.product_template_8911_8_2,8911-8-2/15,891182019091502,Terno 8911-8-2,Talla: 15,39.04,0.00
+__import__.product_template_8911_8_2,8911-8-2/17.5,891182019091752,Terno 8911-8-2,Talla: 17.5,39.04,0.00
+__import__.product_template_8911_8_2,8911-8-2/15.5,891182019091552,Terno 8911-8-2,Talla: 15.5,39.04,0.00
+__import__.product_template_8911_8_2,8911-8-2/14.5,891182019091452,Terno 8911-8-2,Talla: 14.5,39.04,0.00
+__import__.product_template_8911_8_1,8911-8-1/17.5,891182019091751,Terno 8911-8-1,Talla: 17.5,39.04,0.00
+__import__.product_template_8911_8_1,8911-8-1/16.5,891182019091651,Terno 8911-8-1,Talla: 16.5,39.04,0.00
+__import__.product_template_8911_8_1,8911-8-1/15.5,891182019091551,Terno 8911-8-1,Talla: 15.5,39.04,0.00
+__import__.product_template_8911_8_1,8911-8-1/17,891182019091701,Terno 8911-8-1,Talla: 17,39.04,0.00
+__import__.product_template_8911_8_1,8911-8-1/16,891182019091601,Terno 8911-8-1,Talla: 16,39.04,0.00
+__import__.product_template_8911_8_1,8911-8-1/15,891182019091501,Terno 8911-8-1,Talla: 15,39.04,0.00
+__import__.product_template_8911_8_1,8911-8-1/14.5,891182019091451,Terno 8911-8-1,Talla: 14.5,39.04,0.00
+__import__.product_template_d605_9_2,D605-9-2/17.5,460592019091752,Terno D605-9-2,Talla: 17.5,39.04,0.00
+__import__.product_template_d605_9_2,D605-9-2/17,460592019091702,Terno D605-9-2,Talla: 17,39.04,0.00
+__import__.product_template_d605_9_2,D605-9-2/16,460592019091602,Terno D605-9-2,Talla: 16,39.04,0.00
+__import__.product_template_d605_9_2,D605-9-2/15,460592019091502,Terno D605-9-2,Talla: 15,39.04,0.00
+__import__.product_template_d605_9_2,D605-9-2/16.5,460592019091652,Terno D605-9-2,Talla: 16.5,39.04,0.00
+__import__.product_template_d605_9_2,D605-9-2/15.5,460592019091552,Terno D605-9-2,Talla: 15.5,39.04,0.00
+__import__.product_template_d605_9_2,D605-9-2/14.5,460592019091452,Terno D605-9-2,Talla: 14.5,39.04,0.00
+__import__.product_template_8859_15_1,8859-15-1/14.5,8859152019091451,Terno 8859-15-1,Talla: 14.5,39.04,0.00
+__import__.product_template_8859_15_1,8859-15-1/15,8859152019091501,Terno 8859-15-1,Talla: 15,39.04,0.00
+__import__.product_template_8859_15_1,8859-15-1/16.5,8859152019091651,Terno 8859-15-1,Talla: 16.5,39.04,0.00
+__import__.product_template_8859_15_1,8859-15-1/17,8859152019091701,Terno 8859-15-1,Talla: 17,39.04,0.00
+__import__.product_template_8859_15_1,8859-15-1/15.5,8859152019091551,Terno 8859-15-1,Talla: 15.5,39.04,0.00
+__import__.product_template_8859_15_1,8859-15-1/16,8859152019091601,Terno 8859-15-1,Talla: 16,39.04,0.00
+__import__.product_template_8859_15_1,8859-15-1/17.5,8859152019091751,Terno 8859-15-1,Talla: 17.5,39.04,0.00
+__import__.product_template_pt_025_2,PT-025-2/40,PT-025-2/O40,Pantalon PT-025-2,Talla: 40,47.74,0.00
+__import__.product_template_4dsw7003_126,4DSW7003-126/XXL,797082822803,CAMISA CASUAL M/L P/CABALLERO BRIGHT WHITE,Talla: XXL,55.57,0.00
+__import__.product_template_4dsw7003_126,4DSW7003-126/L,797082822780,CAMISA CASUAL M/L P/CABALLERO BRIGHT WHITE,Talla: L,55.57,0.00
+__import__.product_template_4dsw7003_126,4DSW7003-126/M,797082822773,CAMISA CASUAL M/L P/CABALLERO BRIGHT WHITE,Talla: M,55.57,0.00
+__import__.product_template_4dsw7003_126,4DSW7003-126/XL,797082822797,CAMISA CASUAL M/L P/CABALLERO BRIGHT WHITE,Talla: XL,55.57,0.00
+__import__.product_template_4dsw7003_126,4DSW7003-126/S,797082822766,CAMISA CASUAL M/L P/CABALLERO BRIGHT WHITE,Talla: S,55.57,0.00
+__import__.product_template_4dfw8712_493_ch,4DFW8712-493-CH/XL,7453097433030,CAMISA CASUAL M/L P/CABALLERO COLONY BLUE,Talla: XL,55.57,0.00
+__import__.product_template_4dfw8712_493_ch,4DFW8712-493-CH/L,7453097433023,CAMISA CASUAL M/L P/CABALLERO COLONY BLUE,Talla: L,55.57,0.00
+__import__.product_template_4dfw8712_493_ch,4DFW8712-493-CH/M,7453097433016,CAMISA CASUAL M/L P/CABALLERO COLONY BLUE,Talla: M,55.57,0.00
+__import__.product_template_4dfw8712_493_ch,4DFW8712-493-CH/S,7453097433009,CAMISA CASUAL M/L P/CABALLERO COLONY BLUE,Talla: S,55.57,0.00
+__import__.product_template_eefb5900_613,EEFB5900-613/38,7453097487781,Terno EEFB5900-613,Talla: 38,65.13,0.00
+__import__.product_template_eefb5900_613,EEFB5900-613/36,7453097487774,Terno EEFB5900-613,Talla: 36,65.13,0.00
+__import__.product_template_eefb5900_613,EEFB5900-613/30,7453097487743,Terno EEFB5900-613,Talla: 30,65.13,0.00
+__import__.product_template_eefb5900_613,EEFB5900-613/32,7453097487750,Terno EEFB5900-613,Talla: 32,65.13,0.00
+__import__.product_template_eefb5900_613,EEFB5900-613/34,7453097487767,Terno EEFB5900-613,Talla: 34,65.13,0.00
+__import__.product_template_4dfw8712_126_ch,4DFW8712-126-CH/XL,7453097433139,CAMISA CASUAL M/L P/H 100% ALGODON BRIGHT WHITE,Talla: XL,55.57,0.00
+__import__.product_template_4dfw8712_126_ch,4DFW8712-126-CH/L,7453097433122,CAMISA CASUAL M/L P/H 100% ALGODON BRIGHT WHITE,Talla: L,55.57,0.00
+__import__.product_template_4dfw8712_126_ch,4DFW8712-126-CH/M,7453097433115,CAMISA CASUAL M/L P/H 100% ALGODON BRIGHT WHITE,Talla: M,55.57,0.00
+__import__.product_template_4dfw8712_126_ch,4DFW8712-126-CH/S,7453097433108,CAMISA CASUAL M/L P/H 100% ALGODON BRIGHT WHITE,Talla: S,55.57,0.00
+__import__.product_template_cv_k21_002s_se,CV-K21-002S-SE/40,7453099234543,Terno CV-K21-002S-SE,Talla: 40,44.55,0.00
+__import__.product_template_cv_k21_002s_se,CV-K21-002S-SE/38,7453099234536,Terno CV-K21-002S-SE,Talla: 38,44.55,0.00
+__import__.product_template_cv_k21_002s_se,CV-K21-002S-SE/36,7453099234529,Terno CV-K21-002S-SE,Talla: 36,44.55,0.00
+__import__.product_template_cv_k21_002s_se,CV-K21-002S-SE/34,7453099234512,Terno CV-K21-002S-SE,Talla: 34,44.55,0.00
+__import__.product_template_cv_k21_002s_se,CV-K21-002S-SE/33,7453099234505,Terno CV-K21-002S-SE,Talla: 33,44.55,0.00
+__import__.product_template_cv_k21_002s_se,CV-K21-002S-SE/32,7453099234499,Terno CV-K21-002S-SE,Talla: 32,44.55,0.00
+__import__.product_template_cv_k21_002s_se,CV-K21-002S-SE/30,7453099234482,Terno CV-K21-002S-SE,Talla: 30,44.55,0.00
+__import__.product_template_ophb0099_250_op,OPHB0099-250.OP/30,691046761903,Terno OPHB0099-250.OP,Talla: 30,65.13,0.00
+__import__.product_template_ophb0099_250_op,OPHB0099-250.OP/31,691046761910,Terno OPHB0099-250.OP,Talla: 31,65.13,0.00
+__import__.product_template_ophb0099_250_op,OPHB0099-250.OP/32,691046761927,Terno OPHB0099-250.OP,Talla: 32,65.13,0.00
+__import__.product_template_ophb0099_250_op,OPHB0099-250.OP/33,691046761934,Terno OPHB0099-250.OP,Talla: 33,65.13,0.00
+__import__.product_template_ophb0099_250_op,OPHB0099-250.OP/36,691046761958,Terno OPHB0099-250.OP,Talla: 36,65.13,0.00
+__import__.product_template_ophb0099_250_op,OPHB0099-250.OP/34,691046761941,Terno OPHB0099-250.OP,Talla: 34,65.13,0.00
+__import__.product_template_ophb0099_250_op,OPHB0099-250.OP/38,691046761965,Terno OPHB0099-250.OP,Talla: 38,65.13,0.00
+__import__.product_template_rz543_black_tl,RZ543-BLACK-TL/7,RZ543-BLACK-TL/O7,Terno RZ543-BLACK-TL,Talla: 7,152.09,0.00
+__import__.product_template_rz543_black_tl,RZ543-BLACK-TL/7.5,RZ543-BLACK-TL/O7.5,Terno RZ543-BLACK-TL,Talla: 7.5,152.09,0.00
+__import__.product_template_rz543_black_tl,RZ543-BLACK-TL/8,RZ543-BLACK-TL/O8,Terno RZ543-BLACK-TL,Talla: 8,152.09,0.00
+__import__.product_template_rz543_black_tl,RZ543-BLACK-TL/8.5,RZ543-BLACK-TL/O8.5,Terno RZ543-BLACK-TL,Talla: 8.5,104.26,0.00
+__import__.product_template_rz543_black_tl,RZ543-BLACK-TL/9,RZ543-BLACK-TL/O9,Terno RZ543-BLACK-TL,Talla: 9,104.26,0.00
+__import__.product_template_rz1019_navy,RZ1019-NAVY/9,RZ1019-NAVY/O9,Terno RZ1019-NAVY,Talla: 9,104.26,0.00
+__import__.product_template_rz1019_navy,RZ1019-NAVY/8.5,RZ1019-NAVY/O8.5,Terno RZ1019-NAVY,Talla: 8.5,104.26,0.00
+__import__.product_template_rz1019_navy,RZ1019-NAVY/8,RZ1019-NAVY/O8,Terno RZ1019-NAVY,Talla: 8,152.09,0.00
+__import__.product_template_rz1019_navy,RZ1019-NAVY/7.5,RZ1019-NAVY/O7.5,Terno RZ1019-NAVY,Talla: 7.5,152.09,0.00
+__import__.product_template_rz1019_navy,RZ1019-NAVY/7,RZ1019-NAVY/O7,Terno RZ1019-NAVY,Talla: 7,104.26,0.00
+__import__.product_template_rz1019_tan,RZ1019-TAN/7,RZ1019-TAN/O7,Terno RZ1019-TAN,Talla: 7,104.26,0.00
+__import__.product_template_rz1019_tan,RZ1019-TAN/8.5,RZ1019-TAN/O8.5,Terno RZ1019-TAN,Talla: 8.5,104.26,0.00
+__import__.product_template_rz1019_tan,RZ1019-TAN/9,RZ1019-TAN/O9,Terno RZ1019-TAN,Talla: 9,104.26,0.00
+__import__.product_template_rz1019_tan,RZ1019-TAN/7.5,RZ1019-TAN/O7.5,Terno RZ1019-TAN,Talla: 7.5,152.09,0.00
+__import__.product_template_rz1019_tan,RZ1019-TAN/8,RZ1019-TAN/O8,Terno RZ1019-TAN,Talla: 8,104.26,0.00
+__import__.product_template_rz1019_taupe,RZ1019-TAUPE/8,RZ1019-TAUPE/O8,Terno RZ1019-TAUPE,Talla: 8,104.26,0.00
+__import__.product_template_rz1019_taupe,RZ1019-TAUPE/8.5,RZ1019-TAUPE/O8.5,Terno RZ1019-TAUPE,Talla: 8.5,104.26,0.00
+__import__.product_template_rz1019_taupe,RZ1019-TAUPE/9,RZ1019-TAUPE/O9,Terno RZ1019-TAUPE,Talla: 9,104.26,0.00
+__import__.product_template_rz1019_taupe,RZ1019-TAUPE/7,RZ1019-TAUPE/O7,Terno RZ1019-TAUPE,Talla: 7,104.26,0.00
+__import__.product_template_rz1019_taupe,RZ1019-TAUPE/7.5,RZ1019-TAUPE/O7.5,Terno RZ1019-TAUPE,Talla: 7.5,152.09,0.00
+__import__.product_template_cb_f11_001bu,CB-F11-001BU/36,7453099226692,Terno CB-F11-001BU,Talla: 36,304.26,0.00
+__import__.product_template_cb_f11_001bu,CB-F11-001BU/38,7453099226708,Terno CB-F11-001BU,Talla: 38,260.78,0.00
+__import__.product_template_cb_f11_001bu,CB-F11-001BU/40,7453099226715,Terno CB-F11-001BU,Talla: 40,260.78,0.00
+__import__.product_template_cb_f11_001bu,CB-F11-001BU/44,7453099226739,Terno CB-F11-001BU,Talla: 44,260.78,0.00
+__import__.product_template_cb_f11_001bu,CB-F11-001BU/46,7453099226746,Terno CB-F11-001BU,Talla: 46,260.78,0.00
+__import__.product_template_cb_f11_001bu,CB-F11-001BU/42,7453099226722,Terno CB-F11-001BU,Talla: 42,260.78,0.00
+__import__.product_template_pul19_09,PUL19-09-10,PUL19-09-10,ACCESORIO - 2019-09,Talla: 10,16.44,0.00
+__import__.product_template_acce19_09,ACCE19-09-8,ACCE19-09-8,ACCESORIO - 2019-09 (acce19_09),Talla: 8,15.57,0.00
+__import__.product_template_acce19_09,ACCE19-09-9,ACCE19-09-9,ACCESORIO - 2019-09 (acce19_09),Talla: 9,19.91,0.00
+__import__.product_template_acce19_09,ACCE19-09-6,ACCE19-09-6,ACCESORIO - 2019-09 (acce19_09),Ancho Corbata: 6 cm,24.26,0.00
+__import__.product_template_acce19_09,ACCE19-09-7,ACCE19-09-7,ACCESORIO - 2019-09 (acce19_09),Ancho Corbata: 7 cm,26.00,0.00
+__import__.product_template_cart_g_08,CART-G-08-19,CART-G-08-19,CARTERA GRANDE VARIOS MODELOS,Talla: 19,47.74,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/60,008-BLACK-BC-2/O60,Terno 008-BLACK-BC-2,Talla: 60,217.30,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/62,008-BLACK-BC-2/O62,Terno 008-BLACK-BC-2,Talla: 62,217.30,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/64,008-BLACK-BC-2/O64,Terno 008-BLACK-BC-2,Talla: 64,217.30,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/70,008-BLACK-BC-2/O70,Terno 008-BLACK-BC-2,Talla: 70,217.30,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/66,008-BLACK-BC-2/O66,Terno 008-BLACK-BC-2,Talla: 66,217.30,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/68,008-BLACK-BC-2/O68,Terno 008-BLACK-BC-2,Talla: 68,217.30,0.00
+__import__.product_template_pt_008_bg_black,PT-008-BG-BLACK/50,008B120220650,Pantalon PT-008-BG-BLACK,Talla: 50,56.43,0.00
+__import__.product_template_pt_008_bg_black,PT-008-BG-BLACK/46,008B120220646,Pantalon PT-008-BG-BLACK,Talla: 46,56.43,0.00
+__import__.product_template_pt_008_bg_black,PT-008-BG-BLACK/44,008B120220644,Pantalon PT-008-BG-BLACK,Talla: 44,56.43,0.00
+__import__.product_template_pt_008_bg_black,PT-008-BG-BLACK/52,008B120220652,Pantalon PT-008-BG-BLACK,Talla: 52,56.43,0.00
+__import__.product_template_pt_008_bg_black,PT-008-BG-BLACK/48,008B120220648,Pantalon PT-008-BG-BLACK,Talla: 48,56.43,0.00
+__import__.product_template_pt_008_bg_black,PT-008-BG-BLACK/54,008B120220654,Pantalon PT-008-BG-BLACK,Talla: 54,56.43,0.00
+__import__.product_template_17001_4bc_2,17001-4BC-2/54,1700142023035436,Terno 17001-4BC-2,Talla: 54,217.30,0.00
+__import__.product_template_17001_4bc_2,17001-4BC-2/52,1700142023035234,Terno 17001-4BC-2,Talla: 52,217.30,0.00
+__import__.product_template_17001_4bc_2,17001-4BC-2/50,1700142023035032,Terno 17001-4BC-2,Talla: 50,217.30,0.00
+__import__.product_template_17001_4bc_2,17001-4BC-2/48,1700142023034830,Terno 17001-4BC-2,Talla: 48,217.30,0.00
+__import__.product_template_17001_4bc_2,17001-4BC-2/58,1700142023035840,Terno 17001-4BC-2,Talla: 58,243.39,0.00
+__import__.product_template_17001_4bc_2,17001-4BC-2/56,1700142023035638,Terno 17001-4BC-2,Talla: 56,243.39,0.00
+__import__.product_template_17001_4bc_2,17001-4BC-2/46,1700142023034628,Terno 17001-4BC-2,Talla: 46,243.39,0.00
+__import__.product_template_17001_3bc_2,17001-3BC-2/56,1700132023035638,Terno 17001-3BC-2,Talla: 56,243.39,0.00
+__import__.product_template_17001_3bc_2,17001-3BC-2/58,1700132023035840,Terno 17001-3BC-2,Talla: 58,243.39,0.00
+__import__.product_template_17001_3bc_2,17001-3BC-2/50,1700132023035032,Terno 17001-3BC-2,Talla: 50,243.39,0.00
+__import__.product_template_17001_3bc_2,17001-3BC-2/46,1700132023034628,Terno 17001-3BC-2,Talla: 46,243.39,0.00
+__import__.product_template_17001_3bc_2,17001-3BC-2/48,1700132023034830,Terno 17001-3BC-2,Talla: 48,243.39,0.00
+__import__.product_template_17001_3bc_2,17001-3BC-2/52,1700132023035234,Terno 17001-3BC-2,Talla: 52,243.39,0.00
+__import__.product_template_17001_3bc_2,17001-3BC-2/54,1700132023035436,Terno 17001-3BC-2,Talla: 54,243.39,0.00
+__import__.product_template_px_nztd,PX-NZTD-30,PX-NZTD-30,LED DOWN LIGHT 30W 6000-6500K,Talla: 30,10.00,0.00
+__import__.product_template_pt_sd9806_25,PT-SD9806-25/32,PT-SD9806-25/O32,Pantalon PT-SD9806-25,Talla: 32,39.04,0.00
+__import__.product_template_pt_sd9806_25,PT-SD9806-25/34,PT-SD9806-25/O34,Pantalon PT-SD9806-25,Talla: 34,39.04,0.00
+__import__.product_template_pt_sd9806_25,PT-SD9806-25/36,PT-SD9806-25/O36,Pantalon PT-SD9806-25,Talla: 36,39.04,0.00
+__import__.product_template_pt_sd9806_25,PT-SD9806-25/38,PT-SD9806-25/O38,Pantalon PT-SD9806-25,Talla: 38,39.04,0.00
+__import__.product_template_pt_sd9806_25,PT-SD9806-25/40,PT-SD9806-25/O40,Pantalon PT-SD9806-25,Talla: 40,39.04,0.00
+__import__.product_template_pt_sy84085_1,PT-SY84085-1/32,PT-SY84085-1/O32,Pantalon PT-SY84085-1,Talla: 32,39.04,0.00
+__import__.product_template_pt_sy84085_1,PT-SY84085-1/34,PT-SY84085-1/O34,Pantalon PT-SY84085-1,Talla: 34,39.04,0.00
+__import__.product_template_pt_sy84085_1,PT-SY84085-1/36,PT-SY84085-1/O36,Pantalon PT-SY84085-1,Talla: 36,39.04,0.00
+__import__.product_template_pt_sy84085_1,PT-SY84085-1/40,PT-SY84085-1/O40,Pantalon PT-SY84085-1,Talla: 40,39.04,0.00
+__import__.product_template_pt_sy84085_1,PT-SY84085-1/38,PT-SY84085-1/O38,Pantalon PT-SY84085-1,Talla: 38,39.04,0.00
+__import__.product_template_pt_008_black_1,PT-008-BLACK-1/29,PT-008-BLACK-1/O29,Pantalon PT-008-BLACK-1,Talla: 29,39.04,0.00
+__import__.product_template_pt_008_black_1,PT-008-BLACK-1/30,PT-008-BLACK-1/O30,Pantalon PT-008-BLACK-1,Talla: 30,39.04,0.00
+__import__.product_template_pt_025_2,PT-025-2/32,PT-025-2/O32,Pantalon PT-025-2,Talla: 32,39.04,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/50,008-BLACK-BC-2/O50,Terno 008-BLACK-BC-2,Talla: 50,243.39,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/52,008-BLACK-BC-2/O52,Terno 008-BLACK-BC-2,Talla: 52,243.39,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/54,008-BLACK-BC-2/O54,Terno 008-BLACK-BC-2,Talla: 54,243.39,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/46,008-BLACK-BC-2/O46,Terno 008-BLACK-BC-2,Talla: 46,243.39,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/56,008-BLACK-BC-2/O56,Terno 008-BLACK-BC-2,Talla: 56,243.39,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/48,008-BLACK-BC-2/O48,Terno 008-BLACK-BC-2,Talla: 48,243.39,0.00
+__import__.product_template_008_black_bc_2,008-BLACK-BC-2/58,008-BLACK-BC-2/O58,Terno 008-BLACK-BC-2,Talla: 58,243.39,0.00
+__import__.product_template_025_2bc_2,025-2BC-2/48,025-2BC-2/O48,Terno 025-2BC-2,Talla: 48,165.13,0.00
+__import__.product_template_025_2bc_2,025-2BC-2/52,025-2BC-2/O52,Terno 025-2BC-2,Talla: 52,165.13,0.00
+__import__.product_template_025_2bc_2,025-2BC-2/54,025-2BC-2/O54,Terno 025-2BC-2,Talla: 54,165.13,0.00
+__import__.product_template_025_2bc_2,025-2BC-2/58,025-2BC-2/O58,Terno 025-2BC-2,Talla: 58,165.13,0.00
+__import__.product_template_025_2bc_2,025-2BC-2/46,025-2BC-2/O46,Terno 025-2BC-2,Talla: 46,165.13,0.00
+__import__.product_template_025_2bc_2,025-2BC-2/50,025-2BC-2/O50,Terno 025-2BC-2,Talla: 50,165.13,0.00
+__import__.product_template_025_2bc_2,025-2BC-2/56,025-2BC-2/O56,Terno 025-2BC-2,Talla: 56,217.30,0.00
+__import__.product_template_1611_11,1611-11/46,16111120230346,Leva 1611-11,Talla: 46,165.13,0.00
+__import__.product_template_1611_11,1611-11/50,16111120230350,Leva 1611-11,Talla: 50,165.13,0.00
+__import__.product_template_1611_11,1611-11/56,16111120230356,Leva 1611-11,Talla: 56,165.13,0.00
+__import__.product_template_1611_11,1611-11/48,16111120230348,Leva 1611-11,Talla: 48,165.13,0.00
+__import__.product_template_1611_11,1611-11/54,16111120230354,Leva 1611-11,Talla: 54,165.13,0.00
+__import__.product_template_1611_11,1611-11/52,16111120230352,Leva 1611-11,Talla: 52,165.13,0.00
+__import__.product_template_1611_11,1611-11/58,16111120230358,Leva 1611-11,Talla: 58,165.13,0.00
+__import__.product_template_1611_3bc_1,1611-3BC-1/48,16113B12023034830,Terno 1611-3BC-1,Talla: 48,260.78,0.00
+__import__.product_template_1611_3bc_1,1611-3BC-1/56,16113B12023035638,Terno 1611-3BC-1,Talla: 56,260.78,0.00
+__import__.product_template_1611_3bc_1,1611-3BC-1/58,16113B12023035840,Terno 1611-3BC-1,Talla: 58,260.78,0.00
+__import__.product_template_1611_3bc_1,1611-3BC-1/46,16113B12023034628,Terno 1611-3BC-1,Talla: 46,260.78,0.00
+__import__.product_template_1611_3bc_1,1611-3BC-1/50,16113B12023035032,Terno 1611-3BC-1,Talla: 50,260.78,0.00
+__import__.product_template_1611_3bc_1,1611-3BC-1/52,16113B12023035234,Terno 1611-3BC-1,Talla: 52,260.78,0.00
+__import__.product_template_1611_3bc_1,1611-3BC-1/54,16113B12023035436,Terno 1611-3BC-1,Talla: 54,260.78,0.00
+__import__.product_template_1611_2bc_2,1611-2BC-2/58,161122023035840,Terno 1611-2BC-2,Talla: 58,243.39,0.00
+__import__.product_template_1611_2bc_2,1611-2BC-2/56,161122023035638,Terno 1611-2BC-2,Talla: 56,243.39,0.00
+__import__.product_template_1611_2bc_2,1611-2BC-2/54,161122023035436,Terno 1611-2BC-2,Talla: 54,243.39,0.00
+__import__.product_template_1611_2bc_2,1611-2BC-2/52,161122023035234,Terno 1611-2BC-2,Talla: 52,243.39,0.00
+__import__.product_template_1611_2bc_2,1611-2BC-2/48,161122023034830,Terno 1611-2BC-2,Talla: 48,243.39,0.00
+__import__.product_template_1611_2bc_2,1611-2BC-2/50,161122023035032,Terno 1611-2BC-2,Talla: 50,243.39,0.00
+__import__.product_template_1611_2bc_2,1611-2BC-2/46,161122023034628,Terno 1611-2BC-2,Talla: 46,243.39,0.00
+__import__.product_template_1611_3bc_2,1611-3BC-2/56,161132023035638,Terno 1611-3BC-2,Talla: 56,217.30,0.00
+__import__.product_template_1611_3bc_2,1611-3BC-2/58,161132023035840,Terno 1611-3BC-2,Talla: 58,217.30,0.00
+__import__.product_template_1611_3bc_2,1611-3BC-2/54,161132023035436,Terno 1611-3BC-2,Talla: 54,217.30,0.00
+__import__.product_template_1611_3bc_2,1611-3BC-2/52,161132023035234,Terno 1611-3BC-2,Talla: 52,217.30,0.00
+__import__.product_template_1611_3bc_2,1611-3BC-2/50,161132023035032,Terno 1611-3BC-2,Talla: 50,217.30,0.00
+__import__.product_template_1611_3bc_2,1611-3BC-2/48,161132023034830,Terno 1611-3BC-2,Talla: 48,217.30,0.00
+__import__.product_template_1611_3bc_2,1611-3BC-2/46,161132023034628,Terno 1611-3BC-2,Talla: 46,217.30,0.00
+__import__.product_template_acce_12,ACCE-12-18,ACCE-12-18,BISUTERIA VARIOS MODELOS,Talla: 18,15.57,0.00
+__import__.product_template_cv_p01_155f_wh,CV-P01-155F-WH/S,CV-P01-155F-WH/OS,CAMISA M/L P/H WHITE 98% ALGODÓN 2% ELASTANO,Talla: S,47.74,0.00
+__import__.product_template_cv_p01_155f_wh,CV-P01-155F-WH/M,CV-P01-155F-WH/OM,CAMISA M/L P/H WHITE 98% ALGODÓN 2% ELASTANO,Talla: M,17.30,0.00
+__import__.product_template_cv_p01_155f_wh,CV-P01-155F-WH/L,CV-P01-155F-WH/OL,CAMISA M/L P/H WHITE 98% ALGODÓN 2% ELASTANO,Talla: L,47.74,0.00
+__import__.product_template_cv_p01_155f_wh,CV-P01-155F-WH/XL,CV-P01-155F-WH/OXL,CAMISA M/L P/H WHITE 98% ALGODÓN 2% ELASTANO,Talla: XL,47.74,0.00
+__import__.product_template_cv_p01_161f_gr,CV-P01-161F-GR/17,CV-P01-161F-GR/O17,Terno CV-P01-161F-GR,Talla: 17,17.30,0.00
+__import__.product_template_cv_p01_161f_gr,CV-P01-161F-GR/16,CV-P01-161F-GR/O16,Terno CV-P01-161F-GR,Talla: 16,17.30,0.00
+__import__.product_template_cv_p01_161f_gr,CV-P01-161F-GR/17.5,CV-P01-161F-GR/O17.5,Terno CV-P01-161F-GR,Talla: 17.5,17.30,0.00
+__import__.product_template_cv_p01_161f_gr,CV-P01-161F-GR/16.5,CV-P01-161F-GR/O16.5,Terno CV-P01-161F-GR,Talla: 16.5,17.30,0.00
+__import__.product_template_cv_p01_161f_gr,CV-P01-161F-GR/15,CV-P01-161F-GR/O15,Terno CV-P01-161F-GR,Talla: 15,17.30,0.00
+__import__.product_template_cv_p01_161f_gr,CV-P01-161F-GR/15.5,CV-P01-161F-GR/O15.5,Terno CV-P01-161F-GR,Talla: 15.5,17.30,0.00
+__import__.product_template_cv_p01h_149f_wh,CV-P01H-149F-WH/16,CV-P01H-149F-WH/O16,Terno CV-P01H-149F-WH,Talla: 16,17.30,0.00
+__import__.product_template_cv_p01h_149f_wh,CV-P01H-149F-WH/17.5,CV-P01H-149F-WH/O17.5,Terno CV-P01H-149F-WH,Talla: 17.5,17.30,0.00
+__import__.product_template_cv_p01h_149f_wh,CV-P01H-149F-WH/15,CV-P01H-149F-WH/O15,Terno CV-P01H-149F-WH,Talla: 15,47.74,0.00
+__import__.product_template_cv_p01h_149f_wh,CV-P01H-149F-WH/15.5,CV-P01H-149F-WH/O15.5,Terno CV-P01H-149F-WH,Talla: 15.5,17.30,0.00
+__import__.product_template_cv_p01h_149f_wh,CV-P01H-149F-WH/16.5,CV-P01H-149F-WH/O16.5,Terno CV-P01H-149F-WH,Talla: 16.5,17.30,0.00
+__import__.product_template_cv_p01h_149f_wh,CV-P01H-149F-WH/17,CV-P01H-149F-WH/O17,Terno CV-P01H-149F-WH,Talla: 17,17.30,0.00
+__import__.product_template_cv_p04_151f_wh,CV-P04-151F-WH/15,CV-P04-151F-WH/O15,Terno CV-P04-151F-WH,Talla: 15,17.30,0.00
+__import__.product_template_cv_p04_151f_wh,CV-P04-151F-WH/15.5,CV-P04-151F-WH/O15.5,Terno CV-P04-151F-WH,Talla: 15.5,47.74,0.00
+__import__.product_template_cv_p04_151f_wh,CV-P04-151F-WH/16.5,CV-P04-151F-WH/O16.5,Terno CV-P04-151F-WH,Talla: 16.5,47.74,0.00
+__import__.product_template_cv_p04_151f_wh,CV-P04-151F-WH/17.5,CV-P04-151F-WH/O17.5,Terno CV-P04-151F-WH,Talla: 17.5,47.74,0.00
+__import__.product_template_cv_p04_151f_wh,CV-P04-151F-WH/16,CV-P04-151F-WH/O16,Terno CV-P04-151F-WH,Talla: 16,17.30,0.00
+__import__.product_template_cv_p04_151f_wh,CV-P04-151F-WH/17,CV-P04-151F-WH/O17,Terno CV-P04-151F-WH,Talla: 17,47.74,0.00
+__import__.product_template_5cfw8713_126,5CFW8713-126/M,7453085645643,CAMISA P/CABALLERO M/L BRIGHT WHITE PERRY ELLIS,Talla: M,50.35,0.00
+__import__.product_template_5cfw8713_126,5CFW8713-126/L,7453085645650,CAMISA P/CABALLERO M/L BRIGHT WHITE PERRY ELLIS,Talla: L,50.35,0.00
+__import__.product_template_5cfw8713_126,5CFW8713-126/S,7453085645636,CAMISA P/CABALLERO M/L BRIGHT WHITE PERRY ELLIS,Talla: S,50.35,0.00
+__import__.product_template_5cfw8713_126,5CFW8713-126/XL,7453085645667,CAMISA P/CABALLERO M/L BRIGHT WHITE PERRY ELLIS,Talla: XL,50.35,0.00
+__import__.product_template_5cfw8711_499,5CFW8711-499/L,7453085645575,CAMISA P/CABALLERO M/L BABY BLUE PERRY ELLIS,Talla: L,50.35,0.00
+__import__.product_template_5cfw8711_499,5CFW8711-499/M,7453085645568,CAMISA P/CABALLERO M/L BABY BLUE PERRY ELLIS,Talla: M,50.35,0.00
+__import__.product_template_5cfw8711_499,5CFW8711-499/XL,7453085645582,CAMISA P/CABALLERO M/L BABY BLUE PERRY ELLIS,Talla: XL,50.35,0.00
+__import__.product_template_5cfw8711_499,5CFW8711-499/S,7453085645551,CAMISA P/CABALLERO M/L BABY BLUE PERRY ELLIS,Talla: S,50.35,0.00
+__import__.product_template_opbb0513_010_op,OPBB0513-010.OP/38,7453096726553,Terno OPBB0513-010.OP,Talla: 38,56.43,0.00
+__import__.product_template_opbb0513_010_op,OPBB0513-010.OP/36,7453096726546,Terno OPBB0513-010.OP,Talla: 36,56.43,0.00
+__import__.product_template_opbb0513_010_op,OPBB0513-010.OP/34,7453096726539,Terno OPBB0513-010.OP,Talla: 34,56.43,0.00
+__import__.product_template_opbb0513_010_op,OPBB0513-010.OP/31,7453096726508,Terno OPBB0513-010.OP,Talla: 31,56.43,0.00
+__import__.product_template_opbb0513_010_op,OPBB0513-010.OP/33,7453096726522,Terno OPBB0513-010.OP,Talla: 33,56.43,0.00
+__import__.product_template_opbb0513_010_op,OPBB0513-010.OP/32,7453096726515,Terno OPBB0513-010.OP,Talla: 32,56.43,0.00
+__import__.product_template_opbb0513_010_op,OPBB0513-010.OP/30,7453096726492,Terno OPBB0513-010.OP,Talla: 30,56.43,0.00
+__import__.product_template_ophm8017_413_op,OPHM8017-413.OP/38,740670325811,Terno OPHM8017-413.OP,Talla: 38,47.74,0.00
+__import__.product_template_ophm8017_413_op,OPHM8017-413.OP/34,740670325798,Terno OPHM8017-413.OP,Talla: 34,47.74,0.00
+__import__.product_template_ophm8017_413_op,OPHM8017-413.OP/31,740670325767,Terno OPHM8017-413.OP,Talla: 31,47.74,0.00
+__import__.product_template_ophm8017_413_op,OPHM8017-413.OP/36,740670325804,Terno OPHM8017-413.OP,Talla: 36,47.74,0.00
+__import__.product_template_ophm8017_413_op,OPHM8017-413.OP/33,740670325781,Terno OPHM8017-413.OP,Talla: 33,47.74,0.00
+__import__.product_template_ophm8017_413_op,OPHM8017-413.OP/32,740670325774,Terno OPHM8017-413.OP,Talla: 32,47.74,0.00
+__import__.product_template_ophm8017_413_op,OPHM8017-413.OP/30,740670325750,Terno OPHM8017-413.OP,Talla: 30,47.74,0.00
+__import__.product_template_bw4624_116,BW4624/116-7,BW4624/O116-7,Corbata BW4624/116,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_363,S299/363-7,S299/O363-7,Corbata S299/363,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_390,S299/390-7,S299/O390-7,Corbata S299/390,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_395,S299/395-7,S299/O395-7,Corbata S299/395,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_351,S299/351-7,S299/O351-7,Corbata S299/351,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_360,S299/360-7,S299/O360-7,Corbata S299/360,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_373,S299/373-7,S299/O373-7,Corbata S299/373,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_376,S299/376-7,S299/O376-7,Corbata S299/376,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_362,S299/362-7,S299/O362-7,Corbata S299/362,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_349,S299/349-7,S299/O349-7,Corbata S299/349,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_359,S299/359-7,S299/O359-7,Corbata S299/359,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11812_13,MF11812/13-7,MF11812/O13-7,Corbata MF11812/13,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11812_14,MF11812/14-7,MF11812/O14-7,Corbata MF11812/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_130,BW4624/130-7,BW4624/O130-7,Corbata BW4624/130,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11812_4,MF11812/4-7,MF11812/O4-7,Corbata MF11812/4,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11812_2,MF11812/2-7,MF11812/O2-7,Corbata MF11812/2,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11815_1,MF11815/1-7,MF11815/O1-7,Corbata MF11815/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11812_1,MF11812/1-7,MF11812/O1-7,Corbata MF11812/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11815_8,MF11815/8-7,MF11815/O8-7,Corbata MF11815/8,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11815_14,MF11815/14-7,MF11815/O14-7,Corbata MF11815/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11815_7,MF11815/7-7,MF11815/O7-7,Corbata MF11815/7,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_128,BW4624/128-7,BW4624/O128-7,Corbata BW4624/128,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_360,S299/360-6,S299/O360-6,Corbata S299/360,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_373,S299/373-6,S299/O373-6,Corbata S299/373,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_363,S299/363-6,S299/O363-6,Corbata S299/363,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_390,S299/390-6,S299/O390-6,Corbata S299/390,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_395,S299/395-6,S299/O395-6,Corbata S299/395,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_359,S299/359-6,S299/O359-6,Corbata S299/359,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_362,S299/362-6,S299/O362-6,Corbata S299/362,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_376,S299/376-6,S299/O376-6,Corbata S299/376,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11812_2,MF11812/2-6,MF11812/O2-6,Corbata MF11812/2,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11812_1,MF11812/1-6,MF11812/O1-6,Corbata MF11812/1,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_349,S299/349-6,S299/O349-6,Corbata S299/349,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_351,S299/351-6,S299/O351-6,Corbata S299/351,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11812_14,MF11812/14-6,MF11812/O14-6,Corbata MF11812/14,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11812_13,MF11812/13-6,MF11812/O13-6,Corbata MF11812/13,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_bw4624_130,BW4624/130-6,BW4624/O130-6,Corbata BW4624/130,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11812_4,MF11812/4-6,MF11812/O4-6,Corbata MF11812/4,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_bw4624_128,BW4624/128-6,BW4624/O128-6,Corbata BW4624/128,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_bw4624_116,BW4624/116-6,BW4624/O116-6,Corbata BW4624/116,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11815_14,MF11815/14-6,MF11815/O14-6,Corbata MF11815/14,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11815_8,MF11815/8-6,MF11815/O8-6,Corbata MF11815/8,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11815_7,MF11815/7-6,MF11815/O7-6,Corbata MF11815/7,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11815_1,MF11815/1-6,MF11815/O1-6,Corbata MF11815/1,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11891_14,MF11891/14-7,MF11891/O14-7,Corbata MF11891/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11891_9,MF11891/9-7,MF11891/O9-7,Corbata MF11891/9,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11891_1,MF11891/1-7,MF11891/O1-7,Corbata MF11891/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11891_14,MF11891/14-6,MF11891/O14-6,Corbata MF11891/14,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11890_14,MF11890/14-7,MF11890/O14-7,Corbata MF11890/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11890_1,MF11890/1-7,MF11890/O1-7,Corbata MF11890/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11891_9,MF11891/9-6,MF11891/O9-6,Corbata MF11891/9,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11891_1,MF11891/1-6,MF11891/O1-6,Corbata MF11891/1,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11890_14,MF11890/14-6,MF11890/O14-6,Corbata MF11890/14,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11890_1,MF11890/1-6,MF11890/O1-6,Corbata MF11890/1,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11887_5,MF11887/5-7,MF11887/O5-7,Corbata MF11887/5,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11887_14,MF11887/14-6,MF11887/O14-6,Corbata MF11887/14,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11887_14,MF11887/14-7,MF11887/O14-7,Corbata MF11887/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11887_5,MF11887/5-6,MF11887/O5-6,Corbata MF11887/5,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11866_15,MF11866/15-6,MF11866/O15-6,Corbata MF11866/15,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11866_14,MF11866/14-6,MF11866/O14-6,Corbata MF11866/14,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11866_15,MF11866/15-7,MF11866/O15-7,Corbata MF11866/15,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11866_7,MF11866/7-6,MF11866/O7-6,Corbata MF11866/7,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11866_1,MF11866/1-6,MF11866/O1-6,Corbata MF11866/1,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11866_1,MF11866/1-7,MF11866/O1-7,Corbata MF11866/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11866_14,MF11866/14-7,MF11866/O14-7,Corbata MF11866/14,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11866_7,MF11866/7-7,MF11866/O7-7,Corbata MF11866/7,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_11,P897/11-6,P897/O11-6,Corbata P897/11,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p897_11,P897/11-7,P897/O11-7,Corbata P897/11,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_p897_9,P897/9-6,P897/O9-6,Corbata P897/9,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_p897_9,P897/9-7,P897/O9-7,Corbata P897/9,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11868_11,MF11868/11-6,MF11868/O11-6,Corbata MF11868/11,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11868_11,MF11868/11-7,MF11868/O11-7,Corbata MF11868/11,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11868_9,MF11868/9-7,MF11868/O9-7,Corbata MF11868/9,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11868_2,MF11868/2-7,MF11868/O2-7,Corbata MF11868/2,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11868_6,MF11868/6-6,MF11868/O6-6,Corbata MF11868/6,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11868_1,MF11868/1-6,MF11868/O1-6,Corbata MF11868/1,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11868_6,MF11868/6-7,MF11868/O6-7,Corbata MF11868/6,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11868_2,MF11868/2-6,MF11868/O2-6,Corbata MF11868/2,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11868_9,MF11868/9-6,MF11868/O9-6,Corbata MF11868/9,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11868_7,MF11868/7-6,MF11868/O7-6,Corbata MF11868/7,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf11868_7,MF11868/7-7,MF11868/O7-7,Corbata MF11868/7,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf11868_1,MF11868/1-7,MF11868/O1-7,Corbata MF11868/1,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_rz543_black,RZ543-BLACK/9,RZ543-BLACK/O9,Terno RZ543-BLACK,Talla: 9,130.35,0.00
+__import__.product_template_rz543_black,RZ543-BLACK/8.5,RZ543-BLACK/O8.5,Terno RZ543-BLACK,Talla: 8.5,130.35,0.00
+__import__.product_template_rz543_black,RZ543-BLACK/8,RZ543-BLACK/O8,Terno RZ543-BLACK,Talla: 8,130.35,0.00
+__import__.product_template_rz543_black,RZ543-BLACK/7.5,RZ543-BLACK/O7.5,Terno RZ543-BLACK,Talla: 7.5,152.09,0.00
+__import__.product_template_rz543_black,RZ543-BLACK/7,RZ543-BLACK/O7,Terno RZ543-BLACK,Talla: 7,130.35,0.00
+__import__.product_template_rz538_red,RZ538-RED/9,RZ538-RED/O9,Terno RZ538-RED,Talla: 9,130.35,0.00
+__import__.product_template_rz538_red,RZ538-RED/8.5,RZ538-RED/O8.5,Terno RZ538-RED,Talla: 8.5,130.35,0.00
+__import__.product_template_rz538_red,RZ538-RED/7.5,RZ538-RED/O7.5,Terno RZ538-RED,Talla: 7.5,152.09,0.00
+__import__.product_template_rz538_red,RZ538-RED/7,RZ538-RED/O7,Terno RZ538-RED,Talla: 7,152.09,0.00
+__import__.product_template_rz538_red,RZ538-RED/8,RZ538-RED/O8,Terno RZ538-RED,Talla: 8,152.09,0.00
+__import__.product_template_rz552_dk_grey,RZ552-DK.GREY/9,RZ552-DK.GREY/O9,Terno RZ552-DK.GREY,Talla: 9,130.35,0.00
+__import__.product_template_rz552_dk_grey,RZ552-DK.GREY/8.5,RZ552-DK.GREY/O8.5,Terno RZ552-DK.GREY,Talla: 8.5,130.35,0.00
+__import__.product_template_rz552_dk_grey,RZ552-DK.GREY/8,RZ552-DK.GREY/O8,Terno RZ552-DK.GREY,Talla: 8,152.09,0.00
+__import__.product_template_rz552_dk_grey,RZ552-DK.GREY/7.5,RZ552-DK.GREY/O7.5,Terno RZ552-DK.GREY,Talla: 7.5,152.09,0.00
+__import__.product_template_rz552_dk_grey,RZ552-DK.GREY/7,RZ552-DK.GREY/O7,Terno RZ552-DK.GREY,Talla: 7,130.35,0.00
+__import__.product_template_rz714_blk_navy,RZ714-BLK-NAVY/9,RZ714-BLK-NAVY/O9,Terno RZ714-BLK-NAVY,Talla: 9,152.09,0.00
+__import__.product_template_rz714_blk_navy,RZ714-BLK-NAVY/8.5,RZ714-BLK-NAVY/O8.5,Terno RZ714-BLK-NAVY,Talla: 8.5,152.09,0.00
+__import__.product_template_rz714_blk_navy,RZ714-BLK-NAVY/8,RZ714-BLK-NAVY/O8,Terno RZ714-BLK-NAVY,Talla: 8,152.09,0.00
+__import__.product_template_rz714_blk_navy,RZ714-BLK-NAVY/7.5,RZ714-BLK-NAVY/O7.5,Terno RZ714-BLK-NAVY,Talla: 7.5,152.09,0.00
+__import__.product_template_rz714_blk_navy,RZ714-BLK-NAVY/7,RZ714-BLK-NAVY/O7,Terno RZ714-BLK-NAVY,Talla: 7,152.09,0.00
+__import__.product_template_rz742_black,RZ742-BLACK/7,RZ742-BLACK/O7,Terno RZ742-BLACK,Talla: 7,130.35,0.00
+__import__.product_template_rz742_black,RZ742-BLACK/7.5,RZ742-BLACK/O7.5,Terno RZ742-BLACK,Talla: 7.5,152.09,0.00
+__import__.product_template_rz742_black,RZ742-BLACK/8,RZ742-BLACK/O8,Terno RZ742-BLACK,Talla: 8,130.35,0.00
+__import__.product_template_rz742_black,RZ742-BLACK/8.5,RZ742-BLACK/O8.5,Terno RZ742-BLACK,Talla: 8.5,130.35,0.00
+__import__.product_template_rz742_black,RZ742-BLACK/9,RZ742-BLACK/O9,Terno RZ742-BLACK,Talla: 9,130.35,0.00
+__import__.product_template_dim_driver,DIM-DRIVER/18,DIM-DRIVER/18,Terno DIM-DRIVER,Talla: 18,8.00,0.00
+__import__.product_template_dim_driver,DIM-DRIVER/7,DIM-DRIVER/7,Terno DIM-DRIVER,Talla: 7,1.00,0.00
+__import__.product_template_w028_f9,W028-F9-6,W028-F9-6,Corbata W028-F9,Ancho Corbata: 6 cm,17.77,0.00
+__import__.product_template_w028_f9,W028-F9-8,W028-F9-8,Corbata W028-F9,Talla: 8,17.77,0.00
+__import__.product_template_xlh1639_11_apricot,XLH1639-11/APRICOT-10,XLH1639-11/OAPROT-10,ZAPATOS OBSENA,Talla: 10,13.38,0.00
+__import__.product_template_xlh1639_11_apricot,XLH1639-11/APRICOT-6,XLH1639-11/OAPROT-6,ZAPATOS OBSENA,Ancho Corbata: 6 cm,13.38,0.00
+__import__.product_template_xlh1639_11_apricot,XLH1639-11/APRICOT-7,XLH1639-11/OAPROT-7,ZAPATOS OBSENA,Ancho Corbata: 7 cm,13.38,0.00
+__import__.product_template_xlh1639_11_apricot,XLH1639-11/APRICOT-8,XLH1639-11/OAPROT-8,ZAPATOS OBSENA,Talla: 8,13.38,0.00
+__import__.product_template_xlh1639_11_apricot,XLH1639-11/APRICOT-9,XLH1639-11/OAPROT-9,ZAPATOS OBSENA,Talla: 9,13.38,0.00
+__import__.product_template_xlh1639_11_black,XLH1639-11/BLACK-6,XLH1639-11/OBLACK-6,Corbata XLH1639-11/BLACK,Ancho Corbata: 6 cm,29.38,0.00
+__import__.product_template_xlh1639_11_brown,XLH1639-11/BROWN-36,XLH1639-11/OBROWN-36,ZAPATOS OBSENA (xlh1639_11_brown),Talla: 36,13.38,0.00
+__import__.product_template_xlh1639_11_brown,XLH1639-11/BROWN-38,XLH1639-11/OBROWN-38,ZAPATOS OBSENA (xlh1639_11_brown),Talla: 38,12.96,0.00
+__import__.product_template_xlh1639_11_brown,XLH1639-11/BROWN-40,XLH1639-11/OBROWN-40,ZAPATOS OBSENA (xlh1639_11_brown),Talla: 40,13.38,0.00
+__import__.product_template_w028_62,W028-62-10,W028-62-10,PANTALON BRUNO CASSINI (MUJER),Talla: 10,17.77,0.00
+__import__.product_template_w028_62,W028-62-12,W028-62-12,PANTALON BRUNO CASSINI (MUJER),Talla: 12,17.30,0.00
+__import__.product_template_w028_62,W028-62-14,W028-62-14,PANTALON BRUNO CASSINI (MUJER),Talla: 14,17.77,0.00
+__import__.product_template_w028_62,W028-62-16,W028-62-16,PANTALON BRUNO CASSINI (MUJER),Talla: 16,17.77,0.00
+__import__.product_template_w028_62,W028-62-6,W028-62-6,PANTALON BRUNO CASSINI (MUJER),Ancho Corbata: 6 cm,17.77,0.00
+__import__.product_template_w028_62,W028-62-8,W028-62-8,PANTALON BRUNO CASSINI (MUJER),Talla: 8,17.77,0.00
+__import__.product_template_w028_65,W028-65-10,W028-65-10,PANTALON BRUNO CASSINI (MUJER) (w028_65),Talla: 10,17.30,0.00
+__import__.product_template_w028_65,W028-65-12,W028-65-12,PANTALON BRUNO CASSINI (MUJER) (w028_65),Talla: 12,17.77,0.00
+__import__.product_template_w028_65,W028-65-14,W028-65-14,PANTALON BRUNO CASSINI (MUJER) (w028_65),Talla: 14,17.77,0.00
+__import__.product_template_w028_65,W028-65-16,W028-65-16,PANTALON BRUNO CASSINI (MUJER) (w028_65),Talla: 16,17.77,0.00
+__import__.product_template_w028_65,W028-65-8,W028-65-8,PANTALON BRUNO CASSINI (MUJER) (w028_65),Talla: 8,17.77,0.00
+__import__.product_template_w028_75,W028-75-10,W028-75-10,PANTALON BRUNO CASSINI (MUJER) (w028_75),Talla: 10,17.77,0.00
+__import__.product_template_w028_75,W028-75-12,W028-75-12,PANTALON BRUNO CASSINI (MUJER) (w028_75),Talla: 12,17.30,0.00
+__import__.product_template_w028_75,W028-75-14,W028-75-14,PANTALON BRUNO CASSINI (MUJER) (w028_75),Talla: 14,17.77,0.00
+__import__.product_template_w028_75,W028-75-16,W028-75-16,PANTALON BRUNO CASSINI (MUJER) (w028_75),Talla: 16,17.77,0.00
+__import__.product_template_w028_d15,W028-D15-10,W028-D15-10,PANTALON BRUNO CASSINI (MUJER) (w028_d15),Talla: 10,17.30,0.00
+__import__.product_template_w028_d15,W028-D15-12,W028-D15-12,PANTALON BRUNO CASSINI (MUJER) (w028_d15),Talla: 12,17.30,0.00
+__import__.product_template_w028_d15,W028-D15-14,W028-D15-14,PANTALON BRUNO CASSINI (MUJER) (w028_d15),Talla: 14,17.77,0.00
+__import__.product_template_w028_d15,W028-D15-16,W028-D15-16,PANTALON BRUNO CASSINI (MUJER) (w028_d15),Talla: 16,39.91,0.00
+__import__.product_template_w028_d15,W028-D15-8,W028-D15-8,PANTALON BRUNO CASSINI (MUJER) (w028_d15),Talla: 8,17.77,0.00
+__import__.product_template_w028_dgrey,W028-DGREY-10,W028-DGREY-10,PANTALON BRUNO CASSINI (MUJER) (w028_dgrey),Talla: 10,17.30,0.00
+__import__.product_template_w028_dgrey,W028-DGREY-12,W028-DGREY-12,PANTALON BRUNO CASSINI (MUJER) (w028_dgrey),Talla: 12,17.30,0.00
+__import__.product_template_w028_dgrey,W028-DGREY-14,W028-DGREY-14,PANTALON BRUNO CASSINI (MUJER) (w028_dgrey),Talla: 14,17.77,0.00
+__import__.product_template_w028_dgrey,W028-DGREY-16,W028-DGREY-16,PANTALON BRUNO CASSINI (MUJER) (w028_dgrey),Talla: 16,17.77,0.00
+__import__.product_template_w028_f5,W028-F5-10,W028-F5-10,PANTALON BRUNO CASSINI (MUJER) (w028_f5),Talla: 10,17.77,0.00
+__import__.product_template_w028_f5,W028-F5-12,W028-F5-12,PANTALON BRUNO CASSINI (MUJER) (w028_f5),Talla: 12,17.30,0.00
+__import__.product_template_w028_f5,W028-F5-14,W028-F5-14,PANTALON BRUNO CASSINI (MUJER) (w028_f5),Talla: 14,17.77,0.00
+__import__.product_template_w028_f5,W028-F5-16,W028-F5-16,PANTALON BRUNO CASSINI (MUJER) (w028_f5),Talla: 16,17.77,0.00
+__import__.product_template_w028_f5,W028-F5-8,W028-F5-8,PANTALON BRUNO CASSINI (MUJER) (w028_f5),Talla: 8,17.77,0.00
+__import__.product_template_w028_f9,W028-F9-10,W028-F9-10,Corbata W028-F9,Talla: 10,17.77,0.00
+__import__.product_template_w028_f9,W028-F9-12,W028-F9-12,Corbata W028-F9,Talla: 12,17.77,0.00
+__import__.product_template_w028_f9,W028-F9-14,W028-F9-14,Corbata W028-F9,Talla: 14,17.77,0.00
+__import__.product_template_w028_f9,W028-F9-16,W028-F9-16,Corbata W028-F9,Talla: 16,17.77,0.00
+__import__.product_template_ty04_2bc_2,TY04-2BC-2/46,TY04-2BC-2/O46,Terno TY04-2BC-2,Talla: 46,78.17,0.00
+__import__.product_template_ty04_2bc_2,TY04-2BC-2/48,TY04-2BC-2/O48,Terno TY04-2BC-2,Talla: 48,78.17,0.00
+__import__.product_template_ty04_2bc_2,TY04-2BC-2/50,TY04-2BC-2/O50,Terno TY04-2BC-2,Talla: 50,217.30,0.00
+__import__.product_template_sabi_fiesta,SABI-FIESTA-38,SABI-FIESTA-38,M. CARTERA DE FIESTA VARIOS MD,Talla: 38,28.97,0.00
+__import__.product_template_s299_306,S299/306-7,S299/O306-7,Corbata S299/306,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_310,S299/310-6,S299/O310-6,Corbata S299/310,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_310,S299/310-7,S299/O310-7,Corbata S299/310,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_321,S299/321-6,S299/O321-6,Corbata S299/321,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_321,S299/321-7,S299/O321-7,Corbata S299/321,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_322,S299/322-7,S299/O322-7,Corbata S299/322,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_324,S299/324-6,S299/O324-6,Corbata S299/324,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_324,S299/324-7,S299/O324-7,Corbata S299/324,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_325,S299/325-6,S299/O325-6,Corbata S299/325,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_325,S299/325-7,S299/O325-7,Corbata S299/325,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_330,S299/330-6,S299/O330-6,Corbata S299/330,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_330,S299/330-7,S299/O330-7,Corbata S299/330,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_332,S299/332-6,S299/O332-6,Corbata S299/332,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_332,S299/332-7,S299/O332-7,Corbata S299/332,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_333,S299/333-6,S299/O333-6,Corbata S299/333,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_333,S299/333-7,S299/O333-7,Corbata S299/333,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_334,S299/334-6,S299/O334-6,Corbata S299/334,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_334,S299/334-7,S299/O334-7,Corbata S299/334,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_335,S299/335-6,S299/O335-6,Corbata S299/335,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_335,S299/335-7,S299/O335-7,Corbata S299/335,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_339,S299/339-6,S299/O339-6,Corbata S299/339,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_339,S299/339-7,S299/O339-7,Corbata S299/339,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_341,S299/341-6,S299/O341-6,Corbata S299/341,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_341,S299/341-7,S299/O341-7,Corbata S299/341,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_345,S299/345-6,S299/O345-6,Corbata S299/345,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_345,S299/345-7,S299/O345-7,Corbata S299/345,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_301,S299/301-7,S299/O301-7,Corbata S299/301,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_302,S299/302-6,S299/O302-6,Corbata S299/302,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_302,S299/302-7,S299/O302-7,Corbata S299/302,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_303,S299/303-7,S299/O303-7,Corbata S299/303,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_304,S299/304-6,S299/O304-6,Corbata S299/304,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_304,S299/304-7,S299/O304-7,Corbata S299/304,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_305,S299/305-6,S299/O305-6,Corbata S299/305,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_s299_305,S299/305-7,S299/O305-7,Corbata S299/305,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_s299_306,S299/306-6,S299/O306-6,Corbata S299/306,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_pv,PV-42,PV-42,PANTALONETA DE NINO SOLEI,Talla: 42,23.61,0.00
+__import__.product_template_pt6158_61,PT6158-61/32,PT6158-61/O32,Terno PT6158-61,Talla: 32,21.65,0.00
+__import__.product_template_pt6158_61,PT6158-61/34,PT6158-61/O34,Terno PT6158-61,Talla: 34,21.65,0.00
+__import__.product_template_pt6158_61,PT6158-61/36,PT6158-61/O36,Terno PT6158-61,Talla: 36,21.65,0.00
+__import__.product_template_pt6158_61,PT6158-61/38,PT6158-61/O38,Terno PT6158-61,Talla: 38,21.65,0.00
+__import__.product_template_pt6158_61,PT6158-61/40,PT6158-61/O40,Terno PT6158-61,Talla: 40,21.65,0.00
+__import__.product_template_pt6158_61,PT6158-61/42,PT6158-61/O42,Terno PT6158-61,Talla: 42,21.65,0.00
+__import__.product_template_pt6158_63,PT6158-63/34,PT6158-63/O34,Terno PT6158-63,Talla: 34,47.74,0.00
+__import__.product_template_pt6158_63,PT6158-63/36,PT6158-63/O36,Terno PT6158-63,Talla: 36,47.74,0.00
+__import__.product_template_pt6158_63,PT6158-63/38,PT6158-63/O38,Terno PT6158-63,Talla: 38,47.74,0.00
+__import__.product_template_pt6158_63,PT6158-63/40,PT6158-63/O40,Terno PT6158-63,Talla: 40,47.74,0.00
+__import__.product_template_pt6158_63,PT6158-63/42,PT6158-63/O42,Terno PT6158-63,Talla: 42,47.74,0.00
+__import__.product_template_pt_rs3688_blk,PT-RS3688-BLK/L,PT-RS3688-BLK/OL,PANTALON DE TERNO P/DAMA BRUNO CASSINI,Talla: L,39.91,0.00
+__import__.product_template_pt_rs3688_blk_m,PT-RS3688-BLK/M-L,PT-RS3688-BLK/OM-L,PANTALON DE TERNO P/DAMA BRUNO CASSINI (pt_rs3688_blk_m),Talla: L,40.09,0.00
+__import__.product_template_pt_rs3688_blk,PT-RS3688-BLK/S,PT-RS3688-BLK/OS,PANTALON DE TERNO P/DAMA BRUNO CASSINI,Talla: S,39.91,0.00
+__import__.product_template_pt_rs3688_blk,PT-RS3688-BLK/XL,PT-RS3688-BLK/OXL,PANTALON DE TERNO P/DAMA BRUNO CASSINI,Talla: XL,39.91,0.00
+__import__.product_template_pt_rs3688_blk,PT-RS3688-BLK/XS,PT-RS3688-BLK/OXS,PANTALON DE TERNO P/DAMA BRUNO CASSINI,Talla: XS,39.91,0.00
+__import__.product_template_pt_008_1,PT-008-1/29,PT-008-1/O29,Pantalon PT-008-1,Talla: 29,39.04,0.00
+__import__.product_template_pt_008_1,PT-008-1/30,PT-008-1/O30,Pantalon PT-008-1,Talla: 30,39.04,0.00
+__import__.product_template_pt_008_1,PT-008-1/32,PT-008-1/O32,Pantalon PT-008-1,Talla: 32,39.04,0.00
+__import__.product_template_pt_008_1,PT-008-1/34,PT-008-1/O34,Pantalon PT-008-1,Talla: 34,39.04,0.00
+__import__.product_template_pt_008_1,PT-008-1/36,PT-008-1/O36,Pantalon PT-008-1,Talla: 36,39.04,0.00
+__import__.product_template_pt_008_1,PT-008-1/38,PT-008-1/O38,Pantalon PT-008-1,Talla: 38,39.04,0.00
+__import__.product_template_pt_008_1,PT-008-1/40,PT-008-1/O40,Pantalon PT-008-1,Talla: 40,39.04,0.00
+__import__.product_template_pt_008_1,PT-008-1/42,PT-008-1/O42,Pantalon PT-008-1,Talla: 42,47.74,0.00
+__import__.product_template_pt_008_1,PT-008-1/44,PT-008-1/O44,Pantalon PT-008-1,Talla: 44,47.74,0.00
+__import__.product_template_pt_008_1,PT-008-1/46,PT-008-1/O46,Pantalon PT-008-1,Talla: 46,47.74,0.00
+__import__.product_template_pt_008_1,PT-008-1/48,PT-008-1/O48,Pantalon PT-008-1,Talla: 48,47.74,0.00
+__import__.product_template_opwf4121_541_op,OPWF4121-541.OP-M,OPWF4121-541.OP-M,CAMISA PENGUING,Talla: M,78.17,0.00
+__import__.product_template_opwf4121_541_op,OPWF4121-541.OP-S,OPWF4121-541.OP-S,CAMISA PENGUING,Talla: S,78.17,0.00
+__import__.product_template_opwf7028_118_op,OPWF7028-118.OP/L,740670134031,CAMISA M/L P/H 100% ALGODON BRIGHT WHITE,Talla: L,65.13,0.00
+__import__.product_template_opwf7028_118_op,OPWF7028-118.OP/M,740670134024,CAMISA M/L P/H 100% ALGODON BRIGHT WHITE,Talla: M,65.13,0.00
+__import__.product_template_opwf7028_118_op,OPWF7028-118.OP/S,740670134017,CAMISA M/L P/H 100% ALGODON BRIGHT WHITE,Talla: S,65.13,0.00
+__import__.product_template_opwf7028_118_op,OPWF7028-118.OP/XL,740670134048,CAMISA M/L P/H 100% ALGODON BRIGHT WHITE,Talla: XL,65.13,0.00
+__import__.product_template_opwf7028_118_op,OPWF7028-118.OP/XS,740670134000,CAMISA M/L P/H 100% ALGODON BRIGHT WHITE,Talla: XS,65.13,0.00
+__import__.product_template_ophs5077_358_op,OPHS5077-358.OP-30,049952768859,BERMUDA P/H 100% ALGODON,Talla: 30,47.74,0.00
+__import__.product_template_ophs5077_358_op,OPHS5077-358.OP-32,049952768873,BERMUDA P/H 100% ALGODON,Talla: 32,47.74,0.00
+__import__.product_template_ophs5077_468_op,OPHS5077-468.OP-31,049952769139,BERMUDA P/H 100% ALGODON (ophs5077_468_op),Talla: 31,47.74,0.00
+__import__.product_template_ophs5077_468_op,OPHS5077-468.OP-32,049952769146,BERMUDA P/H 100% ALGODON (ophs5077_468_op),Talla: 32,47.74,0.00
+__import__.product_template_ophs5077_468_op,OPHS5077-468.OP-34,049952769160,BERMUDA P/H 100% ALGODON (ophs5077_468_op),Talla: 34,47.74,0.00
+__import__.product_template_opbf6080_op,OPBF6080.OP/38,OPBF6080.OP/O38,Terno OPBF6080.OP,Talla: 38,69.55,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/28,740670136479,Terno OPBF7027-031.OP,Talla: 28,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/29,740670136486,Terno OPBF7027-031.OP,Talla: 29,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/30,740670136493,Terno OPBF7027-031.OP,Talla: 30,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/31,740670136509,Terno OPBF7027-031.OP,Talla: 31,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/32,740670136516,Terno OPBF7027-031.OP,Talla: 32,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/33,740670136523,Terno OPBF7027-031.OP,Talla: 33,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/34,740670136530,Terno OPBF7027-031.OP,Talla: 34,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/36,740670136547,Terno OPBF7027-031.OP,Talla: 36,56.43,0.00
+__import__.product_template_opbf7027_031_op,OPBF7027-031.OP/38,740670136554,Terno OPBF7027-031.OP,Talla: 38,56.43,0.00
+__import__.product_template_nodim_driver,NODIM-DRIVER/7,NODIM-DRIVER/7,Terno NODIM-DRIVER,Talla: 7,1.00,0.00
+__import__.product_template_opbf6080_op,OPBF6080.OP/30,OPBF6080.OP/O30,Terno OPBF6080.OP,Talla: 30,69.55,0.00
+__import__.product_template_opbf6080_op,OPBF6080.OP/31,OPBF6080.OP/O31,Terno OPBF6080.OP,Talla: 31,69.55,0.00
+__import__.product_template_opbf6080_op,OPBF6080.OP/32,OPBF6080.OP/O32,Terno OPBF6080.OP,Talla: 32,69.55,0.00
+__import__.product_template_opbf6080_op,OPBF6080.OP/33,OPBF6080.OP/O33,Terno OPBF6080.OP,Talla: 33,69.55,0.00
+__import__.product_template_opbf6080_op,OPBF6080.OP/34,OPBF6080.OP/O34,Terno OPBF6080.OP,Talla: 34,39.04,0.00
+__import__.product_template_opbf6080_op,OPBF6080.OP/36,OPBF6080.OP/O36,Terno OPBF6080.OP,Talla: 36,69.55,0.00
+__import__.product_template_mf3870_125,MF3870/125-6,MF3870/O125-6,Corbata MF3870/125,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_125,MF3870/125-7,MF3870/O125-7,Corbata MF3870/125,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_127,MF3870/127-6,MF3870/O127-6,Corbata MF3870/127,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_127,MF3870/127-7,MF3870/O127-7,Corbata MF3870/127,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_43,MF3870/43-6,MF3870/O43-6,Corbata MF3870/43,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_43,MF3870/43-7,MF3870/O43-7,Corbata MF3870/43,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_46,MF3870/46-6,MF3870/O46-6,Corbata MF3870/46,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_46,MF3870/46-7,MF3870/O46-7,Corbata MF3870/46,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_50,MF3870/50-6,MF3870/O50-6,Corbata MF3870/50,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_50,MF3870/50-7,MF3870/O50-7,Corbata MF3870/50,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_69,MF3870/69-6,MF3870/O69-6,Corbata MF3870/69,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_69,MF3870/69-7,MF3870/O69-7,Corbata MF3870/69,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_84,MF3870/84-6,MF3870/O84-6,Corbata MF3870/84,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_84,MF3870/84-7,MF3870/O84-7,Corbata MF3870/84,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_97,MF3870/97-6,MF3870/O97-6,Corbata MF3870/97,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_97,MF3870/97-7,MF3870/O97-7,Corbata MF3870/97,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_mf3870_98,MF3870/98-6,MF3870/O98-6,Corbata MF3870/98,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_mf3870_98,MF3870/98-7,MF3870/O98-7,Corbata MF3870/98,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_m_03,M-03-7,M-03-7,Corbata M-03,Ancho Corbata: 7 cm,6.70,0.00
+__import__.product_template_m_03,M-03-8,M-03-8,Corbata M-03,Talla: 8,7.65,0.00
+__import__.product_template_magi,MAGI-32,MAGI-32,ARETES DE CRISTAL,Talla: 32,8.70,0.00
+__import__.product_template_magi,MAGI-38,MAGI-38,ARETES DE CRISTAL,Talla: 38,15.65,0.00
+__import__.product_template_magi,MAGI-42,MAGI-42,ARETES DE CRISTAL,Talla: 42,15.65,0.00
+__import__.product_template_lv_101_06,LV-101-06/46,LV-101-06/O46,Leva LV-101-06,Talla: 46,78.17,0.00
+__import__.product_template_lv_101_06,LV-101-06/48,LV-101-06/O48,Leva LV-101-06,Talla: 48,165.13,0.00
+__import__.product_template_lv_101_06,LV-101-06/50,LV-101-06/O50,Leva LV-101-06,Talla: 50,165.13,0.00
+__import__.product_template_m_03,M-03-10,M-03-10,Corbata M-03,Talla: 10,9.56,0.00
+__import__.product_template_m_03,M-03-12,M-03-12,Corbata M-03,Talla: 12,11.48,0.00
+__import__.product_template_lamp,LAMP-20,LAMP-20,LAMPARA DE PARED LED 20X10X8 - 3000K,Talla: 20,131.74,0.00
+__import__.product_template_lamp,LAMP-30,LAMP-30,LAMPARA DE PARED LED 20X10X8 - 3000K,Talla: 30,137.68,0.00
+__import__.product_template_led_driver,LED-DRIVER/18,LED-DRIVER/18,Terno LED-DRIVER,Talla: 18,3.48,0.00
+__import__.product_template_led_driver,LED-DRIVER/30,LED-DRIVER/30,Terno LED-DRIVER,Talla: 30,1.00,0.00
+__import__.product_template_led_driver,LED-DRIVER/40,LED-DRIVER/40,Terno LED-DRIVER,Talla: 40,8.58,0.00
+__import__.product_template_k822_3,K822-3/14.5,K822-3/O14.5,Terno K822-3,Talla: 14.5,17.30,0.00
+__import__.product_template_k822_3,K822-3/15,K822-3/O15,Terno K822-3,Talla: 15,17.30,0.00
+__import__.product_template_k822_3,K822-3/15.5,K822-3/O15.5,Terno K822-3,Talla: 15.5,17.30,0.00
+__import__.product_template_k822_3,K822-3/16,K822-3/O16,Terno K822-3,Talla: 16,17.30,0.00
+__import__.product_template_k822_3,K822-3/16.5,K822-3/O16.5,Terno K822-3,Talla: 16.5,30.35,0.00
+__import__.product_template_k822_3,K822-3/17,K822-3/O17,Terno K822-3,Talla: 17,30.35,0.00
+__import__.product_template_k822_16dp,K822-16DP/14.5,K822-16DP/O14.5,Terno K822-16DP,Talla: 14.5,47.74,0.00
+__import__.product_template_k822_16dp,K822-16DP/15,K822-16DP/O15,Terno K822-16DP,Talla: 15,47.74,0.00
+__import__.product_template_k822_16dp,K822-16DP/15.5,K822-16DP/O15.5,Terno K822-16DP,Talla: 15.5,47.74,0.00
+__import__.product_template_k822_16dp,K822-16DP/16,K822-16DP/O16,Terno K822-16DP,Talla: 16,47.74,0.00
+__import__.product_template_k822_16dp,K822-16DP/16.5,K822-16DP/O16.5,Terno K822-16DP,Talla: 16.5,47.74,0.00
+__import__.product_template_k822_16dp,K822-16DP/17,K822-16DP/O17,Terno K822-16DP,Talla: 17,47.74,0.00
+__import__.product_template_jones_h,JONES-H/10,JONES-H/O10,Terno JONES-H,Talla: 10,31.16,0.00
+__import__.product_template_jones_h,JONES-H/7,JONES-H/O8,Terno JONES-H,Talla: 7,31.16,0.00
+__import__.product_template_jones_h,JONES-H/9,JONES-H/O9,Terno JONES-H,Talla: 9,31.16,0.00
+__import__.product_template_j11063_dark_blue,J11063/DARK BLUE-28,J11063/ODARK BLUE-28,DARK BLUE,Talla: 28,12.90,0.00
+__import__.product_template_j11063_dark_blue,J11063/DARK BLUE-29,J11063/ODARK BLUE-29,DARK BLUE,Talla: 29,12.90,0.00
+__import__.product_template_j14015ac_dark_blue,J14015AC/DARK BLUE-28,J14015AC/ODARKBL-28,DARK BLUE (j14015ac_dark_blue),Talla: 28,13.30,0.00
+__import__.product_template_j14015ac_dark_blue,J14015AC/DARK BLUE-29,J14015AC/ODARKBLUE-29,DARK BLUE (j14015ac_dark_blue),Talla: 29,13.30,0.00
+__import__.product_template_j14015ac_dark_blue,J14015AC/DARK BLUE-30,J14015AC/ODARKBLUE-30,DARK BLUE (j14015ac_dark_blue),Talla: 30,13.30,0.00
+__import__.product_template_j14015ac_stone_blue,J14015AC/STONE BLUE-28,J14015AC/OSTOBLUE-28,STONE BLUE,Talla: 28,12.90,0.00
+__import__.product_template_j14015ac_stone_blue,J14015AC/STONE BLUE-29,J14015AC/OSTOBLUE-29,STONE BLUE,Talla: 29,12.90,0.00
+__import__.product_template_j14015ac_stone_blue,J14015AC/STONE BLUE-30,J14015AC/OSTOBLUE-30,STONE BLUE,Talla: 30,12.90,0.00
+__import__.product_template_j,J-32,J-32,JUMPER,Talla: 32,37.37,0.00
+__import__.product_template_j07034fc_dark_blk_2,J07034FC/DARK BLK-2-28,J07034FC/ODKBLK-2-28,PANTALON MUJER,Talla: 28,7.05,0.00
+__import__.product_template_j07034fc_dark_blk_2,J07034FC/DARK BLK-2-29,J07034FC/ODKBLK-2-29,PANTALON MUJER,Talla: 29,7.05,0.00
+__import__.product_template_j07034fc_dark_blk_2,J07034FC/DARK BLK-2-30,J07034FC/ODKBLK-2-30,PANTALON MUJER,Talla: 30,7.05,0.00
+__import__.product_template_j07034fc_stone_blk,J07034FC/STONE BLK-28,J07034FC/OSTOBLK-28,STONE BLACK,Talla: 28,12.90,0.00
+__import__.product_template_j07034fc_stone_blk,J07034FC/STONE BLK-29,J07034FC/OSTOBLK-29,STONE BLACK,Talla: 29,12.90,0.00
+__import__.product_template_j11063_bleach_blue,J11063/BLEACH BLUE-28,J11063/OBLEACHBLUE-28,BLEACH BLUE,Talla: 28,13.30,0.00
+__import__.product_template_j11063_bleach_blue,J11063/BLEACH BLUE-29,J11063/OBLEACHBLUE-29,BLEACH BLUE,Talla: 29,13.30,0.00
+__import__.product_template_j11063_bleach_blue,J11063/BLEACH BLUE-30,J11063/OBLEACHBLUE-30,BLEACH BLUE,Talla: 30,13.30,0.00
+__import__.product_template_i101251_grey,I101251/GREY-38,I101251/OGREY-38,ZAPATOS PARA DAMAS,Talla: 38,30.35,0.00
+__import__.product_template_i101251_grey,I101251/GREY-40,I101251O/GREY-40,ZAPATOS PARA DAMAS,Talla: 40,31.16,0.00
+__import__.product_template_i101251_beige,I101251/BEIGE-40,I101251/OBEIGE-40,ZAPATOS PARA DAMAS (i101251_beige),Talla: 40,31.16,0.00
+__import__.product_template_i101251_black,I101251/BLACK-36,I101251/OBLACK-36,ZAPATOS PARA DAMAS (i101251_black),Talla: 36,31.16,0.00
+__import__.product_template_i101251_black,I101251/BLACK-38,I101251/OBLACK-38,ZAPATOS PARA DAMAS (i101251_black),Talla: 38,31.16,0.00
+__import__.product_template_i101251_black,I101251/BLACK-40,I101251/OBLACK-40,ZAPATOS PARA DAMAS (i101251_black),Talla: 40,31.16,0.00
+__import__.product_template_i101251_grey,I101251/GREY-36,I101251/OGREY-36,ZAPATOS PARA DAMAS,Talla: 36,31.16,0.00
+__import__.product_template_i101251_beige,I101251/BEIGE-36,I101251/OBEIGE-36,ZAPATOS PARA DAMAS (i101251_beige),Talla: 36,31.16,0.00
+__import__.product_template_i101251_beige,I101251/BEIGE-38,I101251/OBEIGE-38,ZAPATOS PARA DAMAS (i101251_beige),Talla: 38,31.16,0.00
+__import__.product_template_g07034as_blue,G07034AS/BLUE-28,G07034AS/OBLUE-28,RINSE BLUE,Talla: 28,12.90,0.00
+__import__.product_template_g07034as_light_blue,G07034AS/LIGHT BLUE-28,G07034AS/OLIGBLUE-28,LIGHT BLUE,Talla: 28,13.30,0.00
+__import__.product_template_g07034as_light_blue,G07034AS/LIGHT BLUE-29,G07034AS/OLIGBLUE-29,LIGHT BLUE,Talla: 29,13.30,0.00
+__import__.product_template_cv_l01_048f,CV-L01-048F/15,CV-L01-048F/O15,Terno CV-L01-048F,Talla: 15,47.74,0.00
+__import__.product_template_cv_l01_048f,CV-L01-048F/16,CV-L01-048F/O16,Terno CV-L01-048F,Talla: 16,17.30,0.00
+__import__.product_template_cv_l01_048f,CV-L01-048F/17,CV-L01-048F/O17,Terno CV-L01-048F,Talla: 17,17.30,0.00
+__import__.product_template_cv_l01_050fb,CV-L01-050FB/16,CV-L01-050FB/O16,Terno CV-L01-050FB,Talla: 16,47.74,0.00
+__import__.product_template_cv_l01_048f,CV-L01-048F/15.5,CV-L01-048F/O15.5,Terno CV-L01-048F,Talla: 15.5,17.30,0.00
+__import__.product_template_cv_l01_048f,CV-L01-048F/16.5,CV-L01-048F/O16.5,Terno CV-L01-048F,Talla: 16.5,17.30,0.00
+__import__.product_template_cv_l01_048f,CV-L01-048F/17.5,CV-L01-048F/O17.5,Terno CV-L01-048F,Talla: 17.5,17.30,0.00
+__import__.product_template_cv_l01_050fb,CV-L01-050FB/15.5,CV-L01-050FB/O15.5,Terno CV-L01-050FB,Talla: 15.5,47.74,0.00
+__import__.product_template_cv_l01_050fb,CV-L01-050FB/16.5,CV-L01-050FB/O16.5,Terno CV-L01-050FB,Talla: 16.5,17.30,0.00
+__import__.product_template_cv_j11_030bl,CV-J11-030BL/36,CV-J11-030BL/O36,Terno CV-J11-030BL,Talla: 36,191.22,0.00
+__import__.product_template_cv_j11_030bl,CV-J11-030BL/38,CV-J11-030BL/O38,Terno CV-J11-030BL,Talla: 38,191.22,0.00
+__import__.product_template_cv_j11_030bl,CV-J11-030BL/40,CV-J11-030BL/O40,Terno CV-J11-030BL,Talla: 40,191.22,0.00
+__import__.product_template_cv_j11_030bl,CV-J11-030BL/42,CV-J11-030BL/O42,Terno CV-J11-030BL,Talla: 42,191.22,0.00
+__import__.product_template_cv_j11_030bl,CV-J11-030BL/44,CV-J11-030BL/O44,Terno CV-J11-030BL,Talla: 44,191.22,0.00
+__import__.product_template_cv_j11_030bl,CV-J11-030BL/46,CV-J11-030BL/O46,Terno CV-J11-030BL,Talla: 46,86.87,0.00
+__import__.product_template_cv_j20_002_ol_f,CV-J20-002-OL-F/30,CV-J20-002-OL-F/O30,Terno CV-J20-002-OL-F,Talla: 30,47.74,0.00
+__import__.product_template_cv_j20_002_ol_f,CV-J20-002-OL-F/32,CV-J20-002-OL-F/O32,Terno CV-J20-002-OL-F,Talla: 32,47.74,0.00
+__import__.product_template_cv_j20_002_ol_f,CV-J20-002-OL-F/33,CV-J20-002-OL-F/O33,Terno CV-J20-002-OL-F,Talla: 33,47.74,0.00
+__import__.product_template_cv_j20_002_ol_f,CV-J20-002-OL-F/34,CV-J20-002-OL-F/O34,Terno CV-J20-002-OL-F,Talla: 34,47.74,0.00
+__import__.product_template_cv_j20_002_ol_f,CV-J20-002-OL-F/36,CV-J20-002-OL-F/O36,Terno CV-J20-002-OL-F,Talla: 36,47.74,0.00
+__import__.product_template_cv_j20_002_ol_f,CV-J20-002-OL-F/38,CV-J20-002-OL-F/O38,Terno CV-J20-002-OL-F,Talla: 38,47.74,0.00
+__import__.product_template_cv_j20_002_ol_f,CV-J20-002-OL-F/40,CV-J20-002-OL-F/O40,Terno CV-J20-002-OL-F,Talla: 40,47.74,0.00
+__import__.product_template_cv_k02_083,CV-K02-083/S,CV-K02-083/OS,CAMISA M/C CUADROS - FUCHSIA,Talla: S,17.30,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/28,627650557960,Terno BPM11979.A,Talla: 28,30.35,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/29,627650557977,Terno BPM11979.A,Talla: 29,120.45,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/30,627650557984,Terno BPM11979.A,Talla: 30,120.45,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/31,627650557991,Terno BPM11979.A,Talla: 31,120.45,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/32,627650558004,Terno BPM11979.A,Talla: 32,120.45,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/33,627650558011,Terno BPM11979.A,Talla: 33,120.45,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/34,627650558028,Terno BPM11979.A,Talla: 34,120.45,0.00
+__import__.product_template_bpm11979_a,BPM11979.A/36,627650558035,Terno BPM11979.A,Talla: 36,39.04,0.00
+__import__.product_template_bw4624_75,BW4624/75-6,BW4624/O75-6,Corbata BW4624/75,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_bw4624_75,BW4624/75-7,BW4624/O75-7,Corbata BW4624/75,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_80,BW4624/80-6,BW4624/O80-6,Corbata BW4624/80,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_bw4624_80,BW4624/80-7,BW4624/O80-7,Corbata BW4624/80,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_85,BW4624/85-6,BW4624/O85-6,Corbata BW4624/85,Ancho Corbata: 6 cm,21.65,0.00
+__import__.product_template_bw4624_85,BW4624/85-7,BW4624/O85-7,Corbata BW4624/85,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_bw4624_98,BW4624/98-7,BW4624/O98-7,Corbata BW4624/98,Ancho Corbata: 7 cm,21.65,0.00
+__import__.product_template_9039_bl,9039 BL-16,9039 BL-16,M. BIKINI JUNIOR BLANCO FLOR,Talla: 16,18.31,0.00
+__import__.product_template_93368,93368-32,93368-32,VB HALTER HAWAI ST. EVEN,Talla: 32,58.17,0.00
+__import__.product_template_93368,93368-34,93368-34,VB HALTER HAWAI ST. EVEN,Talla: 34,58.24,0.00
+__import__.product_template_93368,93368-36,93368-36,VB HALTER HAWAI ST. EVEN,Talla: 36,58.24,0.00
+__import__.product_template_8656bl,8656BL-12,8656BL-12,M.PRINCIPIANTE BLUE 08,Talla: 12,5.18,0.00
+__import__.product_template_81216,81216-7,81216-7,CAMISAS BRUNO CASSINI,Ancho Corbata: 7 cm,47.74,0.00
+__import__.product_template_522992_160,522992/160-36,522992/O160-36,BRASIER PREHORMADO EN CAJE Y MILE,Talla: 36,20.45,0.00
+__import__.product_template_534011g_050,534011G/050-32,534011G/O050-32,BRALETTE GIRL EN MILE Y ENC,Talla: 32,13.83,0.00
+__import__.product_template_534011g_050,534011G/050-34,534011G/O050-34,BRALETTE GIRL EN MILE Y ENC,Talla: 34,13.83,0.00
+__import__.product_template_534011g_996,534011G/996-32,534011G/O996-32,BRALETTE GIRL EN MILE Y ENC (534011g_996),Talla: 32,13.83,0.00
+__import__.product_template_534011g_996,534011G/996-34,534011G/O996-34,BRALETTE GIRL EN MILE Y ENC (534011g_996),Talla: 34,13.83,0.00
+__import__.product_template_534011g_996,534011G/996-36,534011G/O996-36,BRALETTE GIRL EN MILE Y ENC (534011g_996),Talla: 36,13.83,0.00
+__import__.product_template_542965_050,542965-050/32,542965-050/O32,Terno 542965-050,Talla: 32,15.09,0.00
+__import__.product_template_542965_050,542965-050/34,542965-050/O34,Terno 542965-050,Talla: 34,15.09,0.00
+__import__.product_template_542965_050,542965-050/36,542965-050/O36,Terno 542965-050,Talla: 36,15.57,0.00
+__import__.product_template_543045_050,543045/050-32,543045/O050-32,TOP DE DAMA EN MILE,Talla: 32,17.30,0.00
+__import__.product_template_543045_050,543045/050-34,543045/O050-34,TOP DE DAMA EN MILE,Talla: 34,16.88,0.00
+__import__.product_template_543045_050,543045/050-36,543045/O050-36,TOP DE DAMA EN MILE,Talla: 36,16.88,0.00
+__import__.product_template_543045_300,543045/300-32,543045/O300-32,TOP DE DAMA EN MILE (543045_300),Talla: 32,17.30,0.00
+__import__.product_template_543045_300,543045/300-34,543045/O300-34,TOP DE DAMA EN MILE (543045_300),Talla: 34,16.88,0.00
+__import__.product_template_543045_300,543045/300-36,543045/O300-36,TOP DE DAMA EN MILE (543045_300),Talla: 36,17.30,0.00
+__import__.product_template_522964_967,522964-967/32,522964-967/O32,Terno 522964-967,Talla: 32,22.52,0.00
+__import__.product_template_522964_967,522964-967/34,522964-967/O34,Terno 522964-967,Talla: 34,22.52,0.00
+__import__.product_template_522964_967,522964-967/36,522964-967/O36,Terno 522964-967,Talla: 36,22.52,0.00
+__import__.product_template_522991_050,522991/050-34,522991/O050-34,BRASIER CONVENCIONAL EN TULL Y FRANJA,Talla: 34,19.04,0.00
+__import__.product_template_522991_050,522991/050-36,522991/O050-36,BRASIER CONVENCIONAL EN TULL Y FRANJA,Talla: 36,18.66,0.00
+__import__.product_template_522991_300,522991/300-34,522991/O300-34,BRASIER CONVENCIONAL EN TULL Y FRANJA (522991_300),Talla: 34,19.04,0.00
+__import__.product_template_522991_300,522991/300-36,522991/O300-36,BRASIER CONVENCIONAL EN TULL Y FRANJA (522991_300),Talla: 36,19.04,0.00
+__import__.product_template_522992_160,522992/160-32,522992/O160-32,BRASIER PREHORMADO EN CAJE Y MILE,Talla: 32,20.45,0.00
+__import__.product_template_522992_160,522992/160-34,522992/O160-34,BRASIER PREHORMADO EN CAJE Y MILE,Talla: 34,20.78,0.00
+__import__.product_template_522963_050,522963-050/32,522963-050/O32,Terno 522963-050,Talla: 32,19.55,0.00
+__import__.product_template_522963_050,522963-050/34,522963-050/O34,Terno 522963-050,Talla: 34,19.55,0.00
+__import__.product_template_522963_050,522963-050/36,522963-050/O36,Terno 522963-050,Talla: 36,19.91,0.00
+__import__.product_template_522963_262,522963-262/32,522963-262/O32,Terno 522963-262,Talla: 32,19.91,0.00
+__import__.product_template_522963_262,522963-262/34,522963-262/O34,Terno 522963-262,Talla: 34,19.55,0.00
+__import__.product_template_522963_262,522963-262/36,522963-262/O36,Terno 522963-262,Talla: 36,19.91,0.00
+__import__.product_template_522964_050,522964-050/32,522964-050/O32,Terno 522964-050,Talla: 32,22.32,0.00
+__import__.product_template_522964_050,522964-050/34,522964-050/O34,Terno 522964-050,Talla: 34,22.52,0.00
+__import__.product_template_522964_050,522964-050/36,522964-050/O36,Terno 522964-050,Talla: 36,22.32,0.00
+__import__.product_template_512961_151,512961-151/36,512961-151/O36,Terno 512961-151,Talla: 36,15.57,0.00
+__import__.product_template_512961_311,512961-311/32,512961-311/O32,Terno 512961-311,Talla: 32,15.57,0.00
+__import__.product_template_512961_311,512961-311/34,512961-311/O34,Terno 512961-311,Talla: 34,15.09,0.00
+__import__.product_template_512961_311,512961-311/36,513961-311/O36,Terno 512961-311,Talla: 36,15.57,0.00
+__import__.product_template_522958g_325,522958G-325/32,522958G-325/O32,Terno 522958G-325,Talla: 32,19.55,0.00
+__import__.product_template_522958g_325,522958G-325/34,522958G-325/O34,Terno 522958G-325,Talla: 34,19.91,0.00
+__import__.product_template_522962_025,522962-025/32,522962-025/O32,Terno 522962-025,Talla: 32,16.52,0.00
+__import__.product_template_522962_025,522962-025/34,522962-025/34,Terno 522962-025,Talla: 34,17.30,0.00
+__import__.product_template_512961_025,512961-025/32,512961-025/O32,Terno 512961-025,Talla: 32,15.57,0.00
+__import__.product_template_512961_025,512961-025/34,512961-025/O34,Terno 512961-025,Talla: 34,15.09,0.00
+__import__.product_template_512961_025,512961-025/36,512961-025/O36,Terno 512961-025,Talla: 36,15.09,0.00
+__import__.product_template_512961_050,512961-050/32,512961-050/O32,Terno 512961-050,Talla: 32,15.57,0.00
+__import__.product_template_512961_050,512961-050/34,512961-050/O34,Terno 512961-050,Talla: 34,15.57,0.00
+__import__.product_template_512961_050,512961-050/36,512961-050/O36,Terno 512961-050,Talla: 36,15.09,0.00
+__import__.product_template_512961_151,512961-151/32,512961-151/O32,Terno 512961-151,Talla: 32,15.09,0.00
+__import__.product_template_512961_151,512961-151/34,512961-151/O34,Terno 512961-151,Talla: 34,15.09,0.00
+__import__.product_template_4cfw8711_126,4CFW8711-126/L,7453085647203,CAMISA CASUAL M/L P/H BRIGHT WHITE,Talla: L,51.22,0.00
+__import__.product_template_4cfw8711_126,4CFW8711-126/M,7453085647197,CAMISA CASUAL M/L P/H BRIGHT WHITE,Talla: M,51.22,0.00
+__import__.product_template_4cfw8711_126,4CFW8711-126/S,7453085647180,CAMISA CASUAL M/L P/H BRIGHT WHITE,Talla: S,51.22,0.00
+__import__.product_template_4cfw8711_126,4CFW8711-126/XL,7453085647210,CAMISA CASUAL M/L P/H BRIGHT WHITE,Talla: XL,51.22,0.00
+__import__.product_template_4cfw8806_010,4CFW8806-010/L,7453085642918,CAMISA CASUAL M/C PERRY ELLIS BLACK,Talla: L,51.22,0.00
+__import__.product_template_4cfw8806_010,4CFW8806-010/S,7453085642895,CAMISA CASUAL M/C PERRY ELLIS BLACK,Talla: S,51.22,0.00
+__import__.product_template_4cfw8806_010,4CFW8806-010/XL,7453085642925,CAMISA CASUAL M/C PERRY ELLIS BLACK,Talla: XL,51.22,0.00
+__import__.product_template_4bsw7069_010,4BSW7069-010/L,094832898379,CAMISA M/C PERRY ELLIS BLACK,Talla: L,47.74,0.00
+__import__.product_template_4bsw7069_010,4BSW7069-010/M,094832898362,CAMISA M/C PERRY ELLIS BLACK,Talla: M,47.74,0.00
+__import__.product_template_4bsw7069_010,4BSW7069-010/S,094832898355,CAMISA M/C PERRY ELLIS BLACK,Talla: S,47.74,0.00
+__import__.product_template_4bsw7069_010,4BSW7069-010/XL,094832898386,CAMISA M/C PERRY ELLIS BLACK,Talla: XL,47.74,0.00
+__import__.product_template_4bfw7013_010,4BFW7013-010/L,797082286940,CAMISA M/L PERRY ELLIS BLACK,Talla: L,47.74,0.00
+__import__.product_template_4bfw7013_010,4BFW7013-010/M,797082286933,CAMISA M/L PERRY ELLIS BLACK,Talla: M,47.74,0.00
+__import__.product_template_4bfw7013_010,4BFW7013-010/S,797082286926,CAMISA M/L PERRY ELLIS BLACK,Talla: S,47.74,0.00
+__import__.product_template_4bfw7013_010,4BFW7013-010/XL,797082286957,CAMISA M/L PERRY ELLIS BLACK,Talla: XL,47.74,0.00
+__import__.product_template_44360_bl,44360/BL-32,44360/OBL-32,BRASIER ESENCIAL ST. EVEN,Talla: 32,24.91,0.00
+__import__.product_template_44360_bl,44360/BL-34,44360/OBL-34,BRASIER ESENCIAL ST. EVEN,Talla: 34,24.91,0.00
+__import__.product_template_44360_ne,44360/NE-32,44360/ONE-32,BRASIER ESENCIAL ST. EVEN (44360_ne),Talla: 32,25.13,0.00
+__import__.product_template_44360_ne,44360/NE-34,44360/ONE-34,BRASIER ESENCIAL ST. EVEN (44360_ne),Talla: 34,25.13,0.00
+__import__.product_template_44381_pe,44381/PE-L,44381/OPE-L,BRASILERA ROMANTICO ST. EVEN,Talla: L,14.70,0.00
+__import__.product_template_44381_pe,44381/PE-S,44381/OPE-S,BRASILERA ROMANTICO ST. EVEN,Talla: S,14.20,0.00
+__import__.product_template_43290,43290/34,43290/O34,Terno 43290,Talla: 34,33.83,0.00
+__import__.product_template_43500,43500/32,43500/32,Terno 43500,Talla: 32,25.90,0.00
+__import__.product_template_43500_am,43500/AM-36,43500/IOAM-36,BRASIER ESENCIAL ST. EVEN (43500_am),Talla: 36,30.35,0.00
+__import__.product_template_43500_bl,43500/BL-32,43500/OBL-32,BRASIER ESENCIAL ST-EVEN,Talla: 32,30.35,0.00
+__import__.product_template_43500_sal,43500/SAL-32,43500/SAL-32,SALMON 32 BRASIER ESENCIAL ST EVEN,Talla: 32,30.29,0.00
+__import__.product_template_43500_sal,43500/SAL-36,43500/SAL-36,SALMON 32 BRASIER ESENCIAL ST EVEN,Talla: 36,30.27,0.00
+__import__.product_template_43510,43510/34,43510/O34,Terno 43510,Talla: 34,23.39,0.00
+__import__.product_template_43514,43514/L,43514/OL,CACHETERO ESENCIAL,Talla: L,12.96,0.00
+__import__.product_template_43514,43514/M,43514/M,CACHETERO ESENCIAL,Talla: M,12.90,0.00
+__import__.product_template_43541,43541/L,43541/OL,BRASILERA ROMANTICA,Talla: L,16.43,0.00
+__import__.product_template_41150_neg,41150-NEG-32,7703701115198,BRASIER NEGRO 32 DAMA ZE,Talla: 32,31.22,0.00
+__import__.product_template_41150_neg,41150-NEG-34,7703701115204,BRASIER NEGRO 32 DAMA ZE,Talla: 34,31.22,0.00
+__import__.product_template_41150_neg,41150-NEG-36,7703701115211,BRASIER NEGRO 32 DAMA ZE,Talla: 36,31.16,0.00
+__import__.product_template_41680,41680-34,41680-34,BRASIER ROMANTICO ST. EVEN,Talla: 34,25.13,0.00
+__import__.product_template_41920,41920-32,41920-32,BRASIER LISOS ST. EVEN,Talla: 32,27.74,0.00
+__import__.product_template_41920,41920-34,41920-34,BRASIER LISOS ST. EVEN,Talla: 34,24.26,0.00
+__import__.product_template_42000_beg,42000-BEG-32,7701341156854,BRASIER BASICO BEIGE 32 DAMA ZE,Talla: 32,22.52,0.00
+__import__.product_template_42000_beg,42000-BEG-34,7701341156861,BRASIER BASICO BEIGE 32 DAMA ZE,Talla: 34,22.23,0.00
+__import__.product_template_42000_beg,42000-BEG-36,7701341156878,BRASIER BASICO BEIGE 32 DAMA ZE,Talla: 36,22.23,0.00
+__import__.product_template_40160_bla,40160-BLA-34,7703701047635,BRASIER BLANCO 34 DAMA ZE,Talla: 34,29.48,0.00
+__import__.product_template_40160_bla,40160-BLA-36,7703701047642,BRASIER BLANCO 34 DAMA ZE,Talla: 36,29.38,0.00
+__import__.product_template_40000_bla,40000-BLA-32,7701460135105,BRASIER BLANCO 32 DAMA ZE,Talla: 32,31.22,0.00
+__import__.product_template_40000_bla,40000-BLA-34,7701460135112,BRASIER BLANCO 32 DAMA ZE,Talla: 34,31.16,0.00
+__import__.product_template_40000_bla,40000-BLA-36,7701460135129,BRASIER BLANCO 32 DAMA ZE,Talla: 36,31.16,0.00
+__import__.product_template_30000_beig,30000-BEIG-32,77041460185933,BRASIER BEIGE 32 DAMA ZE,Talla: 32,20.78,0.00
+__import__.product_template_30000_beig,30000-BEIG-34,7701460185940,BRASIER BEIGE 32 DAMA ZE,Talla: 34,20.45,0.00
+__import__.product_template_30000_beig,30000-BEIG-36,7701460185957,BRASIER BEIGE 32 DAMA ZE,Talla: 36,20.45,0.00
+__import__.product_template_30100_neg,30100-NEG-32,7701460186022,BRASIER NEGRO 32 DAMA ZE (30100_neg),Talla: 32,22.52,0.00
+__import__.product_template_30100_neg,30100-NEG-34,7701460186039,BRASIER NEGRO 32 DAMA ZE (30100_neg),Talla: 34,22.23,0.00
+__import__.product_template_30100_neg,30100-NEG-36,7701460186046,BRASIER NEGRO 32 DAMA ZE (30100_neg),Talla: 36,22.52,0.00
+__import__.product_template_188_b1_bc_1,188-B1-BC-1/46,188-B1-BC-1/O46,Terno 188-B1-BC-1,Talla: 46,260.78,0.00
+__import__.product_template_188_b1_bc_1,188-B1-BC-1/48,188-B1-BC-1/O48,Terno 188-B1-BC-1,Talla: 48,260.78,0.00
+__import__.product_template_188_b1_bc_1,188-B1-BC-1/50,188-B1-BC-1/O50,Terno 188-B1-BC-1,Talla: 50,260.78,0.00
+__import__.product_template_188_b1_bc_1,188-B1-BC-1/52,188-B1-BC-1/O52,Terno 188-B1-BC-1,Talla: 52,260.78,0.00
+__import__.product_template_188_b1_bc_1,188-B1-BC-1/54,188-B1-BC-1/O54,Terno 188-B1-BC-1,Talla: 54,260.78,0.00
+__import__.product_template_188_b1_bc_1,188-B1-BC-1/56,188-B1-BC-1/O56,Terno 188-B1-BC-1,Talla: 56,260.78,0.00
+__import__.product_template_188_b1_bc_1,188-B1-BC-1/58,188-B1-BC-1/O58,Terno 188-B1-BC-1,Talla: 58,260.78,0.00
+__import__.product_template_16350,16350/34,16350/O34,Terno 16350,Talla: 34,25.13,0.00
+__import__.product_template_16360,16360-34,16360-34,"BRASSIER CHAMELA BLANCO, MORADO",Talla: 34,26.00,0.00
+__import__.product_template_16380,16380-34,16380-34,BRASSIER CHAMELA,Talla: 34,41.65,0.00
+__import__.product_template_16834,16834-L,16834-L,"BOXER CHAMELA AZUL, ROSA",Talla: L,25.13,0.00
+__import__.product_template_16841,16841-L,16841-L,BRASILERA CHAMELA TABACO,Talla: L,17.30,0.00
+__import__.product_template_16841,16841-M,16841-M,BRASILERA CHAMELA TABACO,Talla: M,11.90,0.00
+__import__.product_template_16900,16900-34,16900-34,BRASSIER CHAMELA ROSA,Talla: 34,27.59,0.00
+__import__.product_template_16904,16904-M,16904-M,BOXER CHAMELA ROSA,Talla: M,16.43,0.00
+__import__.product_template_17910_bl,17910/BL-34,17910/BL-34,BRASSIER CHAMELA (BLANCO),Talla: 34,37.80,0.00
+__import__.product_template_17910_ne,17910/NE-34,17910/NE-34,BRASSIER CHAMELA (NEGRO),Talla: 34,37.80,0.00
+__import__.product_template_17910_ru,17910/RU-32,17910/ORU-32,BRASSIER CHAMELA (RUBI),Talla: 32,39.04,0.00
+__import__.product_template_17910_ru,17910/RU-34,17910/RU-34,BRASSIER CHAMELA (RUBI),Talla: 34,37.80,0.00
+__import__.product_template_17911_bl,17911/BL-M,17911/OBL-M,BRASILERA CHAMELA (BLANCO),Talla: M,13.30,0.00
+__import__.product_template_17911_ne,17911/NE-L,17911/ONE-L,BRASILERA CHAMELA (NEGRO),Talla: L,13.83,0.00
+__import__.product_template_17911_ne,17911/NE-M,17911/NE-M,BRASILERA CHAMELA (NEGRO),Talla: M,13.30,0.00
+__import__.product_template_17911_ne,17911/NE-S,17911/ONE-S,BRASILERA CHAMELA (NEGRO),Talla: S,13.30,0.00
+__import__.product_template_17931,17931-L,17931-L,PALODEROSA L BRASILERA CHAMELA,Talla: L,19.04,0.00
+__import__.product_template_17931,17931-M,17931-M,PALODEROSA L BRASILERA CHAMELA,Talla: M,18.66,0.00
+__import__.product_template_17cr003100,17CR003100-15,759084822717,CAMISA M/L P/H 100 ALGODON WHITE,Talla: 15,17.30,0.00
+__import__.product_template_17cr003100,17CR003100-15.5,759084822724,CAMISA M/L P/H 100 ALGODON WHITE,Talla: 15.5,17.30,0.00
+__import__.product_template_17cr003100,17CR003100-16,759084822731,CAMISA M/L P/H 100 ALGODON WHITE,Talla: 16,17.30,0.00
+__import__.product_template_17cr003100,17CR003100-16.5,759084822748,CAMISA M/L P/H 100 ALGODON WHITE,Talla: 16.5,17.30,0.00
+__import__.product_template_17cr003100,17CR003100-17,759084822755,CAMISA M/L P/H 100 ALGODON WHITE,Talla: 17,17.30,0.00
+__import__.product_template_17cr003100,17CR003100-17.5,759084822854,CAMISA M/L P/H 100 ALGODON WHITE,Talla: 17.5,17.30,0.00
+__import__.product_template_17cr006100,17CR006100-15,759084823615,CAMISA M/L P/H 100 ALGODON WHITE (17cr006100),Talla: 15,17.30,0.00
+__import__.product_template_17cr006100,17CR006100-15.5,759084823622,CAMISA M/L P/H 100 ALGODON WHITE (17cr006100),Talla: 15.5,17.30,0.00
+__import__.product_template_17cr006100,17CR006100-16,759084823639,CAMISA M/L P/H 100 ALGODON WHITE (17cr006100),Talla: 16,17.30,0.00
+__import__.product_template_17cr006100,17CR006100-16.5,759084823646,CAMISA M/L P/H 100 ALGODON WHITE (17cr006100),Talla: 16.5,17.30,0.00
+__import__.product_template_17cr006100,17CR006100-17,759084823745,CAMISA M/L P/H 100 ALGODON WHITE (17cr006100),Talla: 17,17.30,0.00
+__import__.product_template_17cr006100,17CR006100-17.5,759084823752,CAMISA M/L P/H 100 ALGODON WHITE (17cr006100),Talla: 17.5,17.30,0.00
+__import__.product_template_15290,15290-32,15290-32,BRASSIER CHAMELA (15290),Talla: 32,33.83,0.00
+__import__.product_template_12110black,12110BLACK-34,12110BLACK-34,M.BRASSIERE CHAMELA,Talla: 34,18.17,0.00
+__import__.product_template_082845_01ec,082845-01EC/15,082845-01EC/O15,Terno 082845-01EC,Talla: 15,30.35,0.00
+__import__.product_template_082845_01ec,082845-01EC/15.5,082845-01EC/O15.5,Terno 082845-01EC,Talla: 15.5,17.30,0.00
+__import__.product_template_082845_01ec,082845-01EC/16,082845-01EC/O16,Terno 082845-01EC,Talla: 16,17.30,0.00
+__import__.product_template_082845_01ec,082845-01EC/16.5,082845-01EC/O16.5,Terno 082845-01EC,Talla: 16.5,30.35,0.00
+__import__.product_template_082845_01ec,082845-01EC/17,082845-01EC/O17,Terno 082845-01EC,Talla: 17,30.35,0.00
+__import__.product_template_082845_01ec,082845-01EC/17.5,082845-01EC/O17.5,Terno 082845-01EC,Talla: 17.5,17.30,0.00
+__import__.product_template_082845_01ec,082845-01EC/18,082845-01EC/O18,Terno 082845-01EC,Talla: 18,17.30,0.00
+__import__.product_template_082845_01ec,082845-01EC/18.5,082845-01EC/O18.5,Terno 082845-01EC,Talla: 18.5,30.35,0.00
+__import__.product_template_082845_01ec,082845-01EC/19,082845-01EC/O19,Terno 082845-01EC,Talla: 19,30.35,0.00
+__import__.product_template_082845_01ec,082845-01EC/20,082845-01EC/O20,Terno 082845-01EC,Talla: 20,17.30,0.00
+__import__.product_template_082845_01ec,082845-01EC/14.5,082845-01EC/O14.5,Terno 082845-01EC,Talla: 14.5,17.30,0.00
+__import__.product_template_081920_24ec,081920-24EC/14.5,081920-24EC/O14.5,Terno 081920-24EC,Talla: 14.5,17.30,0.00
+__import__.product_template_081920_24ec,081920-24EC/15,081920-24EC/O15,Terno 081920-24EC,Talla: 15,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/15.5,081920-24EC/O15.5,Terno 081920-24EC,Talla: 15.5,17.30,0.00
+__import__.product_template_081920_24ec,081920-24EC/16,081920-24EC/O16,Terno 081920-24EC,Talla: 16,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/16.5,081920-24EC/O16.5,Terno 081920-24EC,Talla: 16.5,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/17,081920-24EC/O17,Terno 081920-24EC,Talla: 17,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/17.5,081920-24EC/O17.5,Terno 081920-24EC,Talla: 17.5,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/18,081920-24EC/O18,Terno 081920-24EC,Talla: 18,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/18.5,081920-24EC/O18.5,Terno 081920-24EC,Talla: 18.5,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/19,081920-24EC/O19,Terno 081920-24EC,Talla: 19,30.35,0.00
+__import__.product_template_081920_24ec,081920-24EC/20,081920-24EC/O20,Terno 081920-24EC,Talla: 20,30.35,0.00
+__import__.product_template_081920_44ec,081920-44EC/14.5,081920-44EC/O14.5,Terno 081920-44EC,Talla: 14.5,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/15,081920-44EC/O15,Terno 081920-44EC,Talla: 15,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/15.5,081920-44EC/O15.5,Terno 081920-44EC,Talla: 15.5,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/16,081920-44EC/O16,Terno 081920-44EC,Talla: 16,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/16.5,081920-44EC/O16.5,Terno 081920-44EC,Talla: 16.5,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/17,081920-44EC/O17,Terno 081920-44EC,Talla: 17,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/17.5,081920-44EC/O17.5,Terno 081920-44EC,Talla: 17.5,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/18,081920-44EC/O18,Terno 081920-44EC,Talla: 18,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/18.5,081920-44EC/O18.5,Terno 081920-44EC,Talla: 18.5,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/19,081920-44EC/O19,Terno 081920-44EC,Talla: 19,47.74,0.00
+__import__.product_template_081920_44ec,081920-44EC/20,081920-44EC/O20,Terno 081920-44EC,Talla: 20,47.74,0.00
+__import__.product_template_028_f5,028-F5-33,028-F5-33,PANTALON BRUNO CASSINI (HOMBRE),Talla: 33,21.65,0.00
+__import__.product_template_028_f5,028-F5-34,028-F5-34,PANTALON BRUNO CASSINI (HOMBRE),Talla: 34,21.65,0.00
+__import__.product_template_028_f5,028-F5-38,028-F5-38,PANTALON BRUNO CASSINI (HOMBRE),Talla: 38,21.65,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/46,008-1BC-1/O46,Terno 008-1BC-1,Talla: 46,191.22,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/48,008-1BC-1/O48,Terno 008-1BC-1,Talla: 48,191.22,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/50,008-1BC-1/O50,Terno 008-1BC-1,Talla: 50,191.22,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/52,008-1BC-1/O52,Terno 008-1BC-1,Talla: 52,191.22,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/54,008-1BC-1/O54,Terno 008-1BC-1,Talla: 54,191.22,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/56,008-1BC-1/O56,Terno 008-1BC-1,Talla: 56,191.22,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/58,008-1BC-1/O58,Terno 008-1BC-1,Talla: 58,191.22,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/60,008-1BC-1/O60,Terno 008-1BC-1,Talla: 60,278.17,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/62,008-1BC-1/O62,Terno 008-1BC-1,Talla: 62,278.17,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/64,008-1BC-1/O64,Terno 008-1BC-1,Talla: 64,278.17,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/66,008-1BC-1/O66,Terno 008-1BC-1,Talla: 66,278.17,0.00
+__import__.product_template_008_1bc_1,008-1BC-1/68,008-1BC-1/O68,Terno 008-1BC-1,Talla: 68,278.17,0.00
+__import__.product_template_028_65,028-65-32,028-65-32,PANTALON BRUNO CASSINI (HOMBRE) (028_65),Talla: 32,43.39,0.00
+__import__.product_template_028_65,028-65-33,028-65-33,PANTALON BRUNO CASSINI (HOMBRE) (028_65),Talla: 33,43.39,0.00
+__import__.product_template_028_65,028-65-34,028-65-34,PANTALON BRUNO CASSINI (HOMBRE) (028_65),Talla: 34,43.39,0.00
+__import__.product_template_028_65,028-65-38,028-65-38,PANTALON BRUNO CASSINI (HOMBRE) (028_65),Talla: 38,43.39,0.00
+__import__.product_template_028_f5,028-F5-32,028-F5-32,PANTALON BRUNO CASSINI (HOMBRE),Talla: 32,39.04,0.00


### PR DESCRIPTION
### Motivation
- Evitar el error de Odoo `product_product_combination_unique` causado por filas con la misma combinación `(product_tmpl_id/id, Variant Values)` repetida para un mismo template. 
- Proteger la importación de variantes cuando el origen (Contífico) produce variantes huérfanas o valores de atributo inválidos que pueden generar combinaciones vacías duplicadas. 
- Mantener la trazabilidad y la operativa: generar un CSV saneado listo para importación y documentar la versión del exportador.

### Description
- Se incrementó `EXPORTER_VERSION` a `1.5.6` y la versión de proyecto en `README.MD` a `1.0.60` y se añadió la entrada en `CHANGELOG.md` (`1.0.60`).
- En `OdooMigrationService._write_phase2_variant_internal_reference_outputs` se añadió conteo por `(product_tmpl_id/id, Variant Values)`, validación explícita de riesgo y una deduplicación de seguridad que elimina filas duplicadas de esa llave antes de escribir `odoo_product_variant_internal_references.csv` (se genera también un registro de las filas descartadas en `odoo_phase2_variant_internal_reference_validation.csv`).
- Se añadieron mensajes de validación adicionales para detectar y reportar duplicados que podrían violar la unicidad de Odoo (`Duplicate product_tmpl_id + Variant Values` y `Dropped duplicate product_tmpl_id + Variant Values`).
- Se generó el CSV saneado `docs/odoo_import_templates/Last/odoo_product_variant_internal_references_clean.csv` con las filas finales listas para importar sin duplicados por `(template, Variant Values)`.

### Testing
- Se compiló el módulo con `python -m py_compile backend/app/odoo_migration/service.py` y la compilación finalizó correctamente. (éxito)
- Auditoría CSV realizada con scripts internos sobre `docs/odoo_import_templates/Last` y comprobaciones de unicidad devolvieron: `odoo_product_variant_internal_references.csv`: `6241` filas; `odoo_phase2_variant_internal_reference_validation.csv`: `4491` filas; `odoo_phase2_duplicate_variant_keys.csv`: `0` filas; `odoo_phase2_orphaned_skus.csv`: `0` filas. (éxito)
- Verificación del CSV limpio `odoo_product_variant_internal_references_clean.csv` mostró `6241` filas y `0` duplicados por `(product_tmpl_id/id, Variant Values)`, confirmando que la deduplicación de seguridad y el archivo de salida funcionan como se espera. (éxito)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff29c335c083328ffc8763640fcb43)