### PR TITLE
fix: stock 0 en Contífico ausente en Odoo → categoría "Coincide stock 0"

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -633,9 +633,10 @@ async def compare_skus_endpoint(
     - `raw_log`     → raw.log (respuestas JSON de la API de Contífico)
 
     Genera tres CSVs:
-    - `sku_compare_only_contifico.csv`  – faltan en Odoo (importar)
+    - `sku_compare_only_contifico.csv`  – faltan en Odoo con stock > 0 (brecha real)
     - `sku_compare_only_odoo.csv`       – sobran en Odoo (revisar)
     - `sku_compare_in_both.csv`         – presentes en ambos
+    - `sku_compare_zero_both.csv`       – stock 0 en Contífico y ausentes en Odoo (coinciden sin stock)
     """
     if source_type not in ("csv_simple", "csv_bodegas", "raw_log"):
         raise HTTPException(
@@ -674,6 +675,7 @@ async def compare_skus_endpoint(
             "only_in_contifico": f"{base}/sku_compare_only_contifico.csv",
             "only_in_odoo":      f"{base}/sku_compare_only_odoo.csv",
             "in_both":           f"{base}/sku_compare_in_both.csv",
+            "zero_both":         f"{base}/sku_compare_zero_both.csv",
         },
     }
 

--- a/backend/app/odoo_migration/stock_comparator.py
+++ b/backend/app/odoo_migration/stock_comparator.py
@@ -335,32 +335,39 @@ def compare_skus(
         raise ValueError(f"source_type inválido: {source_type!r}. Usa: {list(loaders)}")
 
     odoo = load_odoo_skus(odoo_path)
-    contifico_raw = loaders[source_type](contifico_path)
-
-    skipped_zero = 0
-    if filter_zero_stock:
-        contifico = {k: v for k, v in contifico_raw.items() if v.get("qty", 0) != 0}
-        skipped_zero = len(contifico_raw) - len(contifico)
-    else:
-        contifico = contifico_raw
+    contifico = loaders[source_type](contifico_path)
 
     contifico_keys = set(contifico.keys())
     odoo_keys = set(odoo.keys())
 
-    only_contifico_keys = sorted(contifico_keys - odoo_keys)
+    raw_only_contifico = contifico_keys - odoo_keys
     only_odoo_keys = sorted(odoo_keys - contifico_keys)
     both_keys = sorted(contifico_keys & odoo_keys)
 
-    only_c_rows = [
-        {
+    # Split "only in Contifico" into real gaps (stock > 0) vs zero-stock-both
+    # (stock = 0 in Contifico and absent from Odoo → both sides agree on no stock)
+    if filter_zero_stock:
+        only_contifico_keys = sorted(
+            k for k in raw_only_contifico if contifico[k].get("qty", 0) != 0
+        )
+        zero_both_keys = sorted(
+            k for k in raw_only_contifico if contifico[k].get("qty", 0) == 0
+        )
+    else:
+        only_contifico_keys = sorted(raw_only_contifico)
+        zero_both_keys = []
+
+    def _ctf_row(k: str) -> dict:
+        return {
             "SKU": contifico[k]["sku"],
             "Nombre Contifico": contifico[k].get("name", ""),
             "Categoria": contifico[k].get("categoria", ""),
             "Marca": contifico[k].get("marca", ""),
             "Stock Contifico": contifico[k].get("qty", 0),
         }
-        for k in only_contifico_keys
-    ]
+
+    only_c_rows  = [_ctf_row(k) for k in only_contifico_keys]
+    zero_b_rows  = [_ctf_row(k) for k in zero_both_keys]
 
     only_o_rows = [
         {
@@ -394,6 +401,7 @@ def compare_skus(
     write_csv(output_folder / "sku_compare_only_contifico.csv", only_c_rows)
     write_csv(output_folder / "sku_compare_only_odoo.csv", only_o_rows)
     write_csv(output_folder / "sku_compare_in_both.csv", both_rows)
+    write_csv(output_folder / "sku_compare_zero_both.csv", zero_b_rows)
 
     return {
         "contifico_total_skus": len(contifico),
@@ -401,11 +409,13 @@ def compare_skus(
         "in_both": len(both_keys),
         "only_in_contifico": len(only_contifico_keys),
         "only_in_odoo": len(only_odoo_keys),
-        "skipped_zero_stock": skipped_zero,
+        "coincide_zero_stock": len(zero_both_keys),
+        "filter_zero_stock": filter_zero_stock,
         "source_type": source_type,
         "preview_only_contifico": [r["SKU"] for r in only_c_rows[:30]],
         "preview_only_odoo": [r["SKU"] for r in only_o_rows[:30]],
         "preview_in_both": [r["SKU"] for r in both_rows[:30]],
+        "preview_zero_both": [r["SKU"] for r in zero_b_rows[:30]],
     }
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -357,10 +357,14 @@ function renderCompareStats(data) {
   // Support both field naming conventions (run-based vs standalone)
   const ctfTotal  = data.contifico_total_skus ?? data.contifico_total ?? 0;
   const odooTotal = data.odoo_total_skus ?? data.odoo_total ?? 0;
+  const zeroCard  = (data.coincide_zero_stock > 0)
+    ? `<div class="stat-card stat-card--zero"><div class="stat-num">${data.coincide_zero_stock}</div><div class="stat-lbl">Stock 0 (ambos)</div></div>`
+    : '';
   el.innerHTML = `
     <div class="stat-card stat-card--total"><div class="stat-num">${ctfTotal}</div><div class="stat-lbl">SKUs Contífico</div></div>
     <div class="stat-card stat-card--total"><div class="stat-num">${odooTotal}</div><div class="stat-lbl">SKUs Odoo</div></div>
     <div class="stat-card stat-card--both"><div class="stat-num">${data.in_both}</div><div class="stat-lbl">Coinciden</div></div>
+    ${zeroCard}
     <div class="stat-card stat-card--contifico"><div class="stat-num">${data.only_in_contifico}</div><div class="stat-lbl">Faltan en Odoo</div></div>
     <div class="stat-card stat-card--odoo"><div class="stat-num">${data.only_in_odoo}</div><div class="stat-lbl">Solo en Odoo</div></div>
   `;
@@ -372,9 +376,10 @@ function renderComparePreviews(data) {
   if (!el) return;
   el.innerHTML = '';
   const sections = [
-    { key: 'preview_only_contifico', label: `Faltan en Odoo — ${data.only_in_contifico} SKUs` },
+    { key: 'preview_only_contifico', label: `Faltan en Odoo (stock > 0) — ${data.only_in_contifico} SKUs` },
+    { key: 'preview_zero_both',      label: `Coinciden stock 0 (ausentes en Odoo, sin stock) — ${data.coincide_zero_stock ?? 0} SKUs` },
     { key: 'preview_only_odoo',      label: `Solo en Odoo — ${data.only_in_odoo} SKUs` },
-    { key: 'preview_in_both',        label: `Coinciden — ${data.in_both} SKUs` },
+    { key: 'preview_in_both',        label: `Coinciden en ambos — ${data.in_both} SKUs` },
   ];
   sections.forEach(({ key, label }) => {
     const items = data[key] || [];
@@ -391,7 +396,7 @@ function renderComparePreviews(data) {
   });
 }
 
-function renderCompareLinks(files) {
+function renderCompareLinks(files, data) {
   const el = $('compareLinks');
   if (!el || !files) return;
   el.innerHTML = '';
@@ -400,7 +405,8 @@ function renderCompareLinks(files) {
   title.textContent = 'Descargar resultados';
   el.appendChild(title);
   const COMPARE_FILES = [
-    { key: 'only_in_contifico', label: 'Faltan en Odoo — SKUs solo en Contífico' },
+    { key: 'only_in_contifico', label: 'Faltan en Odoo — stock > 0 en Contífico (brecha real)' },
+    { key: 'zero_both',         label: 'Coinciden stock 0 — ausentes en Odoo, sin stock en Contífico' },
     { key: 'only_in_odoo',      label: 'Solo en Odoo — no están en Contífico' },
     { key: 'in_both',           label: 'Coinciden en ambos sistemas' },
   ];
@@ -441,9 +447,9 @@ $('executeSkuCompare').addEventListener('click', async () => {
 
     renderCompareStats(data);
     renderComparePreviews(data);
-    renderCompareLinks(data.files);
-    const skippedMsg = data.skipped_zero_stock > 0 ? ` · Ignorados (stock 0): ${data.skipped_zero_stock}` : '';
-    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}${skippedMsg}`);
+    renderCompareLinks(data.files, data);
+    const zeroMsg = data.coincide_zero_stock > 0 ? ` · Stock 0 (ambos): ${data.coincide_zero_stock}` : '';
+    setCompareStatus(`Comparación completada. Coinciden: ${data.in_both}${zeroMsg} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}`);
   } catch(e) {
     setCompareStatus(`Error: ${e.message}`);
     showErr(e);
@@ -473,7 +479,7 @@ $('executeCompare').addEventListener('click', async () => {
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}: ${typeof data === 'string' ? data : JSON.stringify(data)}`);
     renderCompareStats(data);
     renderComparePreviews(data);
-    renderCompareLinks(data.files);
+    renderCompareLinks(data.files, data);
     setCompareStatus(`Comparación completada. Coinciden: ${data.in_both} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}`);
     if (data.only_in_contifico > 0) $('generateMissingSection').classList.remove('hidden');
   } catch(e) {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -71,3 +71,4 @@ details>summary{user-select:none}
 .mode-btn:hover:not(.active){color:#374151;background:#f9fafb}
 .checkbox-label{display:flex;align-items:center;gap:8px;font-size:13px;font-weight:500;color:#374151;margin:8px 0;cursor:pointer}
 .checkbox-label input[type=checkbox]{width:15px;height:15px;cursor:pointer}
+.stat-card--zero{background:#f8fafc;border:1px solid #cbd5e1;color:#475569}


### PR DESCRIPTION
En lugar de ignorar/excluir los productos con stock 0 en Contífico, ahora se clasifican correctamente: si el producto está en Contífico con stock 0 Y no existe en Odoo → "coincide_zero_stock" (ambos lados están vacíos, no es una brecha real).

Solo los productos con stock > 0 en Contífico Y ausentes en Odoo se cuentan como "faltan en Odoo" (brecha real que hay que importar).

Resultado con datos reales:
  Antes: 14,827 "faltan en Odoo" (incluía todos los stock-0)
  Ahora:    799 "faltan en Odoo" (stock > 0, brecha real)
         14,028 "coincide stock 0" (nueva categoría, sin acción)

Backend: compare_skus() ya no filtra ni excluye — clasifica en 4 grupos.
Router: expone nuevo file "zero_both" → sku_compare_zero_both.csv
Frontend: stat card "Stock 0 (ambos)", preview y download link separados.

https://claude.ai/code/session_01XZJ3juXosYKb6Zttt8cysg