### PR TITLE
Phase2: safe variant-update CSV, dedupe by (template + Variant Values), SKU fallback matching, and secure file download/manifest updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,35 @@
 - Duplicados en Fase 1 vuelven a modo estricto por defecto (`strict_duplicate_errors=True`) para no ocultar problemas de calidad de datos.
 - Nuevo fallback para Fase 2: variantes sin atributos válidos pueden exportarse como simples (`fallback_orphan_variants_to_simple=True`) en lugar de perderse.
 - Se añade `fallback_orphan_variants_to_simple` al `run_summary.json`.
+
+## 1.0.60 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.6.
+- Se agrega guardarraíl en Fase 2 para detectar y deduplicar por (`product_tmpl_id/id`, `Variant Values`) antes de exportar `odoo_product_variant_internal_references.csv`.
+- Se reportan nuevas validaciones de riesgo para prevenir el error de unicidad de Odoo `product_product_combination_unique`.
+- Se genera en `docs/odoo_import_templates/Last` un CSV saneado de variantes (`odoo_product_variant_internal_references_clean.csv`) listo para importación segura.
+
+## 1.0.61 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.7.
+- Se elimina el artefacto pesado `odoo_product_variant_internal_references_clean.csv` del repo (debe generarse por corrida, no versionarse).
+- Nuevo script `backend/build_safe_variant_update_csv.py` para construir un CSV de actualización segura por `id` + `Internal Reference` + `Barcode` sin tocar `Variant Values` (evita que Odoo recalcule `combination_indices=''`).
+
+## 1.0.62 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.8.
+- Se elimina el flujo apoyado en `docs/odoo_import_templates/Last` para artefactos auxiliares; la operación queda centrada en archivos del `run_id` generado desde frontend.
+- Descarga de archivos de run mejorada: se reemplaza whitelist rígida por validación segura de ruta/extensión (`.csv`, `.log`, `.md`, `.json`) para evitar que archivos generados en nuevas fases aparezcan pero no se puedan descargar.
+- Se agregan a la respuesta estándar de archivos los outputs `odoo_phase2_simples_minimal.csv` y `odoo_phase2_simples_unmatched.csv` cuando existan.
+
+## 1.0.63 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.9.
+- Se agrega salida alias en cada `run_id`: `odoo_product_variant_update_by_id_safe.csv` (mismo contenido que `odoo_phase2_with_odoo_ids_minimal.csv`) para facilitar operación.
+- Se expone este archivo en los links del frontend/API (`_build_files` y respuesta de `/runs/{run_id}/phase2/merge`).
+
+## 1.0.64 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.10.
+- Se genera `odoo_product_variant_update_by_id_safe.csv` desde el momento de creación del run (placeholder con header), para que siempre exista en descargas aun antes de ejecutar `/phase2/merge`.
+- Al ejecutar `/phase2/merge`, ese archivo se rellena con las filas matched por `id` para importación segura.
+
+## 1.0.65 - 2026-05-09
+- Exportador Odoo actualizado a versión 1.5.11.
+- Mejora crítica en `/phase2/merge`: si no hay match por `(template_id + variant_values)` ni por `(template_name + variant_values)`, ahora se aplica fallback por SKU (`Internal Reference` ↔ `default_code` del export de Odoo).
+- Esto evita casos de `odoo_product_variant_update_by_id_safe.csv` vacío cuando Odoo exporta variantes con `product_template_variant_value_ids` distintos o vacíos.

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Migrador ContificoToOdoo
 
-Versión 1.0.59
+Versión 1.0.65
 
 Repositorio reorientado para migrar de Contífico a Odoo de manera ordenada. Conserva el frontend y una API FastAPI ya integrada con gran parte de la funcionalidad operativa, y ahora prioriza la extracción, normalización y carga de datos críticos hacia Odoo.
 

--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -53,6 +53,9 @@ def _build_files(run_id: str) -> dict[str, str]:
         "fase2_merged_with_odoo_ids_csv": f"{base}/odoo_phase2_with_odoo_ids.csv",
         "fase2_merged_unmatched_csv": f"{base}/odoo_phase2_merger_unmatched.csv",
         "fase2_merged_unused_odoo_csv": f"{base}/odoo_phase2_merger_unused_odoo.csv",
+        "fase2_merged_simples_unmatched_csv": f"{base}/odoo_phase2_simples_unmatched.csv",
+        "fase2_merged_simples_minimal_csv": f"{base}/odoo_phase2_simples_minimal.csv",
+        "fase2_variant_update_by_id_safe_csv": f"{base}/odoo_product_variant_update_by_id_safe.csv",
         # === Reportes de calidad (no importar) ===
         "reporte_errores_csv": f"{base}/migration_errors.csv",
         "reporte_mapping_csv": f"{base}/mapping_report.csv",
@@ -309,63 +312,16 @@ def list_runs(limit: int = Query(default=10, ge=1, le=100)):
 
 @router.get("/runs/{run_id}/files/{filename}")
 def download_file(run_id: str, filename: str):
-    allowed = {
-        "product_product.csv",
-        "initial_stock.csv",
-        "stock_quant.csv",
-        "stock_quant_legacy.csv",
-        "migration_errors.csv",
-        "mapping_report.csv",
-        "excluded_zero_stock.csv",
-        "debug.log",
-        "raw.log",
-        "stock_errors.csv",
-        "01_product_templates_with_existing_attributes.csv",
-        "02_variant_update_map.csv",
-        "03_stock_quant_by_variant.csv",
-        "04_missing_attribute_values_report.csv",
-        "import_products_and_variants_report.md",
-        "unmapped_categories.csv",
-        "run_summary.json",
-        "odoo_external_id_conflicts.csv",
-        "odoo_barcode_conflicts.csv",
-        "odoo_missing_products_for_stock.csv",
-        "odoo_duplicate_variant_combinations.csv",
-        "odoo_import_validation_report.csv",
-        "odoo_attribute_rejections.csv",
-        "odoo_product_templates_with_attributes.csv",
-        "odoo_product_templates_simple.csv",
-        "odoo_stock_quant.csv",
-        "odoo_variant_sku_mapping.csv",
-        "odoo_product_templates.csv",
-        "product_internal_reference_update.csv",
-        "product_internal_reference_barcode_conflicts.csv",
-        "odoo_product_variant_internal_references.csv",
-        "odoo_product_variant_internal_references_no_barcode.csv",
-        "odoo_phase2_variant_internal_reference_validation.csv",
-        "odoo_phase2_duplicate_variant_keys.csv",
-        "odoo_phase2_missing_stock_references.csv",
-        "odoo_phase2_csv_format_errors.csv",
-        "odoo_compare_only_in_contifico.csv",
-        "odoo_compare_only_in_odoo.csv",
-        "odoo_compare_in_both.csv",
-        "odoo_missing_simple_for_import.csv",
-        "odoo_missing_templates_with_attributes.csv",
-        "odoo_missing_variants_phase2.csv",
-        "odoo_phase2_with_odoo_ids.csv",
-        "odoo_phase2_with_odoo_ids_minimal.csv",
-        "odoo_phase2_simples_minimal.csv",
-        "odoo_phase2_merger_unmatched.csv",
-        "odoo_phase2_simples_unmatched.csv",
-        "odoo_phase2_merger_unused_odoo.csv",
-        "odoo_phase1_template_renames.csv",
-        "odoo_phase2_orphaned_skus.csv",
-    }
-    if filename not in allowed:
-        raise HTTPException(status_code=400, detail="Archivo no permitido")
-    file_path = _output_root() / run_id / filename
+    if "/" in filename or "\\" in filename or filename.startswith("."):
+        raise HTTPException(status_code=400, detail="Nombre de archivo inválido")
+    file_path = (_output_root() / run_id / filename).resolve()
+    run_root = (_output_root() / run_id).resolve()
+    if run_root not in file_path.parents:
+        raise HTTPException(status_code=400, detail="Ruta de archivo inválida")
     if not file_path.exists() or not file_path.is_file():
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
+    if file_path.suffix.lower() not in {".csv", ".log", ".md", ".json"}:
+        raise HTTPException(status_code=400, detail="Tipo de archivo no permitido")
     media_type = "text/plain; charset=utf-8" if filename.endswith(('.log', '.md')) else "text/csv; charset=utf-8"
     return FileResponse(path=file_path, filename=filename, media_type=media_type)
 
@@ -440,7 +396,7 @@ async def merge_phase2_with_odoo_export(run_id: str, file: UploadFile = File(...
     instead of creating duplicates.
 
     Expected Odoo export columns:
-      id | id | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids
+      id | default_code | product_tmpl_id/id | product_tmpl_id/name | product_template_variant_value_ids
     """
     run_folder = _output_root() / run_id
     if not run_folder.exists():
@@ -469,6 +425,7 @@ async def merge_phase2_with_odoo_export(run_id: str, file: UploadFile = File(...
         "files": {
             "phase2_with_odoo_ids": f"{base}/odoo_phase2_with_odoo_ids.csv",
             "phase2_with_odoo_ids_minimal": f"{base}/odoo_phase2_with_odoo_ids_minimal.csv",
+            "phase2_variant_update_by_id_safe": f"{base}/odoo_product_variant_update_by_id_safe.csv",
             "simples_minimal": f"{base}/odoo_phase2_simples_minimal.csv",
             "unmatched": f"{base}/odoo_phase2_merger_unmatched.csv",
             "simples_unmatched": f"{base}/odoo_phase2_simples_unmatched.csv",

--- a/backend/app/odoo_migration/service.py
+++ b/backend/app/odoo_migration/service.py
@@ -56,7 +56,7 @@ INTERNAL_REF_UPDATE_COLUMNS = [
 INTERNAL_REF_CONFLICT_COLUMNS = [
     "barcode", "conflicting_internal_references", "count", "reason",
 ]
-EXPORTER_VERSION = "1.5.5"
+EXPORTER_VERSION = "1.5.11"
 
 
 def _to_odoo_bool(value: Any) -> str:
@@ -250,6 +250,8 @@ class OdooMigrationService:
         self._write_csv(folder / "odoo_external_id_conflicts.csv", ["external_id","source_sku","source_id","source_name","category","price","classification","reason"], external_id_conflicts)
         self._write_phase2_variant_internal_reference_outputs(folder=folder, variant_map_rows=o19_variant_map_rows, with_attr_rows=with_attr_rows, simple_rows=simple_rows, stock_rows=o19_stock_rows)
         self._write_internal_reference_update_csv(folder=folder, simple_rows=simple_rows, variant_map_rows=o19_variant_map_rows, variant_rows_raw=phase1.get("variant_rows", []))
+        # Placeholder: archivo de actualización segura por id (se completa en /phase2/merge)
+        self._write_csv(folder / "odoo_product_variant_update_by_id_safe.csv", ["id", "Internal Reference", "Barcode", "Sales Price", "Cost"], [])
         barcode_index: dict[str, list[str]] = {}
         for r in o19_variant_map_rows:
             bc = str(r.get("Barcode") or r.get("Internal Reference") or "").strip()
@@ -609,11 +611,14 @@ class OdooMigrationService:
         sku_counts = {}
         barcode_counts = {}
         key_counts = {}
+        template_combo_counts = {}
         for r in variant_rows:
             sku_counts[r["Internal Reference"]] = sku_counts.get(r["Internal Reference"], 0) + 1
             barcode_counts[r["Barcode"]] = barcode_counts.get(r["Barcode"], 0) + 1
             k=(r["Name"], r["Variant Values"])
             key_counts[k] = key_counts.get(k, 0) + 1
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            template_combo_counts[template_combo] = template_combo_counts.get(template_combo, 0) + 1
 
         duplicate_key_rows = []
         for r in variant_rows:
@@ -625,6 +630,24 @@ class OdooMigrationService:
             if key_counts.get(key,0)>1:
                 validation_rows.append({"issue_type":"Duplicate Name + Variant Values","product_template_external_id":"","product_template_name":r["Name"],"internal_reference":sku,"barcode":bc,"variant_values":r["Variant Values"],"source_sku":sku,"reason":"Variant key duplicated"})
                 duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":sku,"barcode":bc,"source_sku":sku,"reason":"Duplicate Name + Variant Values"})
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            if template_combo_counts.get(template_combo, 0) > 1:
+                validation_rows.append({"issue_type":"Duplicate product_tmpl_id + Variant Values","product_template_external_id":str(r.get("product_tmpl_id/id") or "").replace("__import__.", ""),"product_template_name":r["Name"],"internal_reference":sku,"barcode":bc,"variant_values":r["Variant Values"],"source_sku":sku,"reason":"Would violate Odoo unique constraint product_product_combination_unique"})
+                duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":sku,"barcode":bc,"source_sku":sku,"reason":"Duplicate product_tmpl_id + Variant Values"})
+
+        # Hard safety net for Odoo constraint:
+        # product_product_combination_unique requires one row per (template, variant values).
+        deduped_variant_rows = []
+        seen_template_combo: set[tuple[str, str]] = set()
+        for r in variant_rows:
+            template_combo = (r["product_tmpl_id/id"], r["Variant Values"])
+            if template_combo in seen_template_combo:
+                validation_rows.append({"issue_type":"Dropped duplicate product_tmpl_id + Variant Values","product_template_external_id":str(r.get("product_tmpl_id/id") or "").replace("__import__.", ""),"product_template_name":r["Name"],"internal_reference":r["Internal Reference"],"barcode":r["Barcode"],"variant_values":r["Variant Values"],"source_sku":r["Internal Reference"],"reason":"Safety dedupe applied before CSV export"})
+                duplicate_key_rows.append({"product_template_name":r["Name"],"variant_values":r["Variant Values"],"internal_reference":r["Internal Reference"],"barcode":r["Barcode"],"source_sku":r["Internal Reference"],"reason":"Dropped duplicate product_tmpl_id + Variant Values"})
+                continue
+            seen_template_combo.add(template_combo)
+            deduped_variant_rows.append(r)
+        variant_rows = deduped_variant_rows
 
         simple_skus = {str(r.get("Internal Reference") or "").strip() for r in simple_rows if str(r.get("Internal Reference") or "").strip()}
         variant_skus = {r["Internal Reference"] for r in variant_rows}
@@ -1322,12 +1345,14 @@ class OdooMigrationService:
         #   fallback: (norm_name, norm_variant_values) — used when template IDs don't match
         tmpl_id_lookup: dict[tuple, str] = {}   # primary: (tmpl_id, frozenset_variants) → pp_ext_id
         name_lookup: dict[tuple, str] = {}       # fallback: (norm_name, frozenset_variants) → pp_ext_id
+        sku_lookup: dict[str, str] = {}          # fallback 2: sku/default_code -> pp_ext_id
         odoo_pp_to_key: dict[str, tuple] = {}   # pp_ext_id → primary key (for used-tracking)
         all_odoo_rows: list[dict[str, str]] = []
 
         with odoo_export_csv.open("r", newline="", encoding="utf-8-sig") as f:
             for row in csv.DictReader(f):
                 pp_ext_id = str(row.get("id") or "").strip()
+                sku = str(row.get("default_code") or "").strip()
                 tmpl_id = str(row.get("product_tmpl_id/id") or "").strip()
                 tmpl_name = str(row.get("product_tmpl_id/name") or "").strip()
                 variant_vals = str(row.get("product_template_variant_value_ids") or "").strip()
@@ -1341,6 +1366,8 @@ class OdooMigrationService:
                 if tmpl_name:
                     fallback_key = (_norm_name(tmpl_name), norm_vars)
                     name_lookup[fallback_key] = pp_ext_id
+                if sku:
+                    sku_lookup.setdefault(sku.casefold(), pp_ext_id)
                 all_odoo_rows.append({"pp_ext_id": pp_ext_id, "tmpl_id": tmpl_id, "tmpl_name": tmpl_name, "variant_values": variant_vals})
 
         # Process Phase 2 CSV and match each row — try primary key first, then fallback
@@ -1349,6 +1376,7 @@ class OdooMigrationService:
         odoo_keys_used: set[str] = set()  # set of pp_ext_ids that were matched
         matched_by_tmpl_id = 0
         matched_by_name = 0
+        matched_by_sku = 0
 
         with phase2_csv.open("r", newline="", encoding="utf-8-sig") as f:
             for row in csv.DictReader(f):
@@ -1375,6 +1403,14 @@ class OdooMigrationService:
                     if pp_ext_id:
                         match_method = "name"
                         matched_by_name += 1
+                # Fallback 2: match by SKU/default_code from Odoo export.
+                if pp_ext_id is None:
+                    sku_key = str(row.get("Internal Reference") or "").strip().casefold()
+                    if sku_key:
+                        pp_ext_id = sku_lookup.get(sku_key)
+                        if pp_ext_id:
+                            match_method = "sku"
+                            matched_by_sku += 1
 
                 if pp_ext_id:
                     odoo_keys_used.add(pp_ext_id)
@@ -1424,6 +1460,8 @@ class OdooMigrationService:
         self._write_csv(output_folder / "odoo_phase2_with_odoo_ids.csv", matched_cols, matched_rows)
         # Minimal CSV: only id + fields to update — no Name/Variant Values to avoid Odoo relational field validation
         self._write_csv(output_folder / "odoo_phase2_with_odoo_ids_minimal.csv", minimal_cols, matched_rows)
+        # Alias operativo solicitado por negocio para importación segura por id
+        self._write_csv(output_folder / "odoo_product_variant_update_by_id_safe.csv", minimal_cols, matched_rows)
         self._write_csv(output_folder / "odoo_phase2_simples_minimal.csv", simples_minimal_cols, simple_matched_rows)
         self._write_csv(output_folder / "odoo_phase2_merger_unmatched.csv", unmatched_cols, unmatched_rows)
         self._write_csv(output_folder / "odoo_phase2_simples_unmatched.csv", simples_unmatched_cols, simple_unmatched_rows)
@@ -1435,6 +1473,7 @@ class OdooMigrationService:
             "unmatched": len(unmatched_rows),
             "matched_by_tmpl_id": matched_by_tmpl_id,
             "matched_by_name": matched_by_name,
+            "matched_by_sku": matched_by_sku,
             "total_odoo_rows": len(all_odoo_rows),
             "unused_odoo_rows": len(unused_odoo_rows),
             "simple_matched": len(simple_matched_rows),


### PR DESCRIPTION
### Motivation
- Prevent Odoo uniqueness errors and data loss when updating variants by ensuring only one row per `(product_tmpl_id/id, Variant Values)` is exported. 
- Provide a safe, id-based CSV for updating existing `product.product` rows without touching `Variant Values` to avoid Odoo recalculation issues. 
- Improve robustness of the API file download endpoint to avoid path traversal and to allow future phase outputs to be downloadable safely. 

### Description
- Bumped `EXPORTER_VERSION` to `1.5.11` and updated `CHANGELOG.md` and `README.MD` to reflect new releases. 
- Implemented a guardrail in `OdooMigrationService` that detects and reports duplicates by `(product_tmpl_id/id, Variant Values)`, emits validation rows, and drops extra duplicates before writing `odoo_product_variant_internal_references.csv`. 
- Added generation of a placeholder and an alias operational file `odoo_product_variant_update_by_id_safe.csv` (created at run time and filled during `/phase2/merge`) and ensured it is written from both run creation and merge operations. 
- Enhanced matching logic in `merge_phase2_with_odoo_export` to include a SKU/default_code fallback lookup and added the `matched_by_sku` metric; wrote out additional simple/simples/unmatched outputs and exposed the new file links in `_build_files` and the merge response. 
- Replaced the static filename whitelist in the download endpoint with secure path validation and file extension checks, and added support for `.csv`, `.log`, `.md`, and `.json` extensions. 

### Testing
- Ran the repository's automated test suite with `pytest` and the updated service/route behavior locally, and all tests passed. 
- Verified that existing CSV outputs are produced in `backend/data/odoo_migration` and that `/runs/{run_id}/phase2/merge` now fills `odoo_product_variant_update_by_id_safe.csv` and returns the new file links.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff29c335c083328ffc8763640fcb43)