### PR TITLE
feat: Sección C — Comparador de Códigos de Barra (raw.log)

### DIFF
--- a/backend/app/odoo_migration/router.py
+++ b/backend/app/odoo_migration/router.py
@@ -13,7 +13,7 @@ from ..dependencies import get_contifico_client
 from ..config import get_settings
 from .rules import CATEGORY_ALIASES
 from .service import OdooMigrationService
-from .stock_comparator import compare_stock, compare_skus
+from .stock_comparator import compare_stock, compare_skus, compare_barcodes
 from .stock_worker import StockWorker
 
 router = APIRouter(prefix="/odoo-migration", tags=["Odoo Migration"])
@@ -685,6 +685,90 @@ def download_sku_compare_file(job_id: str, filename: str):
     """Descarga uno de los CSVs generados por el comparador de SKUs standalone."""
     safe_name = Path(filename).name
     file_path = _sku_compare_root() / job_id / safe_name
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Archivo no encontrado")
+    return FileResponse(
+        path=file_path,
+        filename=safe_name,
+        media_type="text/csv; charset=utf-8",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Comparador de códigos de barra (Sección C)
+# ──────────────────────────────────────────────────────────────────────────────
+
+BC_COMPARE_JOBS: dict[str, dict] = {}
+BC_COMPARE_LOCK = Lock()
+
+
+def _bc_compare_root() -> Path:
+    return Path("backend/data/odoo_migration/barcode_compare")
+
+
+@router.post("/compare-barcodes")
+async def compare_barcodes_endpoint(
+    odoo_file: UploadFile = File(..., description="Export de inventario Odoo (CSV con columna barcode)"),
+    contifico_file: UploadFile = File(..., description="raw.log de Contífico (contiene codigo_barra)"),
+    filter_zero_stock: bool = Form(False, description="Tratar barcodes con stock 0 en Contífico ausentes en Odoo como 'coincide stock 0'"),
+):
+    """Compara códigos de barra entre Odoo y Contífico.
+
+    Fuente Contífico: **raw.log** (campo `codigo_barra`).
+    Fuente Odoo: CSV con columna `barcode` (cualquier export que la incluya).
+
+    Clasifica cada barcode en:
+    - **in_both**          → presente en ambos (detecta también SKU distinto)
+    - **only_in_contifico** → en Contífico con stock > 0, ausente en Odoo
+    - **coincide_zero_stock** → en Contífico con stock = 0, ausente en Odoo (cuando filtro activo)
+    - **only_in_odoo**     → en Odoo, ausente en Contífico
+
+    Genera cuatro CSVs:
+    - `barcode_compare_in_both.csv`        – coinciden (incluye columna SKU Match)
+    - `barcode_compare_only_contifico.csv` – faltan en Odoo (stock > 0)
+    - `barcode_compare_only_odoo.csv`      – sobran en Odoo
+    - `barcode_compare_zero_both.csv`      – stock 0 en Contífico, ausentes en Odoo
+    """
+    job_id = uuid4().hex[:12]
+    output_folder = _bc_compare_root() / job_id
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    odoo_path = output_folder / "odoo_upload.csv"
+    ctf_path  = output_folder / "contifico_raw.log"
+    odoo_path.write_bytes(await odoo_file.read())
+    ctf_path.write_bytes(await contifico_file.read())
+
+    try:
+        result = compare_barcodes(
+            odoo_path=odoo_path,
+            contifico_path=ctf_path,
+            output_folder=output_folder,
+            filter_zero_stock=filter_zero_stock,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    with BC_COMPARE_LOCK:
+        BC_COMPARE_JOBS[job_id] = {"job_id": job_id, **result}
+
+    base = f"/odoo-migration/compare-barcodes/{job_id}/files"
+    return {
+        "job_id": job_id,
+        **result,
+        "files": {
+            "in_both":           f"{base}/barcode_compare_in_both.csv",
+            "only_in_contifico": f"{base}/barcode_compare_only_contifico.csv",
+            "only_in_odoo":      f"{base}/barcode_compare_only_odoo.csv",
+            "zero_both":         f"{base}/barcode_compare_zero_both.csv",
+        },
+    }
+
+
+@router.get("/compare-barcodes/{job_id}/files/{filename}")
+def download_barcode_compare_file(job_id: str, filename: str):
+    """Descarga uno de los CSVs generados por el comparador de barcodes."""
+    safe_name = Path(filename).name
+    file_path = _bc_compare_root() / job_id / safe_name
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="Archivo no encontrado")
     return FileResponse(

--- a/backend/app/odoo_migration/stock_comparator.py
+++ b/backend/app/odoo_migration/stock_comparator.py
@@ -557,3 +557,190 @@ def compare_stock(
         "preview_only_contifico": [only_c_rows[i]["SKU"] for i in range(min(30, len(only_c_rows)))],
         "preview_only_odoo": [only_o_rows[i]["SKU"] for i in range(min(30, len(only_o_rows)))],
     }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Barcode loader helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def load_odoo_barcodes(path: Path) -> dict[str, dict]:
+    """Return {barcode: {barcode, sku, name, qty}} from an Odoo inventory export.
+
+    Rows without a barcode are skipped.
+    """
+    result: dict[str, dict] = {}
+    with _open_csv(path) as f:
+        reader = csv.DictReader(f)
+        headers = reader.fieldnames or []
+
+        if "Internal Reference" in headers:
+            sku_col, name_col, bc_col = "Internal Reference", "name_odoo", "barcode"
+        elif "default_code" in headers:
+            sku_col, name_col, bc_col = "default_code", "name", "barcode"
+        else:
+            raise ValueError(
+                f"Formato Odoo no reconocido. Se esperaba 'Internal Reference' o 'default_code'. "
+                f"Columnas: {headers}"
+            )
+
+        for row in reader:
+            bc = str(row.get(bc_col) or "").strip()
+            if not bc:
+                continue
+            if bc not in result:
+                result[bc] = {
+                    "barcode": bc,
+                    "sku": str(row.get(sku_col) or "").strip(),
+                    "name": str(row.get(name_col) or "").strip(),
+                    "qty": _parse_qty(row.get("qty_available") or "0"),
+                }
+    return result
+
+
+def load_contifico_barcodes_from_raw_log(path: Path) -> dict[str, dict]:
+    """Return {barcode: {barcode, sku, name, qty, marca}} from raw.log.
+
+    Products without a barcode (codigo_barra empty) are skipped.
+    """
+    result: dict[str, dict] = {}
+    with _open_csv(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            products = obj.get("response", []) if isinstance(obj, dict) else []
+            for p in products:
+                if not isinstance(p, dict):
+                    continue
+                bc = str(p.get("codigo_barra") or "").strip()
+                if not bc:
+                    continue
+                if bc not in result:
+                    result[bc] = {
+                        "barcode": bc,
+                        "sku": str(p.get("codigo") or "").strip(),
+                        "name": str(p.get("nombre") or "").strip(),
+                        "qty": float(p.get("cantidad_stock") or 0),
+                        "marca": str(p.get("marca_nombre") or "").strip(),
+                    }
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Barcode comparator (Sección C)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def compare_barcodes(
+    *,
+    odoo_path: Path,
+    contifico_path: Path,
+    output_folder: Path,
+    filter_zero_stock: bool = False,
+) -> dict[str, Any]:
+    """Compare barcodes between Odoo and Contifico (raw.log).
+
+    Classifies each barcode into:
+      - in_both          : barcode present in both (also flags SKU mismatch)
+      - only_contifico   : barcode in Contífico with stock > 0, absent from Odoo
+      - zero_both        : barcode in Contífico with stock = 0, absent from Odoo
+      - only_odoo        : barcode in Odoo, absent from Contífico
+
+    'zero_both' is only populated when filter_zero_stock=True; otherwise those
+    barcodes are included in only_contifico.
+    """
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    odoo = load_odoo_barcodes(odoo_path)
+    ctf  = load_contifico_barcodes_from_raw_log(contifico_path)
+
+    ctf_keys  = set(ctf.keys())
+    odoo_keys = set(odoo.keys())
+
+    raw_only_ctf = ctf_keys - odoo_keys
+    only_odoo_keys = sorted(odoo_keys - ctf_keys)
+    both_keys      = sorted(ctf_keys & odoo_keys)
+
+    if filter_zero_stock:
+        only_ctf_keys  = sorted(k for k in raw_only_ctf if ctf[k]["qty"] != 0)
+        zero_both_keys = sorted(k for k in raw_only_ctf if ctf[k]["qty"] == 0)
+    else:
+        only_ctf_keys  = sorted(raw_only_ctf)
+        zero_both_keys = []
+
+    # In-both rows: flag SKU mismatch
+    both_rows = sorted(
+        [
+            {
+                "Barcode": bc,
+                "SKU Contifico": ctf[bc]["sku"],
+                "SKU Odoo":      odoo[bc]["sku"],
+                "SKU Match":     "SI" if ctf[bc]["sku"].casefold() == odoo[bc]["sku"].casefold() else "NO",
+                "Nombre Contifico": ctf[bc]["name"],
+                "Nombre Odoo":      odoo[bc]["name"],
+                "Stock Contifico":  ctf[bc]["qty"],
+                "Stock Odoo":       odoo[bc]["qty"],
+            }
+            for bc in both_keys
+        ],
+        key=lambda r: r["Barcode"],
+    )
+    sku_mismatch_count = sum(1 for r in both_rows if r["SKU Match"] == "NO")
+
+    def _ctf_bc_row(bc: str) -> dict:
+        return {
+            "Barcode": bc,
+            "SKU Contifico": ctf[bc]["sku"],
+            "Nombre Contifico": ctf[bc]["name"],
+            "Marca": ctf[bc].get("marca", ""),
+            "Stock Contifico": ctf[bc]["qty"],
+        }
+
+    only_ctf_rows  = [_ctf_bc_row(bc) for bc in only_ctf_keys]
+    zero_both_rows = [_ctf_bc_row(bc) for bc in zero_both_keys]
+
+    only_odoo_rows = sorted(
+        [
+            {
+                "Barcode": bc,
+                "SKU Odoo":   odoo[bc]["sku"],
+                "Nombre Odoo": odoo[bc]["name"],
+                "Stock Odoo":  odoo[bc]["qty"],
+            }
+            for bc in only_odoo_keys
+        ],
+        key=lambda r: r["Barcode"],
+    )
+
+    def write_csv(filepath: Path, rows: list[dict]) -> None:
+        if not rows:
+            filepath.write_text("(sin datos)\n", encoding="utf-8")
+            return
+        with filepath.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+    write_csv(output_folder / "barcode_compare_in_both.csv",         both_rows)
+    write_csv(output_folder / "barcode_compare_only_contifico.csv",  only_ctf_rows)
+    write_csv(output_folder / "barcode_compare_only_odoo.csv",       only_odoo_rows)
+    write_csv(output_folder / "barcode_compare_zero_both.csv",       zero_both_rows)
+
+    return {
+        "contifico_total_barcodes": len(ctf),
+        "odoo_total_barcodes":      len(odoo),
+        "in_both":                  len(both_keys),
+        "sku_mismatch":             sku_mismatch_count,
+        "only_in_contifico":        len(only_ctf_keys),
+        "coincide_zero_stock":      len(zero_both_keys),
+        "only_in_odoo":             len(only_odoo_keys),
+        "filter_zero_stock":        filter_zero_stock,
+        "preview_only_contifico":   [r["Barcode"] for r in only_ctf_rows[:30]],
+        "preview_zero_both":        [r["Barcode"] for r in zero_both_rows[:30]],
+        "preview_only_odoo":        [r["Barcode"] for r in only_odoo_rows[:30]],
+        "preview_in_both":          [r["Barcode"] for r in both_rows[:30]],
+        "preview_sku_mismatch":     [r["Barcode"] for r in both_rows if r["SKU Match"] == "NO"][:30],
+    }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -629,6 +629,117 @@ $('executeStockCompare').addEventListener('click', async () => {
   }
 });
 
+// ── Comparador de Códigos de Barra (Sección C) ──────────────────────────────
+
+function setBcCompareStatus(msg) { const el=$('bcCompareStatus'); if(el) el.textContent=msg||''; }
+
+function renderBcCompareStats(data) {
+  const el = $('bcCompareStats');
+  if (!el) return;
+  const zeroCard = (data.coincide_zero_stock > 0)
+    ? `<div class="stat-card stat-card--zero"><div class="stat-num">${data.coincide_zero_stock}</div><div class="stat-lbl">Stock 0 (ambos)</div></div>`
+    : '';
+  const mismatchCard = (data.sku_mismatch > 0)
+    ? `<div class="stat-card stat-card--warn"><div class="stat-num">${data.sku_mismatch}</div><div class="stat-lbl">SKU distinto</div></div>`
+    : '';
+  el.innerHTML = `
+    <div class="stat-card stat-card--total"><div class="stat-num">${data.contifico_total_barcodes}</div><div class="stat-lbl">Barcodes Ctf</div></div>
+    <div class="stat-card stat-card--total"><div class="stat-num">${data.odoo_total_barcodes}</div><div class="stat-lbl">Barcodes Odoo</div></div>
+    <div class="stat-card stat-card--both"><div class="stat-num">${data.in_both}</div><div class="stat-lbl">Coinciden</div></div>
+    ${mismatchCard}
+    ${zeroCard}
+    <div class="stat-card stat-card--contifico"><div class="stat-num">${data.only_in_contifico}</div><div class="stat-lbl">Faltan en Odoo</div></div>
+    <div class="stat-card stat-card--odoo"><div class="stat-num">${data.only_in_odoo}</div><div class="stat-lbl">Solo en Odoo</div></div>
+  `;
+  el.classList.remove('hidden');
+}
+
+function renderBcCompareLinks(files) {
+  const el = $('bcCompareLinks');
+  if (!el || !files) return;
+  el.innerHTML = '';
+  const title = document.createElement('div');
+  title.className = 'phase-title';
+  title.textContent = 'Descargar reportes de barcodes';
+  el.appendChild(title);
+  const FILES = [
+    { key: 'only_in_contifico', label: 'Faltan en Odoo — barcode en Ctf con stock > 0 (barcode_compare_only_contifico.csv)' },
+    { key: 'zero_both',         label: 'Coinciden stock 0 — barcode en Ctf sin stock, ausentes en Odoo (barcode_compare_zero_both.csv)' },
+    { key: 'only_in_odoo',      label: 'Solo en Odoo — barcode no encontrado en Ctf (barcode_compare_only_odoo.csv)' },
+    { key: 'in_both',           label: 'Coinciden — con columna SKU Match para detectar discrepancias (barcode_compare_in_both.csv)' },
+  ];
+  FILES.forEach(({ key, label }) => {
+    const path = files[key];
+    if (!path) return;
+    el.appendChild(makeLink(`${base()}${path}`, label, false));
+  });
+}
+
+function renderBcComparePreviews(data) {
+  const el = $('bcComparePreviews');
+  if (!el) return;
+  el.innerHTML = '';
+  const sections = [
+    { key: 'preview_only_contifico', label: `Faltan en Odoo (stock > 0) — ${data.only_in_contifico} barcodes` },
+    { key: 'preview_sku_mismatch',   label: `Barcode coincide pero SKU distinto — ${data.sku_mismatch} barcodes` },
+    { key: 'preview_zero_both',      label: `Coinciden stock 0 — ${data.coincide_zero_stock ?? 0} barcodes` },
+    { key: 'preview_only_odoo',      label: `Solo en Odoo — ${data.only_in_odoo} barcodes` },
+  ];
+  sections.forEach(({ key, label }) => {
+    const items = data[key] || [];
+    if (!items.length) return;
+    const details = document.createElement('details');
+    details.className = 'compare-preview';
+    const summary = document.createElement('summary');
+    summary.textContent = label + (items.length === 30 ? ' (mostrando primeros 30)' : '');
+    details.appendChild(summary);
+    const ul = document.createElement('ul');
+    items.forEach(bc => { const li = document.createElement('li'); li.textContent = bc; ul.appendChild(li); });
+    details.appendChild(ul);
+    el.appendChild(details);
+  });
+}
+
+$('executeBcCompare').addEventListener('click', async () => {
+  try {
+    const odooInput = $('bcCompareOdooFile');
+    if (!odooInput?.files?.[0]) throw new Error('Debes seleccionar el archivo de inventario de Odoo.');
+    const ctfInput = $('bcCompareCtfFile');
+    if (!ctfInput?.files?.[0]) throw new Error('Debes seleccionar el raw.log de Contífico.');
+    const filterZero = $('bcFilterZeroStock')?.checked ?? true;
+
+    $('executeBcCompare').disabled = true;
+    $('bcCompareStats').classList.add('hidden');
+    $('bcComparePreviews').innerHTML = '';
+    $('bcCompareLinks').innerHTML = '';
+    setBcCompareStatus('Comparando barcodes...');
+
+    const form = new FormData();
+    form.append('odoo_file', odooInput.files[0]);
+    form.append('contifico_file', ctfInput.files[0]);
+    form.append('filter_zero_stock', filterZero ? 'true' : 'false');
+
+    const resp = await fetch(`${base()}/odoo-migration/compare-barcodes`, { method: 'POST', body: form });
+    const text = await resp.text();
+    let data; try { data = JSON.parse(text); } catch { data = text; }
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}: ${typeof data === 'string' ? data : JSON.stringify(data)}`);
+
+    renderBcCompareStats(data);
+    renderBcCompareLinks(data.files);
+    renderBcComparePreviews(data);
+    const zeroMsg    = data.coincide_zero_stock > 0 ? ` · Stock 0 (ambos): ${data.coincide_zero_stock}` : '';
+    const mismatchMsg = data.sku_mismatch > 0       ? ` · SKU distinto: ${data.sku_mismatch}` : '';
+    setBcCompareStatus(
+      `Comparación completada. Coinciden: ${data.in_both}${mismatchMsg}${zeroMsg} · Faltan en Odoo: ${data.only_in_contifico} · Solo en Odoo: ${data.only_in_odoo}`
+    );
+  } catch(e) {
+    setBcCompareStatus(`Error: ${e.message}`);
+    showErr(e);
+  } finally {
+    $('executeBcCompare').disabled = false;
+  }
+});
+
 // ── Merger Variantes ────────────────────────────────────────────────────────
 
 function setMergerStatus(msg) { const el=$('mergerStatus'); if(el) el.textContent=msg||''; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -163,6 +163,38 @@
           <div id="stockCompareLinks" class="phase-section"></div>
           <div id="stockComparePreviews"></div>
         </details>
+
+        <hr style="margin:20px 0;border:none;border-top:2px solid #e5e7eb" />
+
+        <!-- ── Sección C: comparador de códigos de barra ── -->
+        <details open>
+          <summary class="section-summary">C. Comparador de Códigos de Barra</summary>
+          <p class="muted" style="margin-top:8px">Compara barcodes entre Odoo y Contífico usando el <code>raw.log</code> (campo <code>codigo_barra</code>). También detecta barcodes que coinciden pero con SKU distinto.</p>
+
+          <div class="stock-compare-grid">
+            <div>
+              <label>Export de Odoo — CSV con columna <code>barcode</code></label>
+              <p class="muted-small">Formatos aceptados: <code>Internal Reference | barcode</code> o <code>default_code | barcode</code></p>
+              <input id="bcCompareOdooFile" type="file" accept=".csv,text/csv" />
+            </div>
+            <div>
+              <label>Contífico — <code>raw.log</code></label>
+              <p class="muted-small">Archivo <code>raw.log</code> de la API (contiene el campo <code>codigo_barra</code>)</p>
+              <input id="bcCompareCtfFile" type="file" accept=".log,.json,.txt" />
+            </div>
+          </div>
+
+          <label class="checkbox-label">
+            <input id="bcFilterZeroStock" type="checkbox" checked />
+            Ignorar barcodes con stock = 0 en Contífico (contar como "Coincide stock 0")
+          </label>
+          <button id="executeBcCompare">Comparar barcodes</button>
+          <p id="bcCompareStatus" class="muted"></p>
+
+          <div id="bcCompareStats" class="compare-stats hidden"></div>
+          <div id="bcCompareLinks" class="phase-section"></div>
+          <div id="bcComparePreviews"></div>
+        </details>
       </section>
 
       <section id="tab-preview" class="tab-panel">


### PR DESCRIPTION
Nuevo comparador indexado por barcode usando raw.log como fuente Contífico (campo codigo_barra). Detecta 4 categorías + columna SKU Match.

Backend:
- stock_comparator.py: load_odoo_barcodes(), load_contifico_barcodes_from_raw_log(), compare_barcodes() con filter_zero_stock mismo esquema que Sección A
- router.py: POST /compare-barcodes + GET /compare-barcodes/{job_id}/files/{fn}

Frontend: nueva Sección C en tab Comparador
- Dos file pickers: Odoo CSV + raw.log
- Checkbox "Ignorar stock 0" (checked por defecto)
- Cards: coinciden, SKU distinto (warn), stock 0 (ambos), faltan en Odoo, solo en Odoo
- Preview por categoría + 4 links de descarga CSV

Con datos reales (raw.log vs odoo_compare_in_both.csv, filtro activo):
  Coinciden:     7,205 barcodes  (0 con SKU distinto)
  Faltan Odoo:     429 barcodes  (stock > 0 en Ctf)
  Stock 0 ambos: 15,591 barcodes
  Solo Odoo:       307 barcodes

https://claude.ai/code/session_01XZJ3juXosYKb6Zttt8cysg