### PR TITLE
Secure file download, template+variant dedupe for Phase 2, safe-by-id CSV and version/changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,30 @@
 - Duplicados en Fase 1 vuelven a modo estricto por defecto (`strict_duplicate_errors=True`) para no ocultar problemas de calidad de datos.
 - Nuevo fallback para Fase 2: variantes sin atributos válidos pueden exportarse como simples (`fallback_orphan_variants_to_simple=True`) en lugar de perderse.
 - Se añade `fallback_orphan_variants_to_simple` al `run_summary.json`.
+
+## 1.0.60 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.6.
+- Se agrega guardarraíl en Fase 2 para detectar y deduplicar por (`product_tmpl_id/id`, `Variant Values`) antes de exportar `odoo_product_variant_internal_references.csv`.
+- Se reportan nuevas validaciones de riesgo para prevenir el error de unicidad de Odoo `product_product_combination_unique`.
+- Se genera en `docs/odoo_import_templates/Last` un CSV saneado de variantes (`odoo_product_variant_internal_references_clean.csv`) listo para importación segura.
+
+## 1.0.61 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.7.
+- Se elimina el artefacto pesado `odoo_product_variant_internal_references_clean.csv` del repo (debe generarse por corrida, no versionarse).
+- Nuevo script `backend/build_safe_variant_update_csv.py` para construir un CSV de actualización segura por `id` + `Internal Reference` + `Barcode` sin tocar `Variant Values` (evita que Odoo recalcule `combination_indices=''`).
+
+## 1.0.62 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.8.
+- Se elimina el flujo apoyado en `docs/odoo_import_templates/Last` para artefactos auxiliares; la operación queda centrada en archivos del `run_id` generado desde frontend.
+- Descarga de archivos de run mejorada: se reemplaza whitelist rígida por validación segura de ruta/extensión (`.csv`, `.log`, `.md`, `.json`) para evitar que archivos generados en nuevas fases aparezcan pero no se puedan descargar.
+- Se agregan a la respuesta estándar de archivos los outputs `odoo_phase2_simples_minimal.csv` y `odoo_phase2_simples_unmatched.csv` cuando existan.
+
+## 1.0.63 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.9.
+- Se agrega salida alias en cada `run_id`: `odoo_product_variant_update_by_id_safe.csv` (mismo contenido que `odoo_phase2_with_odoo_ids_minimal.csv`) para facilitar operación.
+- Se expone este archivo en los links del frontend/API (`_build_files` y respuesta de `/runs/{run_id}/phase2/merge`).
+
+## 1.0.64 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.10.
+- Se genera `odoo_product_variant_update_by_id_safe.csv` desde el momento de creación del run (placeholder con header), para que siempre exista en descargas aun antes de ejecutar `/phase2/merge`.
+- Al ejecutar `/phase2/merge`, ese archivo se rellena con las filas matched por `id` para importación segura.

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.59
+Versión 1.0.64
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 

--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -53,6 +53,9 @@ def _build_files(run_id: str) -> dict[str, str]:
         "fase2_merged_with_odoo_ids_csv": f"{base}/odoo_phase2_with_odoo_ids.csv",
         "fase2_merged_unmatched_csv": f"{base}/odoo_phase2_merger_unmatched.csv",
         "fase2_merged_unused_odoo_csv": f"{base}/odoo_phase2_merger_unused_odoo.csv",
+        "fase2_merged_simples_unmatched_csv": f"{base}/odoo_phase2_simples_unmatched.csv",
+        "fase2_merged_simples_minimal_csv": f"{base}/odoo_phase2_simples_minimal.csv",
+        "fase2_variant_update_by_id_safe_csv": f"{base}/odoo_product_variant_update_by_id_safe.csv",
         # === Reportes de calidad (no importar) ===
         "reporte_errores_csv": f"{base}/migration_errors.csv",
         "reporte_mapping_csv": f"{base}/mapping_report.csv",
@@ -309,63 +312,16 @@ def list_runs(limit: int = Query(default=10, ge=1, le=100)):
 
 @router.get("/runs/{run_id}/files/{filename}")
 def download_file(run_id: str, filename: str):
-    allowed = {
-        "product_product.csv",
-        "initial_stock.csv",
-        "stock_quant.csv",
-        "stock_quant_legacy.csv",
-        "migration_errors.csv",
-        "mapping_report.csv",
-        "excluded_zero_stock.csv",
-        "debug.log",
-        "raw.log",
-        "stock_errors.csv",
-        "01_product_templates_with_existing_attributes.csv",
-        "02_variant_update_map.csv",
-        "03_stock_quant_by_variant.csv",
-        "04_missing_attribute_values_report.csv",
-        "import_products_and_variants_report.md",
-        "unmapped_categories.csv",
-        "run_summary.json",
-        "odoo_external_id_conflicts.csv",
-        "odoo_barcode_conflicts.csv",
-        "odoo_missing_products_for_stock.csv",
-        "odoo_duplicate_variant_combinations.csv",
-        "odoo_import_validation_report.csv",
-        "odoo_attribute_rejections.csv",
-        "odoo_product_templates_with_attributes.csv",
-        "odoo_product_templates_simple.csv",
-        "odoo_stock_quant.csv",
-        "odoo_variant_sku_mapping.csv",
-        "odoo_product_templates.csv",
-        "product_internal_reference_update.csv",
-        "product_internal_reference_barcode_conflicts.csv",
-        "odoo_product_variant_internal_references.csv",
-        "odoo_product_variant_internal_references_no_barcode.csv",
-        "odoo_phase2_variant_internal_reference_validation.csv",
-        "odoo_phase2_duplicate_variant_keys.csv",
-        "odoo_phase2_missing_stock_references.csv",
-        "odoo_phase2_csv_format_errors.csv",
-        "odoo_compare_only_in_contifico.csv",
-        "odoo_compare_only_in_odoo.csv",
-        "odoo_compare_in_both.csv",
-        "odoo_missing_simple_for_import.csv",
-        "odoo_missing_templates_with_attributes.csv",
-        "odoo_missing_variants_phase2.csv",
-        "odoo_phase2_with_odoo_ids.csv",
-        "odoo_phase2_with_odoo_ids_minimal.csv",
-        "odoo_phase2_simples_minimal.csv",
-        "odoo_phase2_merger_unmatched.csv",
-        "odoo_phase2_simples_unmatched.csv",
-        "odoo_phase2_merger_unused_odoo.csv",
-        "odoo_phase1_template_renames.csv",
-        "odoo_phase2_orphaned_skus.csv",
-    }
-    if filename not in allowed:
-        raise HTTPException(status_code=400, detail="Archivo no permitido")
-    file_path = _output_root() / run_id / filename
+    if "/" in filename or "\\" in filename or filename.startswith("."):
+        raise HTTPException(status_code=400, detail="Nombre de archivo inválido")
+    file_path = (_output_root() / run_id / filename).resolve()
+    run_root = (_output_root() / run_id).resolve()
+    if run_root not in file_path.parents:
+        raise HTTPException(status_code=400, detail="Ruta de archivo inválida")
     if not file_path.exists() or not file_path.is_file():
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
+    if file_path.suffix.lower() not in {".csv", ".log", ".md", ".json"}:
+        raise HTTPException(status_code=400, detail="Tipo de archivo no permitido")
     media_type = "text/plain; charset=utf-8" if filename.endswith(('.log', '.md')) else "text/csv; charset=utf-8"
     return FileResponse(path=file_path, filename=filename, media_type=media_type)
 
@@ -469,6 +425,7 @@ async def merge_phase2_with_odoo_export(run_id: str, file: UploadFile = File(...
         "files": {
             "phase2_with_odoo_ids": f"{base}/odoo_phase2_with_odoo_ids.csv",
             "phase2_with_odoo_ids_minimal": f"{base}/odoo_phase2_with_odoo_ids_minimal.csv",
+            "phase2_variant_update_by_id_safe": f"{base}/odoo_product_variant_update_by_id_safe.csv",
             "simples_minimal": f"{base}/odoo_phase2_simples_minimal.csv",
             "unmatched": f"{base}/odoo_phase2_merger_unmatched.csv",
             "simples_unmatched": f"{base}/odoo_phase2_simples_unmatched.csv",

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -56,7 +56,7 @@ INTERNAL_REF_UPDATE_COLUMNS = [
 INTERNAL_REF_CONFLICT_COLUMNS = [
     "barcode", "conflicting_internal_references", "count", "reason",
 ]
-EXPORTER_VERSION = "1.5.5"
+EXPORTER_VERSION = "1.5.10"
 
 
 def _to_odoo_bool(value: Any) -> str:
@@ -250,6 +250,8 @@ class OdooMigrationService:
         self._write_csv(folder / "odoo_external_id_conflicts.csv", ["external_id","source_sku","source_id","source_name","category","price","classification","reason"], external_id_conflicts)
         self._write_phase2_variant_internal_reference_outputs(folder=folder, variant_map_rows=o19_variant_map_rows, with_attr_rows=with_attr_rows, simple_rows=simple_rows, stock_rows=o19_stock_rows)
         self._write_internal_reference_update_csv(folder=folder, simple_rows=simple_rows, variant_map_rows=o19_variant_map_rows, variant_rows_raw=phase1.get("variant_rows", []))
+        # Placeholder: archivo de actualización segura por id (se completa en /phase2/merge)
+        self._write_csv(folder / "odoo_product_variant_update_by_id_safe.csv", ["id", "Internal Reference", "Barcode", "Sales Price", "Cost"], [])
         barcode_index: dict[str, list[str]] = {}
         for r in o19_variant_map_rows:
             bc = str(r.get("Barcode") or r.get("Internal Reference") or "").strip()
@@ -609,11 +611,14 @@ class OdooMigrationService:
         sku_counts = {}
         barcode_counts = {}
         key_counts = {}
+        template_combo_counts = {}
         for r in variant_rows:
             sku_counts[r["Internal Reference"]] = sku_counts.get(r["Internal Reference"], 0) + 1
             barcode_counts[r["Barcode"]] = barcode_counts.get(r["Barcode"], 0) + 1
             k=(r["Name"], r["Variant Values"])
             key_counts[k] = key_counts.get(k, 0) + 1
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            template_combo_counts[template_combo] = template_combo_counts.get(template_combo, 0) + 1
 
         duplicate_key_rows = []
         for r in variant_rows:
@@ -625,6 +630,24 @@ class OdooMigrationService:
             if key_counts.get(key,0)>1:
                 validation_rows.append({"issue_type":"Duplicate Name + Variant Values","product_template_external_id":"","product_template_name":r["Name"],"internal_reference":sku,"barcode":bc,"variant_values":r["Variant Values"],"source_sku":sku,"reason":"Variant key duplicated"})
                 duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":sku,"barcode":bc,"source_sku":sku,"reason":"Duplicate Name + Variant Values"})
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            if template_combo_counts.get(template_combo, 0) > 1:
+                validation_rows.append({"issue_type":"Duplicate product_tmpl_id + Variant Values","product_template_external_id":str(r.get("product_tmpl_id/id") or "").replace("__import__.", ""),"product_template_name":r["Name"],"internal_reference":sku,"barcode":bc,"variant_values":r["Variant Values"],"source_sku":sku,"reason":"Would violate Odoo unique constraint product_product_combination_unique"})
+                duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":sku,"barcode":bc,"source_sku":sku,"reason":"Duplicate product_tmpl_id + Variant Values"})
+
+        # Hard safety net for Odoo constraint:
+        # product_product_combination_unique requires one row per (template, variant values).
+        deduped_variant_rows = []
+        seen_template_combo: set[tuple[str, str]] = set()
+        for r in variant_rows:
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            if template_combo in seen_template_combo:
+                validation_rows.append({"issue_type":"Dropped duplicate product_tmpl_id + Variant Values","product_template_external_id":str(r.get("product_tmpl_id/id") or "").replace("__import__.", ""),"product_template_name":r["Name"],"internal_reference":r["Internal Reference"],"barcode":r["Barcode"],"variant_values":r["Variant Values"],"source_sku":r["Internal Reference"],"reason":"Safety dedupe applied before CSV export"})
+                duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":r["Internal Reference"],"barcode":r["Barcode"],"source_sku":r["Internal Reference"],"reason":"Dropped duplicate product_tmpl_id + Variant Values"})
+                continue
+            seen_template_combo.add(template_combo)
+            deduped_variant_rows.append(r)
+        variant_rows = deduped_variant_rows
 
         simple_skus = {str(r.get("Internal Reference") or "").strip() for r in simple_rows if str(r.get("Internal Reference") or "").strip()}
         variant_skus = {r["Internal Reference"] for r in variant_rows}
@@ -1424,6 +1447,8 @@ class OdooMigrationService:
         self._write_csv(output_folder / "odoo_phase2_with_odoo_ids.csv", matched_cols, matched_rows)
         # Minimal CSV: only id + fields to update — no Name/Variant Values to avoid Odoo relational field validation
         self._write_csv(output_folder / "odoo_phase2_with_odoo_ids_minimal.csv", minimal_cols, matched_rows)
+        # Alias operativo solicitado por negocio para importación segura por id
+        self._write_csv(output_folder / "odoo_product_variant_update_by_id_safe.csv", minimal_cols, matched_rows)
         self._write_csv(output_folder / "odoo_phase2_simples_minimal.csv", simples_minimal_cols, simple_matched_rows)
         self._write_csv(output_folder / "odoo_phase2_merger_unmatched.csv", unmatched_cols, unmatched_rows)
         self._write_csv(output_folder / "odoo_phase2_simples_unmatched.csv", simples_unmatched_cols, simple_unmatched_rows)


### PR DESCRIPTION
### Motivation
- Prevent Odoo uniqueness errors and data-loss at Phase 2 by detecting and deduplicating variant rows that would violate `product_product_combination_unique` (same `product_tmpl_id/id` + `Variant Values`).
- Provide an operational alias and placeholder for a safe import-by-`id` CSV so teams can update `Internal Reference`/`Barcode` without touching `Variant Values` and triggering Odoo recalculations.
- Replace brittle file whitelist with a secure path/extension validation to allow newer export artifacts to be downloadable while preventing directory traversal and unsafe file types.
- Keep repo metadata in sync by bumping `EXPORTER_VERSION`, README version, and adding detailed changelog entries for recent releases.

### Description
- Added a safety dedupe in `OdooMigrationService` that detects duplicates by `(product_tmpl_id/id, Variant Values)`, appends validation rows explaining potential Odoo constraint violations, and drops extra rows before writing `odoo_product_variant_internal_references.csv`.
- Introduced `odoo_product_variant_update_by_id_safe.csv` as a generated placeholder during run creation and as an alias populated in `/phase2/merge` with minimal columns (`id`, `Internal Reference`, `Barcode`, `Sales Price`, `Cost`) to support safe updates by `id`.
- Hardened file download logic in `backend/app/odoo_migration/router.py` by validating filenames against path traversal, ensuring the resolved path is inside the run folder, and restricting allowed extensions to `{'.csv', '.log', '.md', '.json'}`; also extended `_build_files` and merge API responses to include the new file aliases.
- Bumped `EXPORTER_VERSION` to `1.5.10`, updated `README.MD` version to `1.0.64`, and expanded `CHANGELOG.md` with entries for `1.0.60` through `1.0.64` describing the changes above.

### Testing
- Ran the test suite with `pytest -q` against the modified backend modules and the test run completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff29c335c083328ffc8763640fcb43)