### PR TITLE
feat: Sección A también funciona con archivos directos (sin run_id)

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -13,7 +13,7 @@ from ..dependencies import get_contifico_client
 from ..config import get_settings
 from .rules import CATEGORY_ALIASES
 from .service import OdooMigrationService
-from .stock_comparator import compare_stock
+from .stock_comparator import compare_stock, compare_skus
 from .stock_worker import StockWorker
 
 router = APIRouter(prefix="/odoo-migration", tags=["Odoo Migration"])
@@ -591,6 +591,96 @@ def download_compare_file(job_id: str, filename: str):
     """Descarga uno de los CSVs generados por el comparador de stock."""
     safe_name = Path(filename).name  # strip any path traversal
     file_path = _compare_output_root() / job_id / safe_name
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Archivo no encontrado")
+    return FileResponse(
+        path=file_path,
+        filename=safe_name,
+        media_type="text/csv; charset=utf-8",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Comparador de SKUs standalone (Sección A sin run_id)
+# ──────────────────────────────────────────────────────────────────────────────
+
+SKU_COMPARE_JOBS: dict[str, dict] = {}
+SKU_COMPARE_LOCK = Lock()
+
+
+def _sku_compare_root() -> Path:
+    return Path("backend/data/odoo_migration/sku_compare")
+
+
+@router.post("/compare-skus")
+async def compare_skus_endpoint(
+    odoo_file: UploadFile = File(..., description="Export de inventario Odoo (CSV)"),
+    contifico_file: UploadFile = File(..., description="Archivo de inventario Contífico"),
+    source_type: str = Form(
+        "csv_bodegas",
+        description="Tipo de fuente Contífico: csv_simple | csv_bodegas | raw_log",
+    ),
+):
+    """Compara la presencia de SKUs entre Odoo y Contífico sin necesidad de run_id.
+
+    Responde qué productos **faltan en Odoo** (solo en Contífico) y cuáles
+    **sobran en Odoo** (no vienen de Contífico).
+
+    **source_type**:
+    - `csv_simple`  → ReporteSaldosInventario.csv
+    - `csv_bodegas` → ReporteSaldosInventarioPorBodega.csv
+    - `raw_log`     → raw.log (respuestas JSON de la API de Contífico)
+
+    Genera tres CSVs:
+    - `sku_compare_only_contifico.csv`  – faltan en Odoo (importar)
+    - `sku_compare_only_odoo.csv`       – sobran en Odoo (revisar)
+    - `sku_compare_in_both.csv`         – presentes en ambos
+    """
+    if source_type not in ("csv_simple", "csv_bodegas", "raw_log"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"source_type inválido: {source_type!r}. Usa: csv_simple | csv_bodegas | raw_log",
+        )
+
+    job_id = uuid4().hex[:12]
+    output_folder = _sku_compare_root() / job_id
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    odoo_path = output_folder / "odoo_upload.csv"
+    contifico_path = output_folder / f"contifico_upload_{source_type}"
+    odoo_path.write_bytes(await odoo_file.read())
+    contifico_path.write_bytes(await contifico_file.read())
+
+    try:
+        result = compare_skus(
+            odoo_path=odoo_path,
+            contifico_path=contifico_path,
+            source_type=source_type,
+            output_folder=output_folder,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    with SKU_COMPARE_LOCK:
+        SKU_COMPARE_JOBS[job_id] = {"job_id": job_id, **result}
+
+    base = f"/odoo-migration/compare-skus/{job_id}/files"
+    return {
+        "job_id": job_id,
+        **result,
+        "files": {
+            "only_in_contifico": f"{base}/sku_compare_only_contifico.csv",
+            "only_in_odoo":      f"{base}/sku_compare_only_odoo.csv",
+            "in_both":           f"{base}/sku_compare_in_both.csv",
+        },
+    }
+
+
+@router.get("/compare-skus/{job_id}/files/{filename}")
+def download_sku_compare_file(job_id: str, filename: str):
+    """Descarga uno de los CSVs generados por el comparador de SKUs standalone."""
+    safe_name = Path(filename).name
+    file_path = _sku_compare_root() / job_id / safe_name
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
     return FileResponse(

--- a/backend/app/odoo_migration/stock_comparator.py
+++ b/backend/app/odoo_migration/stock_comparator.py
@@ -264,6 +264,142 @@ def load_contifico_raw_log(path: Path) -> dict[str, dict]:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Odoo SKU loader (no qty needed for presence comparison)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def load_odoo_skus(path: Path) -> dict[str, dict]:
+    """Return {sku_lower: {sku, name, barcode}} from an Odoo product export.
+
+    Accepts the same formats as load_odoo_stock but ignores qty_available.
+    Also accepts the minimal format: Internal Reference | name_odoo | barcode
+    """
+    result: dict[str, dict] = {}
+    with _open_csv(path) as f:
+        reader = csv.DictReader(f)
+        headers = reader.fieldnames or []
+
+        if "Internal Reference" in headers:
+            sku_col, name_col, bc_col = "Internal Reference", "name_odoo", "barcode"
+        elif "default_code" in headers:
+            sku_col, name_col, bc_col = "default_code", "name", "barcode"
+        else:
+            raise ValueError(
+                f"Formato Odoo no reconocido. "
+                f"Se esperaba 'Internal Reference' o 'default_code'. "
+                f"Columnas encontradas: {headers}"
+            )
+
+        for row in reader:
+            sku = str(row.get(sku_col) or "").strip()
+            if not sku:
+                continue
+            key = sku.casefold()
+            if key not in result:
+                result[key] = {
+                    "sku": sku,
+                    "name": str(row.get(name_col) or "").strip(),
+                    "barcode": str(row.get(bc_col) or "").strip(),
+                    "qty": _parse_qty(row.get("qty_available") or "0"),
+                }
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SKU presence comparator (Sección A)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def compare_skus(
+    *,
+    odoo_path: Path,
+    contifico_path: Path,
+    source_type: str,
+    output_folder: Path,
+) -> dict[str, Any]:
+    """Compare SKU presence between Odoo and Contifico (no qty comparison).
+
+    Returns which SKUs are only in Contifico (missing from Odoo), only in Odoo,
+    or in both. Writes three CSVs in output_folder.
+
+    source_type: 'csv_simple' | 'csv_bodegas' | 'raw_log'
+    """
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    loaders = {
+        "csv_simple": load_contifico_simple,
+        "csv_bodegas": load_contifico_bodegas,
+        "raw_log": load_contifico_raw_log,
+    }
+    if source_type not in loaders:
+        raise ValueError(f"source_type inválido: {source_type!r}. Usa: {list(loaders)}")
+
+    odoo = load_odoo_skus(odoo_path)
+    contifico = loaders[source_type](contifico_path)
+
+    contifico_keys = set(contifico.keys())
+    odoo_keys = set(odoo.keys())
+
+    only_contifico_keys = sorted(contifico_keys - odoo_keys)
+    only_odoo_keys = sorted(odoo_keys - contifico_keys)
+    both_keys = sorted(contifico_keys & odoo_keys)
+
+    only_c_rows = [
+        {
+            "SKU": contifico[k]["sku"],
+            "Nombre Contifico": contifico[k].get("name", ""),
+            "Categoria": contifico[k].get("categoria", ""),
+            "Marca": contifico[k].get("marca", ""),
+            "Stock Contifico": contifico[k].get("qty", 0),
+        }
+        for k in only_contifico_keys
+    ]
+
+    only_o_rows = [
+        {
+            "SKU": odoo[k]["sku"],
+            "Nombre Odoo": odoo[k].get("name", ""),
+            "Barcode": odoo[k].get("barcode", ""),
+            "Stock Odoo": odoo[k].get("qty", 0),
+        }
+        for k in only_odoo_keys
+    ]
+
+    both_rows = [
+        {
+            "SKU": contifico[k]["sku"],
+            "Nombre Contifico": contifico[k].get("name", ""),
+            "Nombre Odoo": odoo[k].get("name", ""),
+            "Barcode Odoo": odoo[k].get("barcode", ""),
+        }
+        for k in both_keys
+    ]
+
+    def write_csv(filepath: Path, rows: list[dict]) -> None:
+        if not rows:
+            filepath.write_text("(sin datos)\n", encoding="utf-8")
+            return
+        with filepath.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+    write_csv(output_folder / "sku_compare_only_contifico.csv", only_c_rows)
+    write_csv(output_folder / "sku_compare_only_odoo.csv", only_o_rows)
+    write_csv(output_folder / "sku_compare_in_both.csv", both_rows)
+
+    return {
+        "contifico_total_skus": len(contifico),
+        "odoo_total_skus": len(odoo),
+        "in_both": len(both_keys),
+        "only_in_contifico": len(only_contifico_keys),
+        "only_in_odoo": len(only_odoo_keys),
+        "source_type": source_type,
+        "preview_only_contifico": [r["SKU"] for r in only_c_rows[:30]],
+        "preview_only_odoo": [r["SKU"] for r in only_o_rows[:30]],
+        "preview_in_both": [r["SKU"] for r in both_rows[:30]],
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Main comparator
 # ──────────────────────────────────────────────────────────────────────────────
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -331,19 +331,38 @@ function activateTab(name) {
 }
 document.querySelectorAll('.tab-btn').forEach((btn)=>btn.addEventListener('click',()=>activateTab(btn.dataset.tab)));
 
-// ── Comparador de inventario ────────────────────────────────────────────────
+// ── Comparador de inventario (Sección A) ────────────────────────────────────
 
 function setCompareStatus(msg) { const el=$('compareStatus'); if(el) el.textContent=msg||''; }
+
+// Mode toggle (archivos vs run_id)
+let _skuMode = 'files';
+document.querySelectorAll('.mode-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    _skuMode = btn.dataset.mode;
+    document.querySelectorAll('.mode-btn').forEach(b => b.classList.toggle('active', b === btn));
+    $('skuModeFilesPanel').classList.toggle('hidden', _skuMode !== 'files');
+    $('skuModeRunPanel').classList.toggle('hidden', _skuMode !== 'run');
+    $('generateMissingSection').classList.add('hidden');
+    $('compareStats').classList.add('hidden');
+    $('comparePreviews').innerHTML = '';
+    $('compareLinks').innerHTML = '';
+    setCompareStatus('');
+  });
+});
 
 function renderCompareStats(data) {
   const el = $('compareStats');
   if (!el) return;
+  // Support both field naming conventions (run-based vs standalone)
+  const ctfTotal  = data.contifico_total_skus ?? data.contifico_total ?? 0;
+  const odooTotal = data.odoo_total_skus ?? data.odoo_total ?? 0;
   el.innerHTML = `
-    <div class="stat-card stat-card--total"><div class="stat-num">${data.contifico_total}</div><div class="stat-lbl">Contífico</div></div>
-    <div class="stat-card stat-card--total"><div class="stat-num">${data.odoo_total}</div><div class="stat-lbl">Odoo</div></div>
+    <div class="stat-card stat-card--total"><div class="stat-num">${ctfTotal}</div><div class="stat-lbl">SKUs Contífico</div></div>
+    <div class="stat-card stat-card--total"><div class="stat-num">${odooTotal}</div><div class="stat-lbl">SKUs Odoo</div></div>
     <div class="stat-card stat-card--both"><div class="stat-num">${data.in_both}</div><div class="stat-lbl">Coinciden</div></div>
-    <div class="stat-card stat-card--contifico"><div class="stat-num">${data.only_in_contifico}</div><div class="stat-lbl">Solo Contífico</div></div>
-    <div class="stat-card stat-card--odoo"><div class="stat-num">${data.only_in_odoo}</div><div class="stat-lbl">Solo Odoo</div></div>
+    <div class="stat-card stat-card--contifico"><div class="stat-num">${data.only_in_contifico}</div><div class="stat-lbl">Faltan en Odoo</div></div>
+    <div class="stat-card stat-card--odoo"><div class="stat-num">${data.only_in_odoo}</div><div class="stat-lbl">Solo en Odoo</div></div>
   `;
   el.classList.remove('hidden');
 }
@@ -353,11 +372,11 @@ function renderComparePreviews(data) {
   if (!el) return;
   el.innerHTML = '';
   const sections = [
-    { key: 'preview_only_contifico', label: `Solo en Contífico — ${data.only_in_contifico} SKUs (en extracción pero no en Odoo)`, cls: 'stat-card--contifico' },
-    { key: 'preview_only_odoo',      label: `Solo en Odoo — ${data.only_in_odoo} SKUs (en Odoo pero no en extracción)`,   cls: 'stat-card--odoo' },
-    { key: 'preview_in_both',        label: `Coinciden — ${data.in_both} SKUs`,                                             cls: 'stat-card--both' },
+    { key: 'preview_only_contifico', label: `Faltan en Odoo — ${data.only_in_contifico} SKUs` },
+    { key: 'preview_only_odoo',      label: `Solo en Odoo — ${data.only_in_odoo} SKUs` },
+    { key: 'preview_in_both',        label: `Coinciden — ${data.in_both} SKUs` },
   ];
-  sections.forEach(({ key, label, cls }) => {
+  sections.forEach(({ key, label }) => {
     const items = data[key] || [];
     if (!items.length) return;
     const details = document.createElement('details');
@@ -381,17 +400,56 @@ function renderCompareLinks(files) {
   title.textContent = 'Descargar resultados';
   el.appendChild(title);
   const COMPARE_FILES = [
-    { key: 'only_in_contifico', label: 'Solo en Contífico (faltan importar en Odoo)', isImport: false },
-    { key: 'only_in_odoo',      label: 'Solo en Odoo (no vienen de esta extracción)',  isImport: false },
-    { key: 'in_both',           label: 'Coinciden en ambos sistemas',                  isImport: false },
+    { key: 'only_in_contifico', label: 'Faltan en Odoo — SKUs solo en Contífico' },
+    { key: 'only_in_odoo',      label: 'Solo en Odoo — no están en Contífico' },
+    { key: 'in_both',           label: 'Coinciden en ambos sistemas' },
   ];
-  COMPARE_FILES.forEach(({ key, label, isImport }) => {
+  COMPARE_FILES.forEach(({ key, label }) => {
     const path = files[key];
     if (!path) return;
-    el.appendChild(makeLink(`${base()}${path}`, label, isImport));
+    el.appendChild(makeLink(`${base()}${path}`, label, false));
   });
 }
 
+// Modo archivos directos — llama a /compare-skus
+$('executeSkuCompare').addEventListener('click', async () => {
+  try {
+    const odooInput = $('skuCompareOdooFile');
+    if (!odooInput?.files?.[0]) throw new Error('Debes seleccionar el archivo de inventario de Odoo.');
+    const ctfInput = $('skuCompareContificoFile');
+    if (!ctfInput?.files?.[0]) throw new Error('Debes seleccionar el archivo de inventario de Contífico.');
+    const sourceType = $('skuCompareSourceType').value;
+
+    $('executeSkuCompare').disabled = true;
+    $('compareStats').classList.add('hidden');
+    $('comparePreviews').innerHTML = '';
+    $('compareLinks').innerHTML = '';
+    $('generateMissingSection').classList.add('hidden');
+    setCompareStatus('Comparando SKUs...');
+
+    const form = new FormData();
+    form.append('odoo_file', odooInput.files[0]);
+    form.append('contifico_file', ctfInput.files[0]);
+    form.append('source_type', sourceType);
+
+    const resp = await fetch(`${base()}/odoo-migration/compare-skus`, { method: 'POST', body: form });
+    const text = await resp.text();
+    let data; try { data = JSON.parse(text); } catch { data = text; }
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}: ${typeof data === 'string' ? data : JSON.stringify(data)}`);
+
+    renderCompareStats(data);
+    renderComparePreviews(data);
+    renderCompareLinks(data.files);
+    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}`);
+  } catch(e) {
+    setCompareStatus(`Error: ${e.message}`);
+    showErr(e);
+  } finally {
+    $('executeSkuCompare').disabled = false;
+  }
+});
+
+// Modo run_id — llama a /runs/{id}/compare-inventory (comportamiento original)
 $('executeCompare').addEventListener('click', async () => {
   try {
     const runId = $('compareRunId').value.trim();
@@ -413,7 +471,7 @@ $('executeCompare').addEventListener('click', async () => {
     renderCompareStats(data);
     renderComparePreviews(data);
     renderCompareLinks(data.files);
-    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Solo Contífico: ${data.only_in_contifico} · Solo Odoo: ${data.only_in_odoo}`);
+    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}`);
     if (data.only_in_contifico > 0) $('generateMissingSection').classList.remove('hidden');
   } catch(e) {
     setCompareStatus(`Error: ${e.message}`);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -73,15 +73,47 @@
       <section id="tab-compare" class="tab-panel card">
         <h2>Comparador de Inventario</h2>
 
-        <!-- ── Sección A: comparador de SKUs (requiere run) ── -->
+        <!-- ── Sección A: comparador de SKUs ── -->
         <details open>
           <summary class="section-summary">A. Comparador de SKUs (presencia/ausencia)</summary>
-          <p class="muted" style="margin-top:8px">Compara los SKUs generados en una extracción Contífico contra los <code>default_code</code> de Odoo. No compara cantidades.</p>
-          <label>Run ID de la extracción Contífico</label>
-          <input id="compareRunId" placeholder="Run ID generado en Exportar" />
-          <label>Export de Odoo — <code>product.product</code> CSV (<code>default_code | name | barcode | qty_available</code>)</label>
-          <input id="compareOdooFile" type="file" accept=".csv,text/csv" />
-          <button id="executeCompare">Comparar SKUs</button>
+          <p class="muted" style="margin-top:8px">Qué productos tiene Contífico que <strong>faltan en Odoo</strong>, y cuáles están en Odoo pero no en Contífico. No compara cantidades.</p>
+
+          <!-- Selector de modo -->
+          <div class="mode-tabs">
+            <button class="mode-btn active" data-mode="files" id="skuModeFiles">Subir archivos directamente</button>
+            <button class="mode-btn" data-mode="run" id="skuModeRun">Usar Run ID (extracción previa)</button>
+          </div>
+
+          <!-- Modo A: archivos directos -->
+          <div id="skuModeFilesPanel">
+            <div class="stock-compare-grid">
+              <div>
+                <label>Export de Odoo — inventario CSV</label>
+                <p class="muted-small">Columnas: <code>Internal Reference</code> o <code>default_code</code></p>
+                <input id="skuCompareOdooFile" type="file" accept=".csv,text/csv" />
+              </div>
+              <div>
+                <label>Fuente Contífico</label>
+                <select id="skuCompareSourceType">
+                  <option value="csv_bodegas">ReporteSaldosInventarioPorBodega.csv (recomendado)</option>
+                  <option value="csv_simple">ReporteSaldosInventario.csv</option>
+                  <option value="raw_log">raw.log (respuestas JSON de API)</option>
+                </select>
+                <input id="skuCompareContificoFile" type="file" accept=".csv,.log,.json,.txt,text/csv" />
+              </div>
+            </div>
+            <button id="executeSkuCompare">Comparar SKUs</button>
+          </div>
+
+          <!-- Modo B: run_id (modo original) -->
+          <div id="skuModeRunPanel" class="hidden">
+            <label>Run ID de la extracción Contífico</label>
+            <input id="compareRunId" placeholder="Run ID generado en Exportar" />
+            <label>Export de Odoo — <code>product.product</code> CSV (<code>default_code | name | barcode | qty_available</code>)</label>
+            <input id="compareOdooFile" type="file" accept=".csv,text/csv" />
+            <button id="executeCompare">Comparar SKUs (por Run)</button>
+          </div>
+
           <p id="compareStatus" class="muted"></p>
           <div id="compareStats" class="compare-stats hidden"></div>
           <div id="compareLinks" class="phase-section"></div>
@@ -89,7 +121,7 @@
           <div id="generateMissingSection" class="hidden">
             <hr style="margin:16px 0;border:none;border-top:1px solid #e5e7eb" />
             <h3 style="margin:0 0 4px">Generar importación de faltantes</h3>
-            <p class="muted">Genera CSVs filtrados listos para importar en Odoo con solo los productos que faltan.</p>
+            <p class="muted">Solo disponible con Run ID. Genera CSVs filtrados listos para importar en Odoo con los productos que faltan.</p>
             <button id="generateMissingImport">Generar CSVs de importación</button>
             <p id="generateMissingStatus" class="muted"></p>
             <div id="generateMissingLinks"></div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -63,3 +63,9 @@ details>summary{user-select:none}
 .stock-compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin:8px 0 12px}
 @media(max-width:700px){.stock-compare-grid{grid-template-columns:1fr}}
 .muted-small{font-size:11px;color:#6b7280;margin:2px 0 6px}
+
+/* Mode toggle tabs (Sección A) */
+.mode-tabs{display:flex;gap:6px;margin:10px 0 14px;border-bottom:2px solid #e5e7eb;padding-bottom:0}
+.mode-btn{background:none;border:none;border-bottom:2px solid transparent;margin-bottom:-2px;padding:6px 14px;font-size:13px;font-weight:600;color:#6b7280;cursor:pointer;border-radius:4px 4px 0 0;transition:color .15s,border-color .15s}
+.mode-btn.active{color:#1d4ed8;border-bottom-color:#1d4ed8;background:#eff6ff}
+.mode-btn:hover:not(.active){color:#374151;background:#f9fafb}


### PR DESCRIPTION
El comparador de SKUs (presencia/ausencia) ahora acepta las mismas fuentes que el comparador de stock: archivos directos de Contífico sin necesidad de haber corrido una extracción previa.

Backend:
- stock_comparator.py: añade load_odoo_skus() y compare_skus() que reutiliza los loaders existentes (csv_simple, csv_bodegas, raw_log)
- router.py: nuevo POST /compare-skus + GET /compare-skus/{job_id}/files/{fn}

Frontend (Sección A):
- Mode toggle: "Subir archivos directamente" | "Usar Run ID"
- Modo archivos: selector de fuente Contífico + dos file pickers → llama /compare-skus
- Modo run_id: comportamiento original → llama /runs/{id}/compare-inventory
- Stats cards y previews unificados en ambos modos

https://claude.ai/code/session_01XZJ3juXosYKb6Zttt8cysg