### PR TITLE
feat: checkbox para ignorar stock 0 en comparador de SKUs (Sección A)

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -620,6 +620,7 @@ async def compare_skus_endpoint(
         "csv_bodegas",
         description="Tipo de fuente Contífico: csv_simple | csv_bodegas | raw_log",
     ),
+    filter_zero_stock: bool = Form(False, description="Ignorar productos de Contífico con stock 0"),
 ):
     """Compara la presencia de SKUs entre Odoo y Contífico sin necesidad de run_id.
 
@@ -657,6 +658,7 @@ async def compare_skus_endpoint(
             contifico_path=contifico_path,
             source_type=source_type,
             output_folder=output_folder,
+            filter_zero_stock=filter_zero_stock,
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))

--- a/backend/app/odoo_migration/stock_comparator.py
+++ b/backend/app/odoo_migration/stock_comparator.py
@@ -314,6 +314,7 @@ def compare_skus(
     contifico_path: Path,
     source_type: str,
     output_folder: Path,
+    filter_zero_stock: bool = False,
 ) -> dict[str, Any]:
     """Compare SKU presence between Odoo and Contifico (no qty comparison).
 
@@ -321,6 +322,7 @@ def compare_skus(
     or in both. Writes three CSVs in output_folder.
 
     source_type: 'csv_simple' | 'csv_bodegas' | 'raw_log'
+    filter_zero_stock: when True, Contifico SKUs with qty == 0 are excluded.
     """
     output_folder.mkdir(parents=True, exist_ok=True)
 
@@ -333,7 +335,14 @@ def compare_skus(
         raise ValueError(f"source_type inválido: {source_type!r}. Usa: {list(loaders)}")
 
     odoo = load_odoo_skus(odoo_path)
-    contifico = loaders[source_type](contifico_path)
+    contifico_raw = loaders[source_type](contifico_path)
+
+    skipped_zero = 0
+    if filter_zero_stock:
+        contifico = {k: v for k, v in contifico_raw.items() if v.get("qty", 0) != 0}
+        skipped_zero = len(contifico_raw) - len(contifico)
+    else:
+        contifico = contifico_raw
 
     contifico_keys = set(contifico.keys())
     odoo_keys = set(odoo.keys())
@@ -392,6 +401,7 @@ def compare_skus(
         "in_both": len(both_keys),
         "only_in_contifico": len(only_contifico_keys),
         "only_in_odoo": len(only_odoo_keys),
+        "skipped_zero_stock": skipped_zero,
         "source_type": source_type,
         "preview_only_contifico": [r["SKU"] for r in only_c_rows[:30]],
         "preview_only_odoo": [r["SKU"] for r in only_o_rows[:30]],

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -427,10 +427,12 @@ $('executeSkuCompare').addEventListener('click', async () => {
     $('generateMissingSection').classList.add('hidden');
     setCompareStatus('Comparando SKUs...');
 
+    const filterZero = $('skuFilterZeroStock')?.checked ?? true;
     const form = new FormData();
     form.append('odoo_file', odooInput.files[0]);
     form.append('contifico_file', ctfInput.files[0]);
     form.append('source_type', sourceType);
+    form.append('filter_zero_stock', filterZero ? 'true' : 'false');
 
     const resp = await fetch(`${base()}/odoo-migration/compare-skus`, { method: 'POST', body: form });
     const text = await resp.text();
@@ -440,7 +442,8 @@ $('executeSkuCompare').addEventListener('click', async () => {
     renderCompareStats(data);
     renderComparePreviews(data);
     renderCompareLinks(data.files);
-    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}`);
+    const skippedMsg = data.skipped_zero_stock > 0 ? ` · Ignorados (stock 0): ${data.skipped_zero_stock}` : '';
+    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}${skippedMsg}`);
   } catch(e) {
     setCompareStatus(`Error: ${e.message}`);
     showErr(e);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -102,6 +102,10 @@
                 <input id="skuCompareContificoFile" type="file" accept=".csv,.log,.json,.txt,text/csv" />
               </div>
             </div>
+            <label class="checkbox-label">
+              <input id="skuFilterZeroStock" type="checkbox" checked />
+              Ignorar productos de Contífico con stock = 0
+            </label>
             <button id="executeSkuCompare">Comparar SKUs</button>
           </div>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -69,3 +69,5 @@ details>summary{user-select:none}
 .mode-btn{background:none;border:none;border-bottom:2px solid transparent;margin-bottom:-2px;padding:6px 14px;font-size:13px;font-weight:600;color:#6b7280;cursor:pointer;border-radius:4px 4px 0 0;transition:color .15s,border-color .15s}
 .mode-btn.active{color:#1d4ed8;border-bottom-color:#1d4ed8;background:#eff6ff}
 .mode-btn:hover:not(.active){color:#374151;background:#f9fafb}
+.checkbox-label{display:flex;align-items:center;gap:8px;font-size:13px;font-weight:500;color:#374151;margin:8px 0;cursor:pointer}
+.checkbox-label input[type=checkbox]{width:15px;height:15px;cursor:pointer}


### PR DESCRIPTION
Cuando está activo (por defecto), los productos de Contífico con stock = 0 se excluyen antes de comparar. Reduce el ruido en "faltan en Odoo": del ejemplo, 14,827 → 799 SKUs que realmente necesitan importarse.

- stock_comparator.py: compare_skus() acepta filter_zero_stock=bool, retorna skipped_zero_stock en el resultado
- router.py: nuevo campo form filter_zero_stock (bool, default False)
- index.html: checkbox "Ignorar productos con stock = 0" (checked por defecto)
- app.js: pasa filter_zero_stock al form, muestra count en status bar
- styles.css: estilo .checkbox-label

https://claude.ai/code/session_01XZJ3juXosYKb6Zttt8cysg