### PR TITLE
feat: Comparador de Stock Odoo vs Contífico (cantidades)

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from threading import Lock, Thread
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File, Form
 from fastapi.responses import FileResponse
 
 from ..contifico import ContificoClient
@@ -13,6 +13,7 @@ from ..dependencies import get_contifico_client
 from ..config import get_settings
 from .rules import CATEGORY_ALIASES
 from .service import OdooMigrationService
+from .stock_comparator import compare_stock
 from .stock_worker import StockWorker
 
 router = APIRouter(prefix="/odoo-migration", tags=["Odoo Migration"])
@@ -507,3 +508,93 @@ def resume_stock(run_id: str):
         raise HTTPException(status_code=404, detail='Worker no encontrado')
     w.resume(); STOCK_JOBS[run_id] = {**STOCK_JOBS.get(run_id, {}), 'status': 'running'}
     return STOCK_JOBS[run_id]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Comparador de inventario (standalone – no requiere run_id)
+# ──────────────────────────────────────────────────────────────────────────────
+
+COMPARE_JOBS: dict[str, dict] = {}
+COMPARE_LOCK = Lock()
+
+
+def _compare_output_root() -> Path:
+    return Path("backend/data/odoo_migration/stock_compare")
+
+
+@router.post("/compare-stock")
+async def compare_stock_endpoint(
+    odoo_file: UploadFile = File(..., description="Export de inventario Odoo (CSV)"),
+    contifico_file: UploadFile = File(..., description="Archivo de inventario Contífico"),
+    source_type: str = Form(
+        "csv_bodegas",
+        description="Tipo de fuente Contífico: csv_simple | csv_bodegas | raw_log",
+    ),
+):
+    """Compara cantidades de stock entre un export de Odoo y un archivo de inventario Contífico.
+
+    **source_type**:
+    - `csv_simple`  → ReporteSaldosInventario.csv
+    - `csv_bodegas` → ReporteSaldosInventarioPorBodega.csv (incluye desglose por bodega)
+    - `raw_log`     → raw.log (respuestas JSON de la API de Contífico)
+
+    Genera cuatro CSVs:
+    - `stock_compare_full.csv`             – todos los SKUs presentes en ambos sistemas
+    - `stock_compare_differ.csv`           – solo los SKUs con diferencias de stock
+    - `stock_compare_only_contifico.csv`   – SKUs solo en Contífico (faltan en Odoo)
+    - `stock_compare_only_odoo.csv`        – SKUs solo en Odoo (faltan en Contífico)
+    """
+    if source_type not in ("csv_simple", "csv_bodegas", "raw_log"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"source_type inválido: {source_type!r}. Usa: csv_simple | csv_bodegas | raw_log",
+        )
+
+    job_id = uuid4().hex[:12]
+    output_folder = _compare_output_root() / job_id
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    # Persist uploaded files
+    odoo_path = output_folder / "odoo_upload.csv"
+    contifico_path = output_folder / f"contifico_upload_{source_type}"
+    odoo_path.write_bytes(await odoo_file.read())
+    contifico_path.write_bytes(await contifico_file.read())
+
+    try:
+        result = compare_stock(
+            odoo_path=odoo_path,
+            contifico_path=contifico_path,
+            source_type=source_type,
+            output_folder=output_folder,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    with COMPARE_LOCK:
+        COMPARE_JOBS[job_id] = {"job_id": job_id, **result}
+
+    base = f"/odoo-migration/compare-stock/{job_id}/files"
+    return {
+        "job_id": job_id,
+        **result,
+        "files": {
+            "full_comparison": f"{base}/stock_compare_full.csv",
+            "differ": f"{base}/stock_compare_differ.csv",
+            "only_in_contifico": f"{base}/stock_compare_only_contifico.csv",
+            "only_in_odoo": f"{base}/stock_compare_only_odoo.csv",
+        },
+    }
+
+
+@router.get("/compare-stock/{job_id}/files/{filename}")
+def download_compare_file(job_id: str, filename: str):
+    """Descarga uno de los CSVs generados por el comparador de stock."""
+    safe_name = Path(filename).name  # strip any path traversal
+    file_path = _compare_output_root() / job_id / safe_name
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Archivo no encontrado")
+    return FileResponse(
+        path=file_path,
+        filename=safe_name,
+        media_type="text/csv; charset=utf-8",
+    )

--- a/backend/app/odoo_migration/stock_comparator.py
+++ b/backend/app/odoo_migration/stock_comparator.py
@@ -1,0 +1,403 @@
+"""Standalone inventory-quantity comparator.
+
+Compares stock levels between an Odoo inventory export and a Contifico
+inventory report (multiple source formats supported).
+
+Supported Contifico sources:
+  csv_simple   – ReporteSaldosInventario.csv       (semicolon, 5 header rows)
+  csv_bodegas  – ReporteSaldosInventarioPorBodega.csv (semicolon, 5 header rows)
+  raw_log      – raw.log (newline-delimited JSON pages, field: cantidad_stock)
+
+Supported Odoo sources:
+  auto-detected from column names:
+    • Simple export : Internal Reference | name_odoo | qty_available | barcode
+    • Full export   : id | default_code | name | qty_available | ...
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Parsing helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _parse_qty(value: str) -> float:
+    """Convert a Spanish-locale number string to float."""
+    v = str(value or "0").strip().replace(",", ".").replace(" ", "")
+    try:
+        return float(v)
+    except ValueError:
+        return 0.0
+
+
+def _open_csv(path: Path) -> io.TextIOWrapper:
+    """Open a CSV that may be UTF-8, UTF-8-BOM, or Latin-1."""
+    for enc in ("utf-8-sig", "utf-8", "latin-1"):
+        try:
+            f = path.open("r", newline="", encoding=enc)
+            f.read(512)
+            f.seek(0)
+            return f
+        except UnicodeDecodeError:
+            pass
+    return path.open("r", newline="", encoding="latin-1", errors="replace")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Odoo loader
+# ──────────────────────────────────────────────────────────────────────────────
+
+def load_odoo_stock(path: Path) -> dict[str, dict]:
+    """Return {sku_lower: {sku, name, qty, barcode}} from an Odoo product export."""
+    result: dict[str, dict] = {}
+    with _open_csv(path) as f:
+        reader = csv.DictReader(f)
+        headers = reader.fieldnames or []
+
+        # Detect format: simple vs full export
+        if "Internal Reference" in headers:
+            sku_col, qty_col, name_col, bc_col = (
+                "Internal Reference", "qty_available", "name_odoo", "barcode"
+            )
+        elif "default_code" in headers:
+            sku_col, qty_col, name_col, bc_col = (
+                "default_code", "qty_available", "name", "barcode"
+            )
+        else:
+            raise ValueError(
+                f"Formato de exportación Odoo no reconocido. "
+                f"Se esperaba 'Internal Reference' o 'default_code'. "
+                f"Columnas encontradas: {headers}"
+            )
+
+        for row in reader:
+            sku = str(row.get(sku_col) or "").strip()
+            if not sku:
+                continue
+            key = sku.casefold()
+            if key not in result:
+                result[key] = {
+                    "sku": sku,
+                    "name": str(row.get(name_col) or "").strip(),
+                    "qty": _parse_qty(row.get(qty_col) or "0"),
+                    "barcode": str(row.get(bc_col) or "").strip(),
+                }
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Contifico loaders
+# ──────────────────────────────────────────────────────────────────────────────
+
+_CONTIFICO_HEADER_ROWS = 5  # company, report title, date, blank, (optional group row)
+
+_BODEGAS_WAREHOUSE_COLS = [
+    "Almacenes",
+    "Bodegas Principales",
+    "Bodegas Showroom",
+    "Oficina Adams",
+    "Bodega Mercaderia en Transito",
+    "Bodega 2",
+    "Bodega Web",
+    "BODEGAS BATAN",
+    "Bodegas Muestras",
+    "BODEGAS TEMPORALES LAVANDERIA",
+]
+
+_BODEGAS_WAREHOUSE_KEYS = [
+    "almacenes",
+    "bodegas_principales",
+    "showroom",
+    "oficina_adams",
+    "en_transito",
+    "bodega_2",
+    "bodega_web",
+    "batan",
+    "muestras",
+    "temporales_lavanderia",
+]
+
+
+def _skip_contifico_headers(f: io.TextIOWrapper, delimiter: str = ";") -> csv.DictReader:
+    """Skip the Contifico multi-row file header and return a DictReader."""
+    lines = []
+    for _ in range(_CONTIFICO_HEADER_ROWS):
+        lines.append(f.readline())
+    return csv.DictReader(f, delimiter=delimiter)
+
+
+def _normalize_header(h: str) -> str:
+    """Strip BOM, whitespace, and common accent variations."""
+    return (
+        h.strip()
+        .lstrip("﻿")
+        .replace("\r", "")
+        .replace("ó", "o")
+        .replace("á", "a")
+        .replace("é", "e")
+        .replace("í", "i")
+        .replace("ú", "u")
+        .replace("Ó", "O")
+        .replace("Á", "A")
+        .replace("É", "E")
+        .replace("Í", "I")
+        .replace("Ú", "U")
+    )
+
+
+def _find_col(row: dict, *candidates: str) -> str | None:
+    """Case-insensitive lookup across normalized column names."""
+    norm = {_normalize_header(k): k for k in row.keys()}
+    for c in candidates:
+        nc = _normalize_header(c)
+        if nc in norm:
+            return norm[nc]
+    return None
+
+
+def load_contifico_simple(path: Path) -> dict[str, dict]:
+    """Load ReporteSaldosInventario.csv → {sku_lower: {sku, name, qty, categoria, marca}}."""
+    result: dict[str, dict] = {}
+    with _open_csv(path) as f:
+        reader = _skip_contifico_headers(f)
+        for row in reader:
+            sku_col = _find_col(row, "Código", "Codigo", "Codigo Catalogo")
+            stock_col = _find_col(row, "Stock")
+            nombre_col = _find_col(row, "Nombre")
+            cat_col = _find_col(row, "Categoría", "Categoria")
+            marca_col = _find_col(row, "Marca")
+
+            if not sku_col:
+                continue
+            sku = str(row.get(sku_col) or "").strip()
+            if not sku:
+                continue
+            key = sku.casefold()
+            if key not in result:
+                result[key] = {
+                    "sku": sku,
+                    "name": str(row.get(nombre_col) or "").strip() if nombre_col else "",
+                    "qty": _parse_qty(row.get(stock_col) or "0") if stock_col else 0.0,
+                    "categoria": str(row.get(cat_col) or "").strip() if cat_col else "",
+                    "marca": str(row.get(marca_col) or "").strip() if marca_col else "",
+                }
+    return result
+
+
+def load_contifico_bodegas(path: Path) -> dict[str, dict]:
+    """Load ReporteSaldosInventarioPorBodega.csv → {sku_lower: {sku, name, qty, warehouses...}}."""
+    result: dict[str, dict] = {}
+    with _open_csv(path) as f:
+        reader = _skip_contifico_headers(f)
+        for row in reader:
+            sku_col = _find_col(row, "Código", "Codigo")
+            total_col = _find_col(row, "Total General")
+            nombre_col = _find_col(row, "Producto", "Nombre")
+            cat_col = _find_col(row, "Categoría", "Categoria")
+            marca_col = _find_col(row, "Marca")
+
+            if not sku_col:
+                continue
+            sku = str(row.get(sku_col) or "").strip()
+            if not sku:
+                continue
+
+            qty_total = _parse_qty(row.get(total_col) or "0") if total_col else 0.0
+
+            warehouses: dict[str, float] = {}
+            for col_name, key in zip(_BODEGAS_WAREHOUSE_COLS, _BODEGAS_WAREHOUSE_KEYS):
+                found = _find_col(row, col_name)
+                if found:
+                    warehouses[key] = _parse_qty(row.get(found) or "0")
+
+            key = sku.casefold()
+            if key not in result:
+                result[key] = {
+                    "sku": sku,
+                    "name": str(row.get(nombre_col) or "").strip() if nombre_col else "",
+                    "qty": qty_total,
+                    "categoria": str(row.get(cat_col) or "").strip() if cat_col else "",
+                    "marca": str(row.get(marca_col) or "").strip() if marca_col else "",
+                    **{f"wh_{k}": v for k, v in warehouses.items()},
+                }
+    return result
+
+
+def load_contifico_raw_log(path: Path) -> dict[str, dict]:
+    """Load raw.log (newline-delimited JSON pages) → {sku_lower: {sku, name, qty, ...}}."""
+    result: dict[str, dict] = {}
+    with _open_csv(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            products = obj.get("response", []) if isinstance(obj, dict) else []
+            if isinstance(obj, list):
+                products = obj
+            for p in products:
+                if not isinstance(p, dict):
+                    continue
+                sku = str(p.get("codigo") or "").strip()
+                if not sku:
+                    continue
+                key = sku.casefold()
+                if key not in result:
+                    result[key] = {
+                        "sku": sku,
+                        "name": str(p.get("nombre") or "").strip(),
+                        "qty": float(p.get("cantidad_stock") or 0),
+                        "marca": str(p.get("marca_nombre") or "").strip(),
+                        "categoria": "",
+                        "barcode": str(p.get("codigo_barra") or "").strip(),
+                        "precio": float(p.get("pvp1") or 0),
+                    }
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Main comparator
+# ──────────────────────────────────────────────────────────────────────────────
+
+def compare_stock(
+    *,
+    odoo_path: Path,
+    contifico_path: Path,
+    source_type: str,
+    output_folder: Path,
+) -> dict[str, Any]:
+    """Compare Odoo vs Contifico inventory quantities.
+
+    Args:
+        odoo_path:        Odoo inventory CSV export.
+        contifico_path:   Contifico inventory file.
+        source_type:      One of 'csv_simple', 'csv_bodegas', 'raw_log'.
+        output_folder:    Directory where output CSVs are written.
+
+    Returns:
+        Summary dict with counts, totals, and delta stats.
+    """
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    # Load data
+    odoo = load_odoo_stock(odoo_path)
+
+    loaders = {
+        "csv_simple": load_contifico_simple,
+        "csv_bodegas": load_contifico_bodegas,
+        "raw_log": load_contifico_raw_log,
+    }
+    if source_type not in loaders:
+        raise ValueError(f"source_type inválido: {source_type!r}. Usa: {list(loaders)}")
+    contifico = loaders[source_type](contifico_path)
+
+    contifico_keys = set(contifico.keys())
+    odoo_keys = set(odoo.keys())
+
+    only_contifico = sorted(contifico_keys - odoo_keys)
+    only_odoo = sorted(odoo_keys - contifico_keys)
+    in_both = sorted(contifico_keys & odoo_keys)
+
+    # Build comparison rows for products in both
+    full_rows: list[dict] = []
+    differ_rows: list[dict] = []
+
+    for key in in_both:
+        c = contifico[key]
+        o = odoo[key]
+        qty_c = c["qty"]
+        qty_o = o["qty"]
+        delta = round(qty_o - qty_c, 4)
+
+        row: dict[str, Any] = {
+            "SKU": c["sku"],
+            "Nombre Contifico": c.get("name", ""),
+            "Nombre Odoo": o.get("name", ""),
+            "Stock Contifico": qty_c,
+            "Stock Odoo": qty_o,
+            "Delta (Odoo-Contifico)": delta,
+            "Match": "SI" if delta == 0 else "NO",
+        }
+        if source_type == "csv_bodegas":
+            for k in _BODEGAS_WAREHOUSE_KEYS:
+                row[f"Contifico - {k}"] = c.get(f"wh_{k}", 0.0)
+        full_rows.append(row)
+        if delta != 0:
+            differ_rows.append(row)
+
+    full_rows.sort(key=lambda r: r["SKU"])
+    differ_rows.sort(key=lambda r: r["SKU"])
+
+    # Only-in-Contifico rows
+    only_c_rows = sorted(
+        [
+            {
+                "SKU": contifico[k]["sku"],
+                "Nombre": contifico[k].get("name", ""),
+                "Categoria": contifico[k].get("categoria", ""),
+                "Marca": contifico[k].get("marca", ""),
+                "Stock Contifico": contifico[k]["qty"],
+            }
+            for k in only_contifico
+        ],
+        key=lambda r: r["SKU"],
+    )
+
+    # Only-in-Odoo rows
+    only_o_rows = sorted(
+        [
+            {
+                "SKU": odoo[k]["sku"],
+                "Nombre": odoo[k].get("name", ""),
+                "Barcode": odoo[k].get("barcode", ""),
+                "Stock Odoo": odoo[k]["qty"],
+            }
+            for k in only_odoo
+        ],
+        key=lambda r: r["SKU"],
+    )
+
+    # Write CSVs
+    def write_csv(filepath: Path, rows: list[dict]) -> None:
+        if not rows:
+            filepath.write_text("(sin datos)\n", encoding="utf-8")
+            return
+        with filepath.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+    write_csv(output_folder / "stock_compare_full.csv", full_rows)
+    write_csv(output_folder / "stock_compare_differ.csv", differ_rows)
+    write_csv(output_folder / "stock_compare_only_contifico.csv", only_c_rows)
+    write_csv(output_folder / "stock_compare_only_odoo.csv", only_o_rows)
+
+    # Stats
+    match_count = len(in_both) - len(differ_rows)
+    total_stock_c = sum(contifico[k]["qty"] for k in contifico_keys)
+    total_stock_o = sum(odoo[k]["qty"] for k in odoo_keys)
+
+    return {
+        "contifico_total_skus": len(contifico),
+        "odoo_total_skus": len(odoo),
+        "in_both": len(in_both),
+        "match": match_count,
+        "differ": len(differ_rows),
+        "only_in_contifico": len(only_contifico),
+        "only_in_odoo": len(only_odoo),
+        "total_stock_contifico": round(total_stock_c, 2),
+        "total_stock_odoo": round(total_stock_o, 2),
+        "delta_global": round(total_stock_o - total_stock_c, 2),
+        "source_type": source_type,
+        "preview_differ": [r["SKU"] for r in differ_rows[:30]],
+        "preview_only_contifico": [only_c_rows[i]["SKU"] for i in range(min(30, len(only_c_rows)))],
+        "preview_only_odoo": [only_o_rows[i]["SKU"] for i in range(min(30, len(only_o_rows)))],
+    }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -456,6 +456,112 @@ $('generateMissingImport').addEventListener('click', async () => {
   }
 });
 
+// ── Comparador de Stock (cantidades) ────────────────────────────────────────
+
+function setStockCompareStatus(msg) { const el=$('stockCompareStatus'); if(el) el.textContent=msg||''; }
+
+function renderStockCompareStats(data) {
+  const el = $('stockCompareStats');
+  if (!el) return;
+  const deltaSign = data.delta_global >= 0 ? '+' : '';
+  el.innerHTML = `
+    <div class="stat-card stat-card--total"><div class="stat-num">${data.contifico_total_skus}</div><div class="stat-lbl">SKUs Contífico</div></div>
+    <div class="stat-card stat-card--total"><div class="stat-num">${data.odoo_total_skus}</div><div class="stat-lbl">SKUs Odoo</div></div>
+    <div class="stat-card stat-card--both"><div class="stat-num">${data.match}</div><div class="stat-lbl">Stock igual</div></div>
+    <div class="stat-card stat-card--warn"><div class="stat-num">${data.differ}</div><div class="stat-lbl">Stock diferente</div></div>
+    <div class="stat-card stat-card--contifico"><div class="stat-num">${data.only_in_contifico}</div><div class="stat-lbl">Solo Contífico</div></div>
+    <div class="stat-card stat-card--odoo"><div class="stat-num">${data.only_in_odoo}</div><div class="stat-lbl">Solo Odoo</div></div>
+    <div class="stat-card stat-card--delta"><div class="stat-num">${deltaSign}${data.delta_global}</div><div class="stat-lbl">Delta global (Odoo−Ctf)</div></div>
+  `;
+  el.classList.remove('hidden');
+}
+
+function renderStockCompareLinks(files) {
+  const el = $('stockCompareLinks');
+  if (!el || !files) return;
+  el.innerHTML = '';
+  const title = document.createElement('div');
+  title.className = 'phase-title';
+  title.textContent = 'Descargar reportes de comparación de stock';
+  el.appendChild(title);
+  const FILES = [
+    { key: 'differ',            label: 'Stock DIFERENTE — diferencias a revisar (stock_compare_differ.csv)' },
+    { key: 'full_comparison',   label: 'Comparación completa — todos los SKUs coincidentes (stock_compare_full.csv)' },
+    { key: 'only_in_contifico', label: 'Solo en Contífico — faltan en Odoo (stock_compare_only_contifico.csv)' },
+    { key: 'only_in_odoo',      label: 'Solo en Odoo — no están en Contífico (stock_compare_only_odoo.csv)' },
+  ];
+  FILES.forEach(({ key, label }) => {
+    const path = files[key];
+    if (!path) return;
+    el.appendChild(makeLink(`${base()}${path}`, label, false));
+  });
+}
+
+function renderStockComparePreviews(data) {
+  const el = $('stockComparePreviews');
+  if (!el) return;
+  el.innerHTML = '';
+  const sections = [
+    { key: 'preview_differ',           label: `Stock diferente — ${data.differ} SKUs`,           cls: 'stat-card--warn' },
+    { key: 'preview_only_contifico',   label: `Solo en Contífico — ${data.only_in_contifico} SKUs`, cls: 'stat-card--contifico' },
+    { key: 'preview_only_odoo',        label: `Solo en Odoo — ${data.only_in_odoo} SKUs`,        cls: 'stat-card--odoo' },
+  ];
+  sections.forEach(({ key, label }) => {
+    const items = data[key] || [];
+    if (!items.length) return;
+    const details = document.createElement('details');
+    details.className = 'compare-preview';
+    const summary = document.createElement('summary');
+    summary.textContent = label + (items.length === 30 ? ' (mostrando primeros 30)' : '');
+    details.appendChild(summary);
+    const ul = document.createElement('ul');
+    items.forEach(sku => { const li = document.createElement('li'); li.textContent = sku; ul.appendChild(li); });
+    details.appendChild(ul);
+    el.appendChild(details);
+  });
+}
+
+$('executeStockCompare').addEventListener('click', async () => {
+  try {
+    const odooInput = $('stockCompareOdooFile');
+    if (!odooInput?.files?.[0]) throw new Error('Debes seleccionar el archivo de inventario de Odoo.');
+    const ctfInput = $('stockCompareContificoFile');
+    if (!ctfInput?.files?.[0]) throw new Error('Debes seleccionar el archivo de inventario de Contífico.');
+    const sourceType = $('stockCompareSourceType').value;
+
+    $('executeStockCompare').disabled = true;
+    $('stockCompareStats').classList.add('hidden');
+    $('stockComparePreviews').innerHTML = '';
+    $('stockCompareLinks').innerHTML = '';
+    setStockCompareStatus('Comparando stock...');
+
+    const form = new FormData();
+    form.append('odoo_file', odooInput.files[0]);
+    form.append('contifico_file', ctfInput.files[0]);
+    form.append('source_type', sourceType);
+
+    const resp = await fetch(`${base()}/odoo-migration/compare-stock`, { method: 'POST', body: form });
+    const text = await resp.text();
+    let data; try { data = JSON.parse(text); } catch { data = text; }
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}: ${typeof data === 'string' ? data : JSON.stringify(data)}`);
+
+    renderStockCompareStats(data);
+    renderStockCompareLinks(data.files);
+    renderStockComparePreviews(data);
+    setStockCompareStatus(
+      `Comparación completada. ` +
+      `Stock igual: ${data.match} · Diferente: ${data.differ} · ` +
+      `Solo Contífico: ${data.only_in_contifico} · Solo Odoo: ${data.only_in_odoo} · ` +
+      `Delta global: ${data.delta_global >= 0 ? '+' : ''}${data.delta_global} unidades`
+    );
+  } catch(e) {
+    setStockCompareStatus(`Error: ${e.message}`);
+    showErr(e);
+  } finally {
+    $('executeStockCompare').disabled = false;
+  }
+});
+
 // ── Merger Variantes ────────────────────────────────────────────────────────
 
 function setMergerStatus(msg) { const el=$('mergerStatus'); if(el) el.textContent=msg||''; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,24 +72,61 @@
 
       <section id="tab-compare" class="tab-panel card">
         <h2>Comparador de Inventario</h2>
-        <p class="muted">Sube el export de <code>product.product</code> de Odoo (<code>default_code | name | barcode | qty_available</code>) para comparar contra los SKUs de la extracción de Contífico.</p>
-        <label>Run ID de la extracción Contífico</label>
-        <input id="compareRunId" placeholder="Run ID generado en Exportar" />
-        <label>Export de Odoo (product.product CSV)</label>
-        <input id="compareOdooFile" type="file" accept=".csv,text/csv" />
-        <button id="executeCompare">Comparar inventarios</button>
-        <p id="compareStatus" class="muted"></p>
-        <div id="compareStats" class="compare-stats hidden"></div>
-        <div id="compareLinks" class="phase-section"></div>
-        <div id="comparePreviews"></div>
-        <div id="generateMissingSection" class="hidden">
-          <hr style="margin:16px 0;border:none;border-top:1px solid #e5e7eb" />
-          <h3 style="margin:0 0 4px">Generar importación de faltantes</h3>
-          <p class="muted">Genera CSVs filtrados listos para importar en Odoo con solo los productos que faltan.</p>
-          <button id="generateMissingImport">Generar CSVs de importación</button>
-          <p id="generateMissingStatus" class="muted"></p>
-          <div id="generateMissingLinks"></div>
-        </div>
+
+        <!-- ── Sección A: comparador de SKUs (requiere run) ── -->
+        <details open>
+          <summary class="section-summary">A. Comparador de SKUs (presencia/ausencia)</summary>
+          <p class="muted" style="margin-top:8px">Compara los SKUs generados en una extracción Contífico contra los <code>default_code</code> de Odoo. No compara cantidades.</p>
+          <label>Run ID de la extracción Contífico</label>
+          <input id="compareRunId" placeholder="Run ID generado en Exportar" />
+          <label>Export de Odoo — <code>product.product</code> CSV (<code>default_code | name | barcode | qty_available</code>)</label>
+          <input id="compareOdooFile" type="file" accept=".csv,text/csv" />
+          <button id="executeCompare">Comparar SKUs</button>
+          <p id="compareStatus" class="muted"></p>
+          <div id="compareStats" class="compare-stats hidden"></div>
+          <div id="compareLinks" class="phase-section"></div>
+          <div id="comparePreviews"></div>
+          <div id="generateMissingSection" class="hidden">
+            <hr style="margin:16px 0;border:none;border-top:1px solid #e5e7eb" />
+            <h3 style="margin:0 0 4px">Generar importación de faltantes</h3>
+            <p class="muted">Genera CSVs filtrados listos para importar en Odoo con solo los productos que faltan.</p>
+            <button id="generateMissingImport">Generar CSVs de importación</button>
+            <p id="generateMissingStatus" class="muted"></p>
+            <div id="generateMissingLinks"></div>
+          </div>
+        </details>
+
+        <hr style="margin:20px 0;border:none;border-top:2px solid #e5e7eb" />
+
+        <!-- ── Sección B: comparador de cantidades de stock ── -->
+        <details open>
+          <summary class="section-summary">B. Comparador de Stock (cantidades)</summary>
+          <p class="muted" style="margin-top:8px">Compara las cantidades de stock entre Odoo y Contífico. No necesita Run ID — sube directamente los dos archivos.</p>
+
+          <div class="stock-compare-grid">
+            <div>
+              <label>Export de Odoo — inventario CSV</label>
+              <p class="muted-small">Formatos aceptados: <code>Internal Reference | qty_available</code> o <code>default_code | qty_available</code></p>
+              <input id="stockCompareOdooFile" type="file" accept=".csv,text/csv" />
+            </div>
+            <div>
+              <label>Archivo de Contífico</label>
+              <select id="stockCompareSourceType">
+                <option value="csv_bodegas">ReporteSaldosInventarioPorBodega.csv (recomendado)</option>
+                <option value="csv_simple">ReporteSaldosInventario.csv</option>
+                <option value="raw_log">raw.log (respuestas JSON de API)</option>
+              </select>
+              <input id="stockCompareContificoFile" type="file" accept=".csv,.log,.json,.txt,text/csv" />
+            </div>
+          </div>
+
+          <button id="executeStockCompare">Comparar stock</button>
+          <p id="stockCompareStatus" class="muted"></p>
+
+          <div id="stockCompareStats" class="compare-stats hidden"></div>
+          <div id="stockCompareLinks" class="phase-section"></div>
+          <div id="stockComparePreviews"></div>
+        </details>
       </section>
 
       <section id="tab-preview" class="tab-panel">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -53,3 +53,13 @@ button:disabled{opacity:.55;cursor:not-allowed}
 .warning-item--error{background:#fef2f2;color:#991b1b;border:1px solid #fecaca}
 .warning-item--warn{background:#fffbeb;color:#92400e;border:1px solid #fde68a}
 .warning-item--info{background:#eff6ff;color:#1e40af;border:1px solid #bfdbfe}
+
+/* Stock comparator */
+.stat-card--warn{background:#fffbeb;border:1px solid #fde68a;color:#92400e}
+.stat-card--delta{background:#f5f3ff;border:1px solid #ddd6fe;color:#4c1d95}
+.section-summary{cursor:pointer;font-size:16px;font-weight:600;padding:4px 0;list-style:none}
+.section-summary::-webkit-details-marker{display:none}
+details>summary{user-select:none}
+.stock-compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin:8px 0 12px}
+@media(max-width:700px){.stock-compare-grid{grid-template-columns:1fr}}
+.muted-small{font-size:11px;color:#6b7280;margin:2px 0 6px}


### PR DESCRIPTION
$(cat <<'EOF'
## Resumen

Nuevo **Comparador de Stock** que compara cantidades de inventario entre Odoo y Contífico sin necesitar un run_id previo. Complementa el comparador de SKUs existente (que solo detecta presencia/ausencia).

## Cambios

### Backend — `stock_comparator.py` (nuevo módulo)
- Carga inventario **Odoo** desde dos formatos de export:
  - Simple: `Internal Reference | qty_available`
  - Completo: `default_code | qty_available | ...`
- Carga inventario **Contífico** desde 3 fuentes:
  - `csv_simple` → `ReporteSaldosInventario.csv` (semicolon, 5 filas de encabezado)
  - `csv_bodegas` → `ReporteSaldosInventarioPorBodega.csv` (con desglose por bodega)
  - `raw_log` → `raw.log` (JSON pages de la API de Contífico)
- Genera 4 CSVs de resultado:
  - `stock_compare_full.csv` — todos los SKUs en ambos sistemas con delta
  - `stock_compare_differ.csv` — solo SKUs con diferencia de stock
  - `stock_compare_only_contifico.csv` — SKUs que faltan en Odoo
  - `stock_compare_only_odoo.csv` — SKUs que sobran en Odoo

### Backend — `router.py`
- `POST /odoo-migration/compare-stock` — upload `odoo_file` + `contifico_file` + `source_type`
- `GET /odoo-migration/compare-stock/{job_id}/files/{filename}` — descarga de CSVs

### Frontend — Sección B en el tab "Comparador"
- Selector de tipo de fuente Contífico (bodegas / simple / raw_log)
- Cards de estadísticas: match, differ, solo-Contífico, solo-Odoo, delta global
- Preview de SKUs con diferencias
- Botones de descarga para los 4 CSVs

## Test plan

- [ ] Subir `InventarioOdoo.xlsx` (exportado como CSV) + `ReporteSaldosInventarioPorBodega.csv` → verificar stats y descargar `stock_compare_differ.csv`
- [ ] Probar con `ReporteSaldosInventario.csv` (source_type=csv_simple)
- [ ] Probar con `raw.log` (source_type=raw_log)
- [ ] Verificar que el comparador de SKUs original (Sección A) sigue funcionando igual
- [ ] Verificar que el delta global = total_stock_odoo - total_stock_contifico

https://claude.ai/code/session_01XZJ3juXosYKb6Zttt8cysg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZJ3juXosYKb6Zttt8cysg)_